### PR TITLE
Prepare test templates for migration

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/abstractImmutablePrimitiveBagTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/abstractImmutablePrimitiveBagTestCase.stg
@@ -37,8 +37,14 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>Bag}.
@@ -70,10 +76,10 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     @Test
     public void sizeDistinct()
     {
-        Assert.assertEquals(0L, this.newWith().sizeDistinct());
-        Assert.assertEquals(1L, this.newWith(<(literal.(type))("1")>).sizeDistinct());
-        Assert.assertEquals(3L, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
-        Assert.assertEquals(3L, this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
+        assertEquals(0L, this.newWith().sizeDistinct());
+        assertEquals(1L, this.newWith(<(literal.(type))("1")>).sizeDistinct());
+        assertEquals(3L, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
+        assertEquals(3L, this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
     }
 
     @Test
@@ -81,14 +87,14 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     {
         Immutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>Bag filtered = bag.selectByOccurrences(i -> i > 2);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), filtered);
+        assertEquals(<name>HashBag.newBagWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), filtered);
     }
 
     @Test
     public void selectDuplicates()
     {
         Immutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag.selectDuplicates());
+        assertEquals(<name>HashBag.newBagWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag.selectDuplicates());
     }
 
     @Test
@@ -97,7 +103,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         Immutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3", "3", "4", "5", "5", "6"]:(literal.(type))(); separator=", ">);
         Immutable<name>Set expected = <name>Sets.immutable.with(<["1", "4", "6"]:(literal.(type))(); separator=", ">);
         Immutable<name>Set actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     protected Immutable<name>Bag newWithOccurrences(<name>IntPair... elementsWithOccurrences)
@@ -127,8 +133,8 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair(<(literal.(type))("10")>, 10));
         ImmutableList\<<name>IntPair> top5 = bag.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertSize(0, this.newWith(<(literal.(type))("1")>).topOccurrences(0));
         Verify.assertSize(0, this.newWith().topOccurrences(5));
         Verify.assertSize(3, this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).topOccurrences(5));
@@ -138,7 +144,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         Verify.assertSize(2, this.newWith(<["1", "1", "2", "2", "3"]:(literal.(type))(); separator=", ">).topOccurrences(1));
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3", "3"]:(literal.(type))(); separator=", ">).topOccurrences(1));
         Verify.assertSize(0, this.newWith().topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
     }
 
     @Test
@@ -157,8 +163,8 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair(<(literal.(type))("10")>, 10));
         ImmutableList\<<name>IntPair> bottom5 = bag.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertSize(0, this.newWith(<(literal.(type))("1")>).bottomOccurrences(0));
         Verify.assertSize(0, this.newWith().bottomOccurrences(5));
         Verify.assertSize(3, this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(5));
@@ -168,7 +174,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(2));
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(1));
         Verify.assertSize(0, this.newWith().bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
     }
 
     @Test
@@ -178,7 +184,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         this.newWith(<["1", "1", "2"]:(literal.(type))(); separator=", ">).forEachWithOccurrences(
                 (<type> argument1, int argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertTrue("<(toStringLiteral.(type))("1")>2<(toStringLiteral.(type))("2")>1".equals(string)
+        assertTrue("<(toStringLiteral.(type))("1")>2<(toStringLiteral.(type))("2")>1".equals(string)
                 || "<(toStringLiteral.(type))("2")>1<(toStringLiteral.(type))("1")>2".equals(string));
     }
 
@@ -191,13 +197,13 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         <name>Iterator iterator = bag.<type>Iterator();
         for (int i = 0; i \< 6; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -208,7 +214,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(14L, sum[0]<(delta.(type))>);
+        assertEquals(14L, sum[0]<(delta.(type))>);
     }
 
     @Test
@@ -217,9 +223,9 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     {
         super.count();
         Immutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(5L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(1L, bag.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertEquals(5L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(1L, bag.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -227,7 +233,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("14")>, this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Test
@@ -239,10 +245,10 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         Immutable<name>Bag bag2 = this.newWith(<["0", "2", "1", "2", "1", "2"]:(literal.(type))(); separator=", ">);
         Immutable<name>Bag bag3 = this.newWith(<["0", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Verify.assertEqualsAndHashCode(bag1, bag2);
-        Assert.assertNotEquals(bag1, bag3);
-        Assert.assertNotEquals(bag2, bag3);
-        Assert.assertNotEquals(this.newWith(), <name>ArrayList.newListWith());
-        Assert.assertNotEquals(this.newWith(<(literal.(type))("1")>), <name>ArrayList.newListWith(<(literal.(type))("1")>));
+        assertNotEquals(bag1, bag3);
+        assertNotEquals(bag2, bag3);
+        assertNotEquals(this.newWith(), <name>ArrayList.newListWith());
+        assertNotEquals(this.newWith(<(literal.(type))("1")>), <name>ArrayList.newListWith(<(literal.(type))("1")>));
     }
 
     @Test
@@ -250,7 +256,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">]", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toString());
+        assertEquals("[<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">]", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toString());
     }
 
     @Test
@@ -258,7 +264,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).makeString());
+        assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).makeString());
     }
 
     @Test
@@ -268,7 +274,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).appendString(appendable1);
-        Assert.assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", appendable1.toString());
+        assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", appendable1.toString());
     }
 
     @Test
@@ -276,7 +282,7 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toList());
     }
 
     @Test
@@ -284,25 +290,25 @@ public abstract class AbstractImmutable<name>BagTestCase extends AbstractImmutab
     public void toSortedList()
     {
         super.toSortedList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSortedList());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Immutable<name>Bag expected = this.classUnderTest();
-        Assert.assertSame(expected, expected.toImmutable());
+        assertSame(expected, expected.toImmutable());
     }
 
     @Test
     public void toStringOfItemToCount()
     {
         Immutable<name>Bag empty = this.newWith();
-        Assert.assertEquals("{}", empty.toStringOfItemToCount());
-        Assert.assertEquals("{" + <(literal.(type))("100")> + "=3}", this.newWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">).toStringOfItemToCount());
+        assertEquals("{}", empty.toStringOfItemToCount());
+        assertEquals("{" + <(literal.(type))("100")> + "=3}", this.newWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">).toStringOfItemToCount());
         String actual = this.newWith(<["100", "101", "101"]:(literal.(type))(); separator=", ">).toStringOfItemToCount();
-        Assert.assertTrue(("{" + <(literal.(type))("100")> + "=1, " + <(literal.(type))("101")> + "=2}").equals(actual) || ("{" + <(literal.(type))("101")> + "=2, " + <(literal.(type))("100")> + "=1}").equals(actual));
+        assertTrue(("{" + <(literal.(type))("100")> + "=1, " + <(literal.(type))("101")> + "=2}").equals(actual) || ("{" + <(literal.(type))("101")> + "=2, " + <(literal.(type))("100")> + "=1}").equals(actual));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
@@ -23,12 +23,14 @@ import org.eclipse.collections.api.bag.primitive.Immutable<name>Bag;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyBag}.
@@ -53,7 +55,7 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
     }
 
     @Override
@@ -67,7 +69,7 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
     }
 
     @Override
@@ -88,7 +90,7 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -105,7 +107,7 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((<type> argument1, int argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertEquals("", string);
+        assertEquals("", string);
     }
 
     @Override
@@ -117,15 +119,15 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
         Immutable<name>Bag bag = this.classUnderTest();
         Immutable<name>Set expected = <name>Sets.immutable.empty();
         Immutable<name>Set actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void occurrencesOf()
     {
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("1")>));
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("2")>));
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("3")>));
+        assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("1")>));
+        assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("2")>));
+        assertEquals(0, this.classUnderTest().occurrencesOf(<(literal.(type))("3")>));
     }
 
     @Override
@@ -136,7 +138,7 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
 
         Immutable<name>EmptyBag iterable = new Immutable<name>EmptyBag();
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveHashBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveHashBagTest.stg
@@ -23,10 +23,11 @@ import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
-import org.junit.Assert;
+
 import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>HashBag}.
@@ -48,7 +49,7 @@ public class Immutable<name>HashBagTest extends AbstractImmutable<name>BagTestCa
 
         Immutable<name>HashBag iterable = Immutable<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class Immutable<name>HashBagTest extends AbstractImmutable<name>BagTestCa
         Immutable<name>Bag bag = this.classUnderTest();
         Immutable<name>Set expected = <name>Sets.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>Set actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -71,11 +72,11 @@ public class Immutable<name>HashBagTest extends AbstractImmutable<name>BagTestCa
         <name>HashBag mutable4 = <name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
         Mutable<name>Bag mutableBag = new <name>HashBag(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>HashBag immutableBag = Immutable<name>HashBag.newBagWith(mutableBag);
-        Assert.assertEquals(mutable3, mutableBag);
-        Assert.assertEquals(immutable3, immutableBag);
+        assertEquals(mutable3, mutableBag);
+        assertEquals(immutable3, immutableBag);
         mutableBag.add(<(literal.(type))("4")>);
-        Assert.assertEquals(mutable4, mutableBag);
-        Assert.assertEquals(immutable3, immutableBag);
+        assertEquals(mutable4, mutableBag);
+        assertEquals(immutable3, immutableBag);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveSingletonBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveSingletonBagTest.stg
@@ -21,10 +21,11 @@ import org.eclipse.collections.api.bag.primitive.Immutable<name>Bag;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
-import org.junit.Assert;
-import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>SingletonBag}.
@@ -45,7 +46,7 @@ public class Immutable<name>SingletonBagTest extends AbstractImmutable<name>BagT
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((<type> argument1, int argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>1", string);
+        assertEquals("<(toStringLiteral.(type))("1")>1", string);
     }
 
     @Override
@@ -54,9 +55,9 @@ public class Immutable<name>SingletonBagTest extends AbstractImmutable<name>BagT
     {
         Immutable<name>SingletonBag bag = new Immutable<name>SingletonBag(<(literal.(type))("1")>);
         Immutable<name>Bag filtered1 = bag.selectByOccurrences(i -> i > 0);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), filtered1);
+        assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), filtered1);
         Immutable<name>Bag filtered2 = bag.selectByOccurrences(i -> i > 1);
-        Assert.assertEquals(<name>Bags.immutable.empty(), filtered2);
+        assertEquals(<name>Bags.immutable.empty(), filtered2);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class Immutable<name>SingletonBagTest extends AbstractImmutable<name>BagT
     public void selectDuplicates()
     {
         Immutable<name>SingletonBag bag = new Immutable<name>SingletonBag(<(literal.(type))("1")>);
-        Assert.assertEquals(<name>HashBag.newBagWith(), bag.selectDuplicates());
+        assertEquals(<name>HashBag.newBagWith(), bag.selectDuplicates());
     }
 
     @Override
@@ -76,7 +77,7 @@ public class Immutable<name>SingletonBagTest extends AbstractImmutable<name>BagT
         Immutable<name>Bag bag = this.classUnderTest();
         Immutable<name>Set expected = <name>Sets.immutable.with(<(literal.(type))("1")>);
         Immutable<name>Set actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Override
@@ -87,7 +88,7 @@ public class Immutable<name>SingletonBagTest extends AbstractImmutable<name>BagT
 
         Immutable<name>SingletonBag iterable = new Immutable<name>SingletonBag(<(literal.(type))("1")>);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("1")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
@@ -33,12 +33,17 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable<name>CollectionTestCase;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Mutable<name>Bag}.
@@ -67,9 +72,9 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     @Test
     public void sizeDistinct()
     {
-        Assert.assertEquals(0L, this.newWith().sizeDistinct());
-        Assert.assertEquals(3L, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
-        Assert.assertEquals(3L, this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
+        assertEquals(0L, this.newWith().sizeDistinct());
+        assertEquals(3L, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
+        assertEquals(3L, this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">).sizeDistinct());
     }
 
     @Test
@@ -77,14 +82,14 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         Mutable<name>Bag bag = this.newWith(<["100", "100", "100", "50", "50"]:(literal.(type))(); separator=", ">);
         Mutable<name>Bag filtered = bag.selectByOccurrences(i -> i > 2);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), filtered);
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), filtered);
     }
 
     @Test
     public void selectDuplicates()
     {
         Mutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag.selectDuplicates());
+        assertEquals(<name>HashBag.newBagWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag.selectDuplicates());
     }
 
     @Test
@@ -93,7 +98,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Mutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3", "3", "4", "5", "5", "6"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set expected = <name>Sets.mutable.with(<["1", "4", "6"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     protected Mutable<name>Bag newWithOccurrences(<name>IntPair... elementsWithOccurrences)
@@ -123,8 +128,8 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
                 PrimitiveTuples.pair(<(literal.(type))("10")>, 10));
         MutableList\<<name>IntPair> top5 = bag.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertSize(0, this.newWith(<(literal.(type))("1")>).topOccurrences(0));
         Verify.assertSize(0, this.newWith().topOccurrences(5));
         Verify.assertSize(3, this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).topOccurrences(5));
@@ -134,7 +139,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Verify.assertSize(2, this.newWith(<["1", "1", "2", "2", "3"]:(literal.(type))(); separator=", ">).topOccurrences(1));
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3", "3"]:(literal.(type))(); separator=", ">).topOccurrences(1));
         Verify.assertSize(0, this.newWith().topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
     }
 
     @Test
@@ -153,8 +158,8 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
                 PrimitiveTuples.pair(<(literal.(type))("10")>, 10));
         MutableList\<<name>IntPair> bottom5 = bag.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertSize(0, this.newWith(<(literal.(type))("1")>).bottomOccurrences(0));
         Verify.assertSize(0, this.newWith().bottomOccurrences(5));
         Verify.assertSize(3, this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(5));
@@ -164,7 +169,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(2));
         Verify.assertSize(3, this.newWith(<["1", "1", "2", "2", "3", "3"]:(literal.(type))(); separator=", ">).bottomOccurrences(1));
         Verify.assertSize(0, this.newWith().bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
     }
 
     @Test
@@ -172,11 +177,11 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         Mutable<name>Bag bag = this.newWith();
         bag.addOccurrences(<(literal.(type))("100")>, 3);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
         bag.addOccurrences(<(literal.(type))("100")>, 2);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
         bag.addOccurrences(<(literal.(type))("100")>, 0);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
     }
 
     @Test
@@ -189,16 +194,16 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void removeOccurrences()
     {
         Mutable<name>Bag bag = this.newWith();
-        Assert.assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 2));
+        assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 2));
         bag.addOccurrences(<(literal.(type))("100")>, 5);
-        Assert.assertTrue(bag.removeOccurrences(<(literal.(type))("100")>, 2));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
-        Assert.assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 0));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
-        Assert.assertTrue(bag.removeOccurrences(<(literal.(type))("100")>, 5));
-        Assert.assertEquals(new <name>HashBag(), bag);
-        Assert.assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 5));
-        Assert.assertEquals(new <name>HashBag(), bag);
+        assertTrue(bag.removeOccurrences(<(literal.(type))("100")>, 2));
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 0));
+        assertEquals(<name>HashBag.newBagWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertTrue(bag.removeOccurrences(<(literal.(type))("100")>, 5));
+        assertEquals(new <name>HashBag(), bag);
+        assertFalse(bag.removeOccurrences(<(literal.(type))("100")>, 5));
+        assertEquals(new <name>HashBag(), bag);
     }
 
     @Test
@@ -214,7 +219,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         StringBuilder stringBuilder = new StringBuilder();
         this.newWith(<["1", "1", "2"]:(literal.(type))(); separator=", ">).forEachWithOccurrences((<type> argument1, int argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertTrue("<(toStringLiteral.(type))("1")>2<(toStringLiteral.(type))("2")>1".equals(string)
+        assertTrue("<(toStringLiteral.(type))("1")>2<(toStringLiteral.(type))("2")>1".equals(string)
                 || "<(toStringLiteral.(type))("2")>1<(toStringLiteral.(type))("1")>2".equals(string));
     }
 
@@ -224,10 +229,10 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         super.add();
         Mutable<name>Bag bag = this.newWith();
-        Assert.assertTrue(bag.add(<(literal.(type))("100")>));
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("100")>), bag);
-        Assert.assertTrue(bag.add(<(literal.(type))("100")>));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100"]:(literal.(type))(); separator=", ">), bag);
+        assertTrue(bag.add(<(literal.(type))("100")>));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("100")>), bag);
+        assertTrue(bag.add(<(literal.(type))("100")>));
+        assertEquals(<name>HashBag.newBagWith(<["100", "100"]:(literal.(type))(); separator=", ">), bag);
     }
 
     @Test
@@ -236,11 +241,11 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         super.addAllIterable();
         Mutable<name>Bag bag = this.newWith();
-        Assert.assertTrue(bag.addAll(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(bag.addAll(new <name>ArrayList()));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag);
-        Assert.assertTrue(bag.addAll(<name>HashBag.newBagWith(<["4", "4", "4", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3", "4", "4", "4", "4"]:(literal.(type))(); separator=", ">), bag);
+        assertTrue(bag.addAll(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(bag.addAll(new <name>ArrayList()));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), bag);
+        assertTrue(bag.addAll(<name>HashBag.newBagWith(<["4", "4", "4", "4"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3", "4", "4", "4", "4"]:(literal.(type))(); separator=", ">), bag);
     }
 
     @Test
@@ -249,19 +254,19 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         super.remove();
         Mutable<name>Bag bag = this.newWith();
-        Assert.assertFalse(bag.remove(<(literal.(type))("100")>));
+        assertFalse(bag.remove(<(literal.(type))("100")>));
         Verify.assertSize(0, bag);
-        Assert.assertEquals(new <name>HashBag(), bag);
-        Assert.assertTrue(bag.add(<(literal.(type))("100")>));
+        assertEquals(new <name>HashBag(), bag);
+        assertTrue(bag.add(<(literal.(type))("100")>));
         Verify.assertSize(1, bag);
-        Assert.assertTrue(bag.add(<(literal.(type))("100")>));
+        assertTrue(bag.add(<(literal.(type))("100")>));
         Verify.assertSize(2, bag);
-        Assert.assertTrue(bag.remove(<(literal.(type))("100")>));
+        assertTrue(bag.remove(<(literal.(type))("100")>));
         Verify.assertSize(1, bag);
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("100")>), bag);
-        Assert.assertTrue(bag.remove(<(literal.(type))("100")>));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("100")>), bag);
+        assertTrue(bag.remove(<(literal.(type))("100")>));
         Verify.assertSize(0, bag);
-        Assert.assertEquals(new <name>HashBag(), bag);
+        assertEquals(new <name>HashBag(), bag);
     }
 
     @Test
@@ -273,13 +278,13 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         <name>Iterator iterator = bag.<type>Iterator();
         for (int i = 0; i \< 6; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -292,13 +297,13 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Mutable<name>Iterator iterator = bag.<type>Iterator();
         for (int i = 0; i \< 6; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
             iterator.remove();
         }
 
         Verify.assertEmpty(bag);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -309,7 +314,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(14L, sum[0]<(delta.(type))>);
+        assertEquals(14L, sum[0]<(delta.(type))>);
     }
 
     @Test
@@ -318,9 +323,9 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     {
         super.count();
         Mutable<name>Bag bag = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(5L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(1L, bag.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertEquals(5L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(1L, bag.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, bag.count(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -328,7 +333,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("14")>, this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Test
@@ -340,8 +345,8 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Mutable<name>Bag bag2 = this.newWith(<["0", "2", "1", "2", "1", "2"]:(literal.(type))(); separator=", ">);
         Mutable<name>Bag bag3 = this.newWith(<["0", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Verify.assertEqualsAndHashCode(bag1, bag2);
-        Assert.assertNotEquals(bag1, bag3);
-        Assert.assertNotEquals(bag2, bag3);
+        assertNotEquals(bag1, bag3);
+        assertNotEquals(bag2, bag3);
     }
 
     @Test
@@ -349,7 +354,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">]", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toString());
+        assertEquals("[<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">]", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toString());
     }
 
     @Test
@@ -357,7 +362,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).makeString());
+        assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).makeString());
     }
 
     @Test
@@ -367,7 +372,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).appendString(appendable1);
-        Assert.assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", appendable1.toString());
+        assertEquals("<["1", "1", "1"]:(toStringLiteral.(type))(); separator=", ">", appendable1.toString());
     }
 
     @Test
@@ -375,7 +380,7 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "1", "1"]:(literal.(type))(); separator=", ">).toList());
     }
 
     @Test
@@ -383,14 +388,14 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void toSortedList()
     {
         super.toSortedList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSortedList());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
-        Assert.assertNotSame(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertNotSame(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(Immutable<name>Bag.class, this.classUnderTest().toImmutable());
     }
 
@@ -398,10 +403,10 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
     public void toStringOfItemToCount()
     {
         Mutable<name>Bag empty = this.newWith();
-        Assert.assertEquals("{}", empty.toStringOfItemToCount());
-        Assert.assertEquals("{" + <(literal.(type))("100")> + "=3}", this.newWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">).toStringOfItemToCount());
+        assertEquals("{}", empty.toStringOfItemToCount());
+        assertEquals("{" + <(literal.(type))("100")> + "=3}", this.newWith(<["100", "100", "100"]:(literal.(type))(); separator=", ">).toStringOfItemToCount());
         String actual = this.newWith(<["100", "101", "101"]:(literal.(type))(); separator=", ">).toStringOfItemToCount();
-        Assert.assertTrue(("{" + <(literal.(type))("100")> + "=1, " + <(literal.(type))("101")> + "=2}").equals(actual) || ("{" + <(literal.(type))("101")> + "=2, " + <(literal.(type))("100")> + "=1}").equals(actual));
+        assertTrue(("{" + <(literal.(type))("100")> + "=1, " + <(literal.(type))("101")> + "=2}").equals(actual) || ("{" + <(literal.(type))("101")> + "=2, " + <(literal.(type))("100")> + "=1}").equals(actual));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/primitiveHashBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/primitiveHashBagTest.stg
@@ -20,8 +20,9 @@ package org.eclipse.collections.impl.bag.mutable.primitive;
 
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link <name>HashBag}.
@@ -65,11 +66,11 @@ public class <name>HashBagTest extends AbstractMutable<name>BagTestCase
         <name>HashBag hashBag1 = new <name>HashBag().with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         <name>HashBag hashBag2 = new <name>HashBag().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>);
         <name>HashBag hashBag3 = new <name>HashBag().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>).with(<(literal.(type))("5")>);
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), hashBag);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), hashBag0);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), hashBag1);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), hashBag2);
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), hashBag3);
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), hashBag);
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), hashBag0);
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), hashBag1);
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), hashBag2);
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), hashBag3);
     }
 
     @Override
@@ -80,7 +81,7 @@ public class <name>HashBagTest extends AbstractMutable<name>BagTestCase
 
         <name>HashBag hashBag = <name>HashBag.newBagWith(<["1", "1", "2", "2", "2", "2", "3"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum = hashBag.injectInto(<wrapperName>.valueOf(<(literal.(type))("4")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("17")>), sum);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("17")>), sum);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/synchronizedPrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/synchronizedPrimitiveBagTest.stg
@@ -18,8 +18,10 @@ body(type, wrapperName, name) ::= <<
 package org.eclipse.collections.impl.bag.mutable.primitive;
 
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>Bag}.
@@ -46,10 +48,10 @@ public class Synchronized<name>BagTest extends AbstractMutable<name>BagTestCase
         super.asSynchronized();
         Synchronized<name>Bag bag = this.classUnderTest();
         Mutable<name>Bag bagWithLockObject = new Synchronized<name>Bag(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), new Object());
-        Assert.assertEquals(bag, bagWithLockObject);
-        Assert.assertSame(bagWithLockObject, bagWithLockObject.asSynchronized());
-        Assert.assertSame(bag, bag.asSynchronized());
-        Assert.assertEquals(bag, bag.asSynchronized());
+        assertEquals(bag, bagWithLockObject);
+        assertSame(bagWithLockObject, bagWithLockObject.asSynchronized());
+        assertSame(bag, bag.asSynchronized());
+        assertEquals(bag, bag.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
@@ -25,10 +25,14 @@ import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.tuple.primitive.<name>IntPair;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>Bag}.
@@ -203,24 +207,24 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     public void contains()
     {
         Unmodifiable<name>Bag collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
+            assertTrue(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("-1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("-1")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         Unmodifiable<name>Bag collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection1.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(collection1.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection1.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("3")>));
+        assertTrue(collection1.contains(<(literal.(type))("0")>));
+        assertTrue(collection1.contains(<(literal.(type))("1")>));
+        assertTrue(collection1.contains(<(literal.(type))("2")>));
+        assertFalse(collection1.contains(<(literal.(type))("3")>));
     }
 
     @Override
@@ -241,8 +245,8 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.bag, this.bag.asUnmodifiable());
-        Assert.assertEquals(this.bag, this.bag.asUnmodifiable());
+        assertSame(this.bag, this.bag.asUnmodifiable());
+        assertEquals(this.bag, this.bag.asUnmodifiable());
     }
 
     @Override
@@ -251,9 +255,9 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     {
         Unmodifiable<name>Bag unmodifiable<name>Bag = this.classUnderTest();
         Mutable<name>Iterator iterator = unmodifiable<name>Bag.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -262,8 +266,8 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     {
         Unmodifiable<name>Bag unmodifiable<name>Bag = this.classUnderTest();
         Mutable<name>Iterator iterator = unmodifiable<name>Bag.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/block/factory/primitivePredicatesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/factory/primitivePredicatesTest.stg
@@ -17,8 +17,10 @@ body(type, name) ::= <<
 package org.eclipse.collections.impl.block.factory.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Provides a set of common tests of predicates for <type> values.
@@ -29,58 +31,58 @@ public final class <name>PredicatesTest
     @Test
     public void testEqual()
     {
-        Assert.assertTrue(<name>Predicates.equal(<(literal.(type))("5")>).accept(<(literal.(type))("5")>));
-        Assert.assertFalse(<name>Predicates.equal(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
+        assertTrue(<name>Predicates.equal(<(literal.(type))("5")>).accept(<(literal.(type))("5")>));
+        assertFalse(<name>Predicates.equal(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
     }
 
     @Test
     public void testLessThan()
     {
-        Assert.assertTrue(<name>Predicates.lessThan(<(literal.(type))("5")>).accept(<(literal.(type))("4")>));
-        Assert.assertFalse(<name>Predicates.lessThan(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
+        assertTrue(<name>Predicates.lessThan(<(literal.(type))("5")>).accept(<(literal.(type))("4")>));
+        assertFalse(<name>Predicates.lessThan(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
     }
 
     @Test
     public void testGreaterThan()
     {
-        Assert.assertTrue(<name>Predicates.greaterThan(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
-        Assert.assertFalse(<name>Predicates.greaterThan(<(literal.(type))("5")>).accept(<(literal.(type))("4")>));
+        assertTrue(<name>Predicates.greaterThan(<(literal.(type))("5")>).accept(<(literal.(type))("6")>));
+        assertFalse(<name>Predicates.greaterThan(<(literal.(type))("5")>).accept(<(literal.(type))("4")>));
     }
 
     @Test
     public void alwaysTrue()
     {
-        Assert.assertTrue(<name>Predicates.alwaysTrue().accept(<(literal.(type))("5")>));
+        assertTrue(<name>Predicates.alwaysTrue().accept(<(literal.(type))("5")>));
     }
 
     @Test
     public void alwaysFalse()
     {
-        Assert.assertFalse(<name>Predicates.alwaysFalse().accept(<(literal.(type))("5")>));
+        assertFalse(<name>Predicates.alwaysFalse().accept(<(literal.(type))("5")>));
     }
 
     <(predicatesTest.(type))()>
     @Test
     public void testAnd()
     {
-        Assert.assertTrue(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("6")>));
-        Assert.assertFalse(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("8")>));
-        Assert.assertFalse(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("4")>));
+        assertTrue(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("6")>));
+        assertFalse(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("8")>));
+        assertFalse(<name>Predicates.and(<name>Predicates.greaterThan(<(literal.(type))("5")>), <name>Predicates.lessThan(<(literal.(type))("7")>)).accept(<(literal.(type))("4")>));
     }
 
     @Test
     public void testOr()
     {
-        Assert.assertFalse(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("6")>));
-        Assert.assertTrue(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("4")>));
-        Assert.assertTrue(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("8")>));
+        assertFalse(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("6")>));
+        assertTrue(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("4")>));
+        assertTrue(<name>Predicates.or(<name>Predicates.lessThan(<(literal.(type))("5")>), <name>Predicates.greaterThan(<(literal.(type))("7")>)).accept(<(literal.(type))("8")>));
     }
 
     @Test
     public void testNot()
     {
-        Assert.assertFalse(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("5")>)).accept(<(literal.(type))("5")>));
-        Assert.assertTrue(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("5")>)).accept(<(literal.(type))("6")>));
+        assertFalse(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("5")>)).accept(<(literal.(type))("5")>));
+        assertTrue(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("5")>)).accept(<(literal.(type))("6")>));
     }
 
     @Test
@@ -109,15 +111,15 @@ allIntPredicateTests() ::= <<
 @Test
 public void testIsOdd()
 {
-    Assert.assertTrue(<name>Predicates.isOdd().accept(<(literal.(type))("5")>));
-    Assert.assertFalse(<name>Predicates.isOdd().accept(<(literal.(type))("6")>));
+    assertTrue(<name>Predicates.isOdd().accept(<(literal.(type))("5")>));
+    assertFalse(<name>Predicates.isOdd().accept(<(literal.(type))("6")>));
 }
 
 @Test
 public void testIsEven()
 {
-    Assert.assertTrue(<name>Predicates.isEven().accept(<(literal.(type))("6")>));
-    Assert.assertFalse(<name>Predicates.isEven().accept(<(literal.(type))("5")>));
+    assertTrue(<name>Predicates.isEven().accept(<(literal.(type))("6")>));
+    assertFalse(<name>Predicates.isEven().accept(<(literal.(type))("5")>));
 }
 
 >>
@@ -126,66 +128,66 @@ allCharPredicateTests() ::= <<
 @Test
 public void testIsUpperCase()
 {
-    Assert.assertTrue(CharPredicates.isUpperCase().accept('A'));
-    Assert.assertFalse(CharPredicates.isUpperCase().accept('a'));
+    assertTrue(CharPredicates.isUpperCase().accept('A'));
+    assertFalse(CharPredicates.isUpperCase().accept('a'));
 }
 
 @Test
 public void testIsLowerCase()
 {
-    Assert.assertTrue(CharPredicates.isLowerCase().accept('a'));
-    Assert.assertFalse(CharPredicates.isLowerCase().accept('A'));
+    assertTrue(CharPredicates.isLowerCase().accept('a'));
+    assertFalse(CharPredicates.isLowerCase().accept('A'));
 }
 
 @Test
 public void testIsDigit()
 {
-    Assert.assertTrue(CharPredicates.isDigit().accept('5'));
-    Assert.assertFalse(CharPredicates.isDigit().accept('a'));
+    assertTrue(CharPredicates.isDigit().accept('5'));
+    assertFalse(CharPredicates.isDigit().accept('a'));
 }
 
 @Test
 public void testIsDigitOrDot()
 {
-    Assert.assertTrue(CharPredicates.isDigitOrDot().accept('5'));
-    Assert.assertTrue(CharPredicates.isDigitOrDot().accept('.'));
-    Assert.assertFalse(CharPredicates.isDigitOrDot().accept('a'));
+    assertTrue(CharPredicates.isDigitOrDot().accept('5'));
+    assertTrue(CharPredicates.isDigitOrDot().accept('.'));
+    assertFalse(CharPredicates.isDigitOrDot().accept('a'));
 }
 
 @Test
 public void testIsLetter()
 {
-    Assert.assertTrue(CharPredicates.isLetter().accept('a'));
-    Assert.assertTrue(CharPredicates.isLetter().accept('A'));
-    Assert.assertFalse(CharPredicates.isLetter().accept('5'));
+    assertTrue(CharPredicates.isLetter().accept('a'));
+    assertTrue(CharPredicates.isLetter().accept('A'));
+    assertFalse(CharPredicates.isLetter().accept('5'));
 }
 
 @Test
 public void testIsLetterOrDigit()
 {
-    Assert.assertTrue(CharPredicates.isLetterOrDigit().accept('a'));
-    Assert.assertTrue(CharPredicates.isLetterOrDigit().accept('A'));
-    Assert.assertTrue(CharPredicates.isLetterOrDigit().accept('5'));
-    Assert.assertFalse(CharPredicates.isLetterOrDigit().accept('.'));
-    Assert.assertFalse(CharPredicates.isLetterOrDigit().accept('#'));
+    assertTrue(CharPredicates.isLetterOrDigit().accept('a'));
+    assertTrue(CharPredicates.isLetterOrDigit().accept('A'));
+    assertTrue(CharPredicates.isLetterOrDigit().accept('5'));
+    assertFalse(CharPredicates.isLetterOrDigit().accept('.'));
+    assertFalse(CharPredicates.isLetterOrDigit().accept('#'));
 }
 
 @Test
 public void testisWhitespace()
 {
-    Assert.assertTrue(CharPredicates.isWhitespace().accept(' '));
-    Assert.assertTrue(CharPredicates.isWhitespace().accept('\n'));
-    Assert.assertFalse(CharPredicates.isWhitespace().accept('A'));
-    Assert.assertFalse(CharPredicates.isWhitespace().accept('5'));
-    Assert.assertFalse(CharPredicates.isWhitespace().accept('.'));
-    Assert.assertFalse(CharPredicates.isWhitespace().accept('#'));
+    assertTrue(CharPredicates.isWhitespace().accept(' '));
+    assertTrue(CharPredicates.isWhitespace().accept('\n'));
+    assertFalse(CharPredicates.isWhitespace().accept('A'));
+    assertFalse(CharPredicates.isWhitespace().accept('5'));
+    assertFalse(CharPredicates.isWhitespace().accept('.'));
+    assertFalse(CharPredicates.isWhitespace().accept('#'));
 }
 
 @Test
 public void testIsUndefined()
 {
-    Assert.assertTrue(CharPredicates.isUndefined().accept((char) 888));
-    Assert.assertFalse(CharPredicates.isUndefined().accept('a'));
+    assertTrue(CharPredicates.isUndefined().accept((char) 888));
+    assertFalse(CharPredicates.isUndefined().accept('a'));
 }
 
 >>
@@ -194,10 +196,10 @@ allDoublePredicateTests() ::= <<
 @Test
 public void equalWithDelta()
 {
-    Assert.assertFalse(DoublePredicates.not(DoublePredicates.equal(5.0, Double.valueOf("1e-15"))).accept(5.0));
-    Assert.assertFalse(DoublePredicates.not(DoublePredicates.equal(5.0, 2.0)).accept(6.0));
-    Assert.assertTrue(DoublePredicates.not(DoublePredicates.equal(5.0, Double.valueOf("1e-15"))).accept(6.0));
-    Assert.assertTrue(DoublePredicates.not(DoublePredicates.equal(5.0, 1.0)).accept(7.0));
+    assertFalse(DoublePredicates.not(DoublePredicates.equal(5.0, Double.valueOf("1e-15"))).accept(5.0));
+    assertFalse(DoublePredicates.not(DoublePredicates.equal(5.0, 2.0)).accept(6.0));
+    assertTrue(DoublePredicates.not(DoublePredicates.equal(5.0, Double.valueOf("1e-15"))).accept(6.0));
+    assertTrue(DoublePredicates.not(DoublePredicates.equal(5.0, 1.0)).accept(7.0));
 }
 
 >>
@@ -206,10 +208,10 @@ allFloatPredicateTests() ::= <<
 @Test
 public void equalWithDelta()
 {
-    Assert.assertFalse(FloatPredicates.not(FloatPredicates.equal(5.0f, Float.valueOf("1e-15"))).accept(5.0f));
-    Assert.assertFalse(FloatPredicates.not(FloatPredicates.equal(5.0f, 2.0f)).accept(6.0f));
-    Assert.assertTrue(FloatPredicates.not(FloatPredicates.equal(5.0f, Float.valueOf("1e-15"))).accept(6.0f));
-    Assert.assertTrue(FloatPredicates.not(FloatPredicates.equal(5.0f, 1.0f)).accept(7.0f));
+    assertFalse(FloatPredicates.not(FloatPredicates.equal(5.0f, Float.valueOf("1e-15"))).accept(5.0f));
+    assertFalse(FloatPredicates.not(FloatPredicates.equal(5.0f, 2.0f)).accept(6.0f));
+    assertTrue(FloatPredicates.not(FloatPredicates.equal(5.0f, Float.valueOf("1e-15"))).accept(6.0f));
+    assertTrue(FloatPredicates.not(FloatPredicates.equal(5.0f, 1.0f)).accept(7.0f));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/block/function/primitiveCaseFunctionTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/function/primitiveCaseFunctionTest.stg
@@ -22,8 +22,11 @@ package org.eclipse.collections.impl.block.function.primitive;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * This file was automatically generated from template file primitiveCaseFunctionTest.stg.
@@ -34,7 +37,7 @@ public class <name>CaseFunctionTest
     public void noopCase()
     {
         <name>CaseFunction\<<wrapperName>\> function = new <name>CaseFunction\<<wrapperName>\>();
-        Assert.assertNull(function.valueOf(<(literal.(type))("0")>));
+        assertNull(function.valueOf(<(literal.(type))("0")>));
     }
 
     @Test
@@ -42,7 +45,7 @@ public class <name>CaseFunctionTest
     {
         <name>CaseFunction\<<wrapperName>\> function = new <name>CaseFunction\<<wrapperName>\>();
         function.addCase(ignored -> true, <wrapperName>::valueOf);
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("0")>), function.valueOf(<(literal.(type))("0")>));
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("0")>), function.valueOf(<(literal.(type))("0")>));
     }
 
     @Test
@@ -51,13 +54,13 @@ public class <name>CaseFunctionTest
         <name>CaseFunction\<String> function = new <name>CaseFunction\<String>(i -> "Yow!")
                 .addCase(i -> <(equals.(type))("i", "0")>, i -> "Patience, grasshopper");
 
-        Assert.assertEquals("Yow!", function.valueOf(<(literal.(type))("1")>));
+        assertEquals("Yow!", function.valueOf(<(literal.(type))("1")>));
 
         <name>CaseFunction\<String> function1 = function.setDefault(i -> "Patience, young grasshopper");
-        Assert.assertSame(function, function1);
+        assertSame(function, function1);
 
-        Assert.assertEquals("Patience, grasshopper", function.valueOf(<(literal.(type))("0")>));
-        Assert.assertEquals("Patience, young grasshopper", function.valueOf(<(literal.(type))("1")>));
+        assertEquals("Patience, grasshopper", function.valueOf(<(literal.(type))("0")>));
+        assertEquals("Patience, young grasshopper", function.valueOf(<(literal.(type))("1")>));
 
         Verify.assertContains("<name>CaseFunction", function.toString());
     }
@@ -72,7 +75,7 @@ public class <name>CaseFunctionTest
                         .addCase(e -> <(equals.(type))("e % 3", "0")>, e -> "Fizz")
                         .addCase(e -> <(equals.(type))("e % 5", "0")>, e -> "Buzz"))
                 .makeString(":");
-        Assert.assertEquals(
+        assertEquals(
                 "::Fizz::Buzz:Fizz:::Fizz:Buzz::Fizz:::FizzBuzz:::Fizz::Buzz",
                 fizzBuzz);
     }

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedObjectPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedObjectPrimitiveProcedureTest.stg
@@ -18,8 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for Object and <type> values.
@@ -41,13 +42,13 @@ public final class CheckedObject<name>ProcedureTest
                 result[0] = true;
             }
         }.value(null, <(zero.(type))>);
-        Assert.assertTrue(result[0]);
+        assertTrue(result[0]);
     }
 
     @Test
     public void runtimeException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> {
+        assertThrows(RuntimeException.class, () -> {
             new CheckedObject<name>Procedure\<Object>()
             {
                 @Override
@@ -62,7 +63,7 @@ public final class CheckedObject<name>ProcedureTest
     @Test
     public void checkedException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> {
+        assertThrows(RuntimeException.class, () -> {
             new CheckedObject<name>Procedure\<Object>()
             {
                 @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveObjectProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveObjectProcedureTest.stg
@@ -18,8 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type> and Object values.
@@ -41,13 +42,13 @@ public final class Checked<name>ObjectProcedureTest
                 result[0] = true;
             }
         }.value(<(zero.(type))>, null);
-        Assert.assertTrue(result[0]);
+        assertTrue(result[0]);
     }
 
     @Test
     public void runtimeException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> new Checked<name>ObjectProcedure\<Object>()
+        assertThrows(RuntimeException.class, () -> new Checked<name>ObjectProcedure\<Object>()
         {
             @Override
             public void safeValue(<type> item, Object object) throws Exception
@@ -60,7 +61,7 @@ public final class Checked<name>ObjectProcedureTest
     @Test
     public void checkedException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> new Checked<name>ObjectProcedure\<Object>()
+        assertThrows(RuntimeException.class, () -> new Checked<name>ObjectProcedure\<Object>()
         {
             @Override
             public void safeValue(<type> item, Object object) throws Exception

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitivePrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitivePrimitiveProcedureTest.stg
@@ -21,9 +21,9 @@ body(type1, type2, name1, name2) ::= <<
 package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
-
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type1> and <type2> values.
@@ -45,13 +45,13 @@ public final class Checked<name1><name2>ProcedureTest
                 result[0] = true;
             }
         }.value(<(zero.(type1))>, <(zero.(type2))>);
-        Assert.assertTrue(result[0]);
+        assertTrue(result[0]);
     }
 
     @Test
     public void runtimeException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> new Checked<name1><name2>Procedure()
+        assertThrows(RuntimeException.class, () -> new Checked<name1><name2>Procedure()
         {
             @Override
             public void safeValue(<type1> item1, <type2> item2) throws Exception
@@ -64,7 +64,7 @@ public final class Checked<name1><name2>ProcedureTest
     @Test
     public void checkedException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> new Checked<name1><name2>Procedure()
+        assertThrows(RuntimeException.class, () -> new Checked<name1><name2>Procedure()
         {
             @Override
             public void safeValue(<type1> item1, <type2> item2) throws Exception

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveProcedureTest.stg
@@ -18,8 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type> values.
@@ -41,13 +42,13 @@ public final class Checked<name>ProcedureTest
                 result[0] = true;
             }
         }.value(<(zero.(type))>);
-        Assert.assertTrue(result[0]);
+        assertTrue(result[0]);
     }
 
     @Test
     public void runtimeException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> {
+        assertThrows(RuntimeException.class, () -> {
             new Checked<name>Procedure()
             {
                 @Override
@@ -62,7 +63,7 @@ public final class Checked<name>ProcedureTest
     @Test
     public void checkedException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> {
+        assertThrows(RuntimeException.class, () -> {
             new Checked<name>Procedure()
             {
                 @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/collectPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/collectPrimitiveProcedureTest.stg
@@ -21,8 +21,9 @@ import org.eclipse.collections.api.block.function.primitive.<name>Function;
 import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * This file was automatically generated from template file CollectPrimitiveProcedureTest.stg.
@@ -40,7 +41,7 @@ public class Collect<name>ProcedureTest
         procedure.value("00");
 
         Immutable<name>List expected = <name>Lists.immutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(expected, targetList);
+        assertEquals(expected, targetList);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/primitiveCaseProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/primitiveCaseProcedureTest.stg
@@ -23,8 +23,9 @@ import org.eclipse.collections.api.list.primitive.<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * This file was automatically generated from template file primitiveCaseProcedureTest.stg.
@@ -41,7 +42,7 @@ public class <name>CaseProcedureTest
         Verify.assertEmpty(result);
         procedure.setDefault(result::add);
         source.each(procedure);
-        Assert.assertEquals(result, source);
+        assertEquals(result, source);
         Verify.assertContains("<name>CaseProcedure", procedure.toString());
     }
 
@@ -55,8 +56,8 @@ public class <name>CaseProcedureTest
                 new <name>CaseProcedure(defaultList::add)
                         .addCase(value -> <(equals.(type))("value", "1")>, ifOneList::add);
         list.each(procedure);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), defaultList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), defaultList);
     }
 
     @Test
@@ -70,8 +71,8 @@ public class <name>CaseProcedureTest
                         .addCase(value -> <(equals.(type))("value", "1")>, ifOneList::add)
                         .addCase(value -> <(equals.(type))("value", "2")>, ifTwoList::add);
         list.each(procedure);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), ifTwoList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), ifTwoList);
         Verify.assertContains("<name>CaseProcedure", procedure.toString());
     }
 
@@ -87,9 +88,9 @@ public class <name>CaseProcedureTest
                         .addCase(value -> <(equals.(type))("value", "1")>, ifOneList::add)
                         .addCase(value -> <(equals.(type))("value", "2")>, ifTwoList::add);
         list.each(procedure);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
-        Assert.assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), ifTwoList);
-        Assert.assertEquals(<name>Lists.mutable.with(<["3", "4"]:(literal.(type))(); separator=", ">), defaultList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("1")>), ifOneList);
+        assertEquals(<name>Lists.mutable.with(<(literal.(type))("2")>), ifTwoList);
+        assertEquals(<name>Lists.mutable.with(<["3", "4"]:(literal.(type))(); separator=", ">), defaultList);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/sumOfPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/sumOfPrimitiveProcedureTest.stg
@@ -20,8 +20,9 @@ body(type, wrapperName, name) ::= <<
 package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.function.primitive.<name>Function;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SumOf<name>Procedure}.
@@ -41,7 +42,7 @@ public class SumOf<name>ProcedureTest
         <type> actual = (<type>) procedure.getResult();
         <type> expected = (<type>) 6;
 
-        Assert.assertTrue(<(equals.(type))("actual", "expected")>);
+        assertTrue(<(equals.(type))("actual", "expected")>);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/immutable/abstractImmutablePrimitiveCollectionTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/immutable/abstractImmutablePrimitiveCollectionTestCase.stg
@@ -21,8 +21,10 @@ package org.eclipse.collections.impl.collection.immutable.primitive;
 import org.eclipse.collections.api.collection.primitive.Immutable<name>Collection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Abstract<name>IterableTestCase;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Collection}s.
@@ -41,10 +43,10 @@ public abstract class AbstractImmutable<name>CollectionTestCase extends Abstract
 
     protected void assertSizeAndContains(Immutable<name>Collection collection, <type>... elements)
     {
-        Assert.assertEquals(elements.length, collection.size());
+        assertEquals(elements.length, collection.size());
         for (<type> i: elements)
         {
-            Assert.assertTrue(collection.contains(i));
+            assertTrue(collection.contains(i));
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
@@ -26,8 +26,14 @@ import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Collection}s
@@ -55,24 +61,24 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         collection.clear();
         Verify.assertEmpty(collection);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(collection.contains(<(literal.(type))("0")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         collection1.clear();
         Verify.assertEmpty(collection1);
         Verify.assertSize(0, collection1);
-        Assert.assertFalse(collection1.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("31")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("32")>));
+        assertFalse(collection1.contains(<(literal.(type))("0")>));
+        assertFalse(collection1.contains(<(literal.(type))("1")>));
+        assertFalse(collection1.contains(<(literal.(type))("31")>));
+        assertFalse(collection1.contains(<(literal.(type))("32")>));
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         collection2.clear();
         Verify.assertSize(0, collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection2);
+        assertEquals(this.newMutableCollectionWith(), collection2);
     }
 
     @Override
@@ -89,191 +95,191 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         super.contains();
         Mutable<name>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
-            Assert.assertTrue(collection.remove(number));
-            Assert.assertFalse(collection.contains(number));
+            assertTrue(collection.contains(number));
+            assertTrue(collection.remove(number));
+            assertFalse(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("-1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("-1")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
     }
 
     @Test
     public void add()
     {
         Mutable<name>Collection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.add(<(literal.(type))("1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyCollection);
+        assertTrue(emptyCollection.add(<(literal.(type))("1")>));
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyCollection);
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertTrue(collection.add(<(literal.(type))("4")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.add(<(literal.(type))("4")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
     public void addAllArray()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.addAll());
-        Assert.assertTrue(collection.addAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.addAll());
+        assertTrue(collection.addAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
     public void addAllIterable()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.addAll(this.newMutableCollectionWith()));
-        Assert.assertTrue(collection.addAll(this.newMutableCollectionWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.addAll(this.newMutableCollectionWith()));
+        assertTrue(collection.addAll(this.newMutableCollectionWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
     public void remove()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.remove(<(literal.(type))("-1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.remove(<(literal.(type))("3")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.remove(<(literal.(type))("-1")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.remove(<(literal.(type))("3")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
     public void removeIf()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("-1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertFalse(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertTrue(collection.removeIf(<name>Predicates.alwaysTrue()));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.removeIf(<name>Predicates.alwaysTrue()));
-        Assert.assertTrue(collection.isEmpty());
+        assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("-1")>)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertFalse(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertTrue(collection.removeIf(<name>Predicates.alwaysTrue()));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.removeIf(<name>Predicates.alwaysTrue()));
+        assertTrue(collection.isEmpty());
 
         collection = this.classUnderTest();
-        Assert.assertTrue(collection.removeIf(<name>Predicates.alwaysTrue()));
-        Assert.assertTrue(collection.isEmpty());
+        assertTrue(collection.removeIf(<name>Predicates.alwaysTrue()));
+        assertTrue(collection.isEmpty());
 
         collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeIf(<name>Predicates.alwaysFalse()));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.removeIf(<name>Predicates.alwaysFalse()));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
-        Assert.assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
-        Assert.assertTrue(collection.removeIf(<name>Predicates.lessThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         Mutable<name>Collection remove = this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(remove::contains));
+        assertEquals(this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         remove = this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(remove::contains));
+        assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.newMutableCollectionWith(<["1", "3", "2", "5", "6", "4"]:(literal.(type))(); separator=", ">);
         remove = this.newMutableCollectionWith(<["2", "4", "6"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(remove::contains));
+        assertEquals(this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.newMutableCollectionWith(<["1", "3", "2", "5", "6", "4"]:(literal.(type))(); separator=", ">);
         remove = this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "6", "4"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeIf(remove::contains));
+        assertEquals(this.newMutableCollectionWith(<["2", "6", "4"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
 
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeAll());
-        Assert.assertFalse(collection.removeAll(<(literal.(type))("-1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.removeAll(<["1", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.removeAll(<["3", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll(<(literal.(type))("-1")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeAll(<["1", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeAll(<["3", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection1.removeAll());
-        Assert.assertTrue(collection1.removeAll(<["0", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1);
+        assertFalse(collection1.removeAll());
+        assertTrue(collection1.removeAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1);
     }
 
     @Test
     public void removeAll_iterable()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeAll(this.newMutableCollectionWith()));
-        Assert.assertFalse(collection.removeAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.removeAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.removeAll(this.newMutableCollectionWith()));
+        assertFalse(collection.removeAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.removeAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
         Mutable<name>Collection collection1 = this.classUnderTest();
-        Assert.assertTrue(collection1.removeAll(this.newMutableCollectionWith(<["3", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertTrue(collection1.removeAll(this.newMutableCollectionWith(<["3", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection2.removeAll(new <name>ArrayList()));
-        Assert.assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2", "3"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertFalse(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("0")>)));
-        Assert.assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.removeAll(new <name>ArrayList()));
+        assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("0")>)));
+        assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection3.removeAll(<name>HashBag.newBagWith(<["0", "1", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertTrue(collection3.removeAll(<name>HashBag.newBagWith(<["0", "1", "1"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
     public void retainAll()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.retainAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.retainAll(<["1", "2", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.retainAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.retainAll(<["1", "2", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
 
         Mutable<name>Collection collection1 = this.classUnderTest();
-        Assert.assertTrue(collection1.retainAll(<["-3", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
-        Assert.assertTrue(collection1.retainAll(<(literal.(type))("-1")>));
+        assertTrue(collection1.retainAll(<["-3", "1"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertTrue(collection1.retainAll(<(literal.(type))("-1")>));
         Verify.assertEmpty(collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection2.retainAll(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertFalse(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(collection2.retainAll(<["5", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.retainAll(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(collection2.retainAll(<["5", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection3.retainAll(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertTrue(collection3.retainAll(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
 
         Mutable<name>Collection collection4 = this.classUnderTest();
-        Assert.assertTrue(collection4.retainAll());
+        assertTrue(collection4.retainAll());
         Verify.assertEmpty(collection4);
     }
 
@@ -281,31 +287,31 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     public void retainAll_iterable()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertFalse(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
-        Assert.assertTrue(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertFalse(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertTrue(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "5"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
 
         Mutable<name>Collection collection1 = this.classUnderTest();
-        Assert.assertTrue(collection1.retainAll(this.newMutableCollectionWith(<["-3", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
-        Assert.assertTrue(collection1.retainAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
+        assertTrue(collection1.retainAll(this.newMutableCollectionWith(<["-3", "1"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertTrue(collection1.retainAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
         Verify.assertEmpty(collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection2.retainAll(this.newMutableCollectionWith(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertFalse(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["5", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.retainAll(this.newMutableCollectionWith(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertFalse(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
+        assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["5", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection3.retainAll(<name>HashBag.newBagWith(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertTrue(collection3.retainAll(<name>HashBag.newBagWith(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
 
         Mutable<name>Collection collection4 = this.classUnderTest();
-        Assert.assertTrue(collection4.retainAll(new <name>ArrayList()));
+        assertTrue(collection4.retainAll(new <name>ArrayList()));
         Verify.assertEmpty(collection4);
     }
 
@@ -318,12 +324,12 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection1 = this.newWith().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>);
         Mutable<name>Collection collection2 = this.newWith().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>);
         Mutable<name>Collection collection3 = this.newWith().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>).with(<(literal.(type))("5")>);
-        Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
+        assertSame(emptyCollection, collection);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
@@ -335,66 +341,66 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection1 = this.newWith().withAll(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Mutable<name>Collection collection2 = this.newWith().withAll(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Mutable<name>Collection collection3 = this.newWith().withAll(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
-        Assert.assertEquals(this.classUnderTest(), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
+        assertSame(emptyCollection, collection);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
+        assertEquals(this.classUnderTest(), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
     public void without()
     {
         Mutable<name>Collection collection = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(collection, collection.without(<(literal.(type))("9")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("9")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("2")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("3")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("5")>), collection.without(<(literal.(type))("4")>));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("5")>));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("6")>));
+        assertSame(collection, collection.without(<(literal.(type))("9")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("9")>));
+        assertEquals(this.newMutableCollectionWith(<["2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("1")>));
+        assertEquals(this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("2")>));
+        assertEquals(this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("3")>));
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("5")>), collection.without(<(literal.(type))("4")>));
+        assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("5")>));
+        assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("6")>));
     }
 
     @Test
     public void withoutAll()
     {
         Mutable<name>Collection collection = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(collection, collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["2", "20"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<(literal.(type))("9")>)));
+        assertSame(collection, collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["2", "20"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<(literal.(type))("9")>)));
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1.withoutAll(<name>HashBag.newBagWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1.withoutAll(<name>HashBag.newBagWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void asSynchronized()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertEquals(collection, collection.asSynchronized());
+        assertEquals(collection, collection.asSynchronized());
         Verify.assertInstanceOf(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().getClass(), this.classUnderTest().asSynchronized());
 
         Mutable<name>Collection collection1 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>Collection synchronizedCollection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).asSynchronized();
         Verify.assertInstanceOf(synchronizedCollection.getClass(), collection1.asSynchronized());
-        Assert.assertEquals(synchronizedCollection, collection1.asSynchronized());
+        assertEquals(synchronizedCollection, collection1.asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().getClass(), this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
 
         Mutable<name>Collection collection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>Collection unmodifiableCollection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable();
         Verify.assertInstanceOf(unmodifiableCollection.getClass(), collection.asUnmodifiable());
-        Assert.assertEquals(unmodifiableCollection, collection.asUnmodifiable());
+        assertEquals(unmodifiableCollection, collection.asUnmodifiable());
     }
 
     @Test
@@ -408,7 +414,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
             iterator.remove();
         }
         Verify.assertEmpty(<type>Iterable);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -416,8 +422,8 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection <type>Iterable = this.classUnderTest();
         Mutable<name>Iterator iterator = <type>Iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
@@ -425,10 +431,10 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection <type>Iterable = this.classUnderTest();
         Mutable<name>Iterator iterator = <type>Iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
         iterator.remove();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     /**
@@ -437,8 +443,8 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     @Test
     public void newEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().newEmpty().isEmpty());
-        Assert.assertNotSame(this.classUnderTest(), this.classUnderTest().newEmpty());
+        assertTrue(this.classUnderTest().newEmpty().isEmpty());
+        assertNotSame(this.classUnderTest(), this.classUnderTest().newEmpty());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -57,10 +57,17 @@ import org.eclipse.collections.impl.factory.primitive.ShortSets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link <name>Iterable}s
@@ -82,23 +89,23 @@ public abstract class Abstract<name>IterableTestCase
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(3, iterable);
         Verify.assertSize(4, this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable1 = this.newWith();
         Verify.assertEmpty(iterable1);
-        Assert.assertFalse(iterable1.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable1.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable2 = this.newWith(<(literal.(type))("1")>);
         Verify.assertSize(1, iterable2);
-        Assert.assertFalse(iterable2.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void newCollection()
     {
-        Assert.assertEquals(this.newMutableCollectionWith(), this.newWith());
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(), this.newWith());
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
@@ -116,13 +123,13 @@ public abstract class Abstract<name>IterableTestCase
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.newWith().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
-        Assert.assertTrue(this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertFalse(this.newWith().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).notEmpty());
     }
 
     @Test
@@ -130,39 +137,39 @@ public abstract class Abstract<name>IterableTestCase
     {
         Mutable<name>List tapResult = <name>Lists.mutable.empty();
         <name>Iterable collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Test
     public void contains()
     {
         <name>Iterable iterable = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(iterable.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(iterable.contains(<(literal.(type))("49")>));
+        assertFalse(iterable.contains(<(literal.(type))("29")>));
+        assertFalse(iterable.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(iterable.contains(number));
+            assertTrue(iterable.contains(number));
         }
 
-        Assert.assertFalse(iterable.contains(<(literal.(type))("-1")>));
-        Assert.assertFalse(iterable.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(iterable.contains(<(literal.(type))("49")>));
+        assertFalse(iterable.contains(<(literal.(type))("-1")>));
+        assertFalse(iterable.contains(<(literal.(type))("29")>));
+        assertFalse(iterable.contains(<(literal.(type))("49")>));
 
         <name>Iterable iterable1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable1.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(iterable1.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(iterable1.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(iterable1.contains(<(literal.(type))("3")>));
+        assertTrue(iterable1.contains(<(literal.(type))("0")>));
+        assertTrue(iterable1.contains(<(literal.(type))("1")>));
+        assertTrue(iterable1.contains(<(literal.(type))("2")>));
+        assertFalse(iterable1.contains(<(literal.(type))("3")>));
 
         <name>Iterable iterable2 = this.classUnderTest();
         for (<type> each = 1; each \<= iterable2.size(); each++)
         {
-            Assert.assertTrue(iterable2.contains(each));
+            assertTrue(iterable2.contains(each));
         }
-        Assert.assertFalse(iterable2.contains(<(castIntToNarrowTypeWithParens.(type))("iterable2.size() + 1")>));
+        assertFalse(iterable2.contains(<(castIntToNarrowTypeWithParens.(type))("iterable2.size() + 1")>));
     }
 
 <if(primitive.floatingPoint)>
@@ -176,33 +183,33 @@ public abstract class Abstract<name>IterableTestCase
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(this.classUnderTest().toArray()));
-        Assert.assertFalse(this.classUnderTest().containsAll(<(castIntToNarrowTypeWithParens.(type))("this.classUnderTest().size() + 1")>));
+        assertTrue(this.classUnderTest().containsAll(this.classUnderTest().toArray()));
+        assertFalse(this.classUnderTest().containsAll(<(castIntToNarrowTypeWithParens.(type))("this.classUnderTest().size() + 1")>));
 
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable.containsAll(<(literal.(type))("1")>));
-        Assert.assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAll(<["1", "2", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<(literal.(type))("1")>));
+        assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAll(<["1", "2", "4"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable1 = this.newWith(<["14", "2", "30", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable1.containsAll(<(literal.(type))("14")>));
-        Assert.assertTrue(iterable1.containsAll(<(literal.(type))("35")>));
-        Assert.assertFalse(iterable1.containsAll(<(literal.(type))("-1")>));
-        Assert.assertTrue(iterable1.containsAll(<["14", "1", "30"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable1.containsAll(<["14", "1", "32"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable1.containsAll(<["14", "1", "35"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable1.containsAll(<["0", "2", "35", "-1"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable1.containsAll(<["31", "-1"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable1.containsAll(<(literal.(type))("14")>));
+        assertTrue(iterable1.containsAll(<(literal.(type))("35")>));
+        assertFalse(iterable1.containsAll(<(literal.(type))("-1")>));
+        assertTrue(iterable1.containsAll(<["14", "1", "30"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable1.containsAll(<["14", "1", "32"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable1.containsAll(<["14", "1", "35"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable1.containsAll(<["0", "2", "35", "-1"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable1.containsAll(<["31", "-1"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsAll(<(literal.(type))("0")>));
-        Assert.assertTrue(iterable2.containsAll(<["0", "0", "0"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable2.containsAll(<["0", "1", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable2.containsAll(<["0", "1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable2.containsAll(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable2.containsAll(<["3", "4"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsAll(<(literal.(type))("0")>));
+        assertTrue(iterable2.containsAll(<["0", "0", "0"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsAll(<["0", "1", "1"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsAll(<["0", "1", "2"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsAll(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsAll(<["3", "4"]:(literal.(type))(); separator=", ">));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -212,51 +219,51 @@ public abstract class Abstract<name>IterableTestCase
         }
 
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertTrue(iterable3.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable3.containsAll());
-        Assert.assertFalse(iterable3.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable3.containsAll(array));
+        assertTrue(iterable3.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable3.containsAll());
+        assertFalse(iterable3.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable3.containsAll(array));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertTrue(iterable4.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable4.containsAll());
-        Assert.assertFalse(iterable4.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable4.containsAll(array));
+        assertTrue(iterable4.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable4.containsAll());
+        assertFalse(iterable4.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable4.containsAll(array));
     }
 
     @Test
     public void containsAllIterable()
     {
         <name>Iterable source = this.classUnderTest();
-        Assert.assertTrue(source.containsAll(this.classUnderTest()));
-        Assert.assertFalse(source.containsAll(<name>ArrayList.newListWith(<(castIntToNarrowTypeWithParens.(type))("source.size() + 1")>)));
+        assertTrue(source.containsAll(this.classUnderTest()));
+        assertFalse(source.containsAll(<name>ArrayList.newListWith(<(castIntToNarrowTypeWithParens.(type))("source.size() + 1")>)));
 
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(this.newWith().containsAll(new <name>ArrayList()));
-        Assert.assertFalse(this.newWith().containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.newWith().containsAll(new <name>ArrayList()));
+        assertFalse(this.newWith().containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "4"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable iterable1 = this.newWith(<["14", "2", "30", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("14")>)));
-        Assert.assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("35")>)));
-        Assert.assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("-1")>)));
-        Assert.assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "30"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "32"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "35"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<["0", "2", "35", "-1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<["31", "-1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("14")>)));
+        assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("35")>)));
+        assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<(literal.(type))("-1")>)));
+        assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "30"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "32"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable1.containsAll(<name>HashSet.newSetWith(<["14", "1", "35"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<["0", "2", "35", "-1"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable1.containsAll(<name>HashSet.newSetWith(<["31", "-1"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>)));
-        Assert.assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "0", "0"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>)));
+        assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "0", "0"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -266,32 +273,32 @@ public abstract class Abstract<name>IterableTestCase
         }
 
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertTrue(iterable3.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable3.containsAll(<name>Lists.mutable.empty()));
-        Assert.assertFalse(iterable3.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable3.containsAll(<name>Lists.immutable.with(array)));
+        assertTrue(iterable3.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable3.containsAll(<name>Lists.mutable.empty()));
+        assertFalse(iterable3.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable3.containsAll(<name>Lists.immutable.with(array)));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertTrue(iterable4.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable4.containsAll(<name>Lists.mutable.empty()));
-        Assert.assertFalse(iterable4.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable4.containsAll(<name>Lists.immutable.with(array)));
+        assertTrue(iterable4.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable4.containsAll(<name>Lists.mutable.empty()));
+        assertFalse(iterable4.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable4.containsAll(<name>Lists.immutable.with(array)));
     }
 
     @Test
     public void containsAnyArray()
     {
         <name>Iterable iterable = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable.containsAny(<["1", "1", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAny());
-        Assert.assertTrue(iterable.containsAny(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAny(<["6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAny(<["1", "1", "1"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAny());
+        assertTrue(iterable.containsAny(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAny(<["6", "7", "8"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "3", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsAny(<["3", "3", "1", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable2.containsAny());
-        Assert.assertTrue(iterable2.containsAny(<["-1", "3", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable2.containsAny(<["2", "4", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsAny(<["3", "3", "1", "9"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsAny());
+        assertTrue(iterable2.containsAny(<["-1", "3", "5"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsAny(<["2", "4", "6"]:(literal.(type))(); separator=", ">));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -302,40 +309,40 @@ public abstract class Abstract<name>IterableTestCase
             unmatched[i] = <(castIntToNarrowTypeWithParens.(type))("i + 34")>;
         }
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertTrue(iterable3.containsAny(array));
-        Assert.assertFalse(iterable3.containsAny(unmatched));
+        assertTrue(iterable3.containsAny(array));
+        assertFalse(iterable3.containsAny(unmatched));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertTrue(iterable4.containsAny(array));
-        Assert.assertFalse(iterable4.containsAny(unmatched));
+        assertTrue(iterable4.containsAny(array));
+        assertFalse(iterable4.containsAny(unmatched));
 
         <name>Iterable emptyIterable = this.newWith();
-        Assert.assertFalse(emptyIterable.containsAny());
-        Assert.assertFalse(emptyIterable.containsAny(<["0", "0"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(emptyIterable.containsAny(<(literal.(type))("-1")>));
-        Assert.assertFalse(emptyIterable.containsAny(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(emptyIterable.containsAny());
+        assertFalse(emptyIterable.containsAny(<["0", "0"]:(literal.(type))(); separator=", ">));
+        assertFalse(emptyIterable.containsAny(<(literal.(type))("-1")>));
+        assertFalse(emptyIterable.containsAny(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void containsAnyIterable()
     {
         <name>Iterable iterable = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable.containsAny(<name>Lists.immutable.with(<["1", "1", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAny(<name>Lists.mutable.empty()));
-        Assert.assertTrue(iterable.containsAny(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAny(<name>Lists.mutable.with(<["6", "7", "8"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAny(<name>Lists.immutable.with(<["1", "1", "1"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAny(<name>Lists.mutable.empty()));
+        assertTrue(iterable.containsAny(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAny(<name>Lists.mutable.with(<["6", "7", "8"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "3", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsAny(<name>Sets.immutable.with(<["3", "3", "1", "9"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable2.containsAny(<name>Sets.mutable.empty()));
-        Assert.assertTrue(iterable2.containsAny(<name>Sets.immutable.with(<["-1", "3", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable2.containsAny(<name>Sets.mutable.with(<["2", "4", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsAny(<name>Sets.immutable.with(<["3", "3", "1", "9"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable2.containsAny(<name>Sets.mutable.empty()));
+        assertTrue(iterable2.containsAny(<name>Sets.immutable.with(<["-1", "3", "5"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable2.containsAny(<name>Sets.mutable.with(<["2", "4", "6"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable emptyIterable = this.newWith();
-        Assert.assertFalse(emptyIterable.containsAny(<name>Lists.mutable.empty()));
-        Assert.assertFalse(emptyIterable.containsAny(<name>Lists.immutable.with(<["0", "0"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(emptyIterable.containsAny(<name>Lists.mutable.with(<(literal.(type))("-1")>)));
-        Assert.assertFalse(emptyIterable.containsAny(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(emptyIterable.containsAny(<name>Lists.mutable.empty()));
+        assertFalse(emptyIterable.containsAny(<name>Lists.immutable.with(<["0", "0"]:(literal.(type))(); separator=", ">)));
+        assertFalse(emptyIterable.containsAny(<name>Lists.mutable.with(<(literal.(type))("-1")>)));
+        assertFalse(emptyIterable.containsAny(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -350,32 +357,32 @@ public abstract class Abstract<name>IterableTestCase
         bigger[size - 1] = <(literal.(type))("33")>;
 
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertTrue(iterable3.containsAny(<name>Lists.immutable.with(array)));
-        Assert.assertFalse(iterable3.containsAny(<name>Lists.mutable.with(unmatched)));
-        Assert.assertFalse(iterable3.containsAny(<name>Sets.mutable.with(unmatched)));
-        Assert.assertTrue(iterable3.containsAny(<name>Sets.mutable.with(bigger)));
+        assertTrue(iterable3.containsAny(<name>Lists.immutable.with(array)));
+        assertFalse(iterable3.containsAny(<name>Lists.mutable.with(unmatched)));
+        assertFalse(iterable3.containsAny(<name>Sets.mutable.with(unmatched)));
+        assertTrue(iterable3.containsAny(<name>Sets.mutable.with(bigger)));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertTrue(iterable4.containsAny(<name>Lists.immutable.with(array)));
-        Assert.assertFalse(iterable4.containsAny(<name>Lists.mutable.with(unmatched)));
-        Assert.assertTrue(iterable4.containsAny(<name>Sets.immutable.with(array)));
-        Assert.assertTrue(iterable4.containsAny(<name>Sets.immutable.with(bigger)));
+        assertTrue(iterable4.containsAny(<name>Lists.immutable.with(array)));
+        assertFalse(iterable4.containsAny(<name>Lists.mutable.with(unmatched)));
+        assertTrue(iterable4.containsAny(<name>Sets.immutable.with(array)));
+        assertTrue(iterable4.containsAny(<name>Sets.immutable.with(bigger)));
     }
 
     @Test
     public void containsNoneArray()
     {
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(iterable.containsNone(<["1", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsNone());
-        Assert.assertFalse(iterable.containsNone(<["3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsNone(<["7", "8", "11"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsNone(<["1", "1"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsNone());
+        assertFalse(iterable.containsNone(<["3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsNone(<["7", "8", "11"]:(literal.(type))(); separator=", ">));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "3", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsNone(<["2", "4", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable2.containsNone());
-        Assert.assertFalse(iterable2.containsNone(<["-1", "1", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable2.containsNone(<["7", "3", "1", "0"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsNone(<["2", "4", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable2.containsNone());
+        assertFalse(iterable2.containsNone(<["-1", "1", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable2.containsNone(<["7", "3", "1", "0"]:(literal.(type))(); separator=", ">));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -386,40 +393,40 @@ public abstract class Abstract<name>IterableTestCase
             unmatched[i] = <(castIntToNarrowTypeWithParens.(type))("i + 34")>;
         }
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertFalse(iterable3.containsNone(array));
-        Assert.assertTrue(iterable3.containsNone(unmatched));
+        assertFalse(iterable3.containsNone(array));
+        assertTrue(iterable3.containsNone(unmatched));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertFalse(iterable4.containsNone(array));
-        Assert.assertTrue(iterable4.containsNone(unmatched));
+        assertFalse(iterable4.containsNone(array));
+        assertTrue(iterable4.containsNone(unmatched));
 
         <name>Iterable emptyIterable = this.newWith();
-        Assert.assertTrue(emptyIterable.containsNone(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(emptyIterable.containsNone());
-        Assert.assertTrue(emptyIterable.containsNone(<["-1", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(emptyIterable.containsNone(<(literal.(type))("0")>));
+        assertTrue(emptyIterable.containsNone(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertTrue(emptyIterable.containsNone());
+        assertTrue(emptyIterable.containsNone(<["-1", "5"]:(literal.(type))(); separator=", ">));
+        assertTrue(emptyIterable.containsNone(<(literal.(type))("0")>));
     }
 
     @Test
     public void containsNoneIterable()
     {
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(iterable.containsNone(<name>Lists.immutable.with(<["1", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable.containsNone(<name>Lists.mutable.empty()));
-        Assert.assertFalse(iterable.containsNone(<name>Lists.mutable.with(<["3", "4", "5", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable.containsNone(<name>Lists.immutable.with(<["7", "8", "11"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsNone(<name>Lists.immutable.with(<["1", "1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsNone(<name>Lists.mutable.empty()));
+        assertFalse(iterable.containsNone(<name>Lists.mutable.with(<["3", "4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsNone(<name>Lists.immutable.with(<["7", "8", "11"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable iterable2 = this.newWith(<["0", "1", "3", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable2.containsNone(<name>Sets.immutable.with(<["2", "4", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable2.containsNone(<name>Sets.mutable.empty()));
-        Assert.assertFalse(iterable2.containsNone(<name>Sets.immutable.with(<["-1", "1", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable2.containsNone(<name>Sets.mutable.with(<["7", "3", "1", "0"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsNone(<name>Sets.immutable.with(<["2", "4", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable2.containsNone(<name>Sets.mutable.empty()));
+        assertFalse(iterable2.containsNone(<name>Sets.immutable.with(<["-1", "1", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable2.containsNone(<name>Sets.mutable.with(<["7", "3", "1", "0"]:(literal.(type))(); separator=", ">)));
 
         <name>Iterable emptyIterable = this.newWith();
-        Assert.assertTrue(emptyIterable.containsNone(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(emptyIterable.containsNone(<name>Lists.mutable.empty()));
-        Assert.assertTrue(emptyIterable.containsNone(<name>Lists.immutable.with(<["-1", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(emptyIterable.containsNone(<name>Lists.mutable.with(<(literal.(type))("0")>)));
+        assertTrue(emptyIterable.containsNone(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertTrue(emptyIterable.containsNone(<name>Lists.mutable.empty()));
+        assertTrue(emptyIterable.containsNone(<name>Lists.immutable.with(<["-1", "5"]:(literal.(type))(); separator=", ">)));
+        assertTrue(emptyIterable.containsNone(<name>Lists.mutable.with(<(literal.(type))("0")>)));
 
         int size = 33;
         <type>[] array = new <type>[size];
@@ -434,16 +441,16 @@ public abstract class Abstract<name>IterableTestCase
         bigger[size - 1] = <(literal.(type))("33")>;
 
         <name>Iterable iterable3 = this.newWith(array);
-        Assert.assertFalse(iterable3.containsNone(<name>Lists.immutable.with(array)));
-        Assert.assertTrue(iterable3.containsNone(<name>Lists.mutable.with(unmatched)));
-        Assert.assertTrue(iterable3.containsNone(<name>Sets.mutable.with(unmatched)));
-        Assert.assertFalse(iterable3.containsNone(<name>Sets.mutable.with(bigger)));
+        assertFalse(iterable3.containsNone(<name>Lists.immutable.with(array)));
+        assertTrue(iterable3.containsNone(<name>Lists.mutable.with(unmatched)));
+        assertTrue(iterable3.containsNone(<name>Sets.mutable.with(unmatched)));
+        assertFalse(iterable3.containsNone(<name>Sets.mutable.with(bigger)));
 
         <name>Iterable iterable4 = <name>Sets.mutable.with(array);
-        Assert.assertFalse(iterable4.containsNone(<name>Lists.immutable.with(array)));
-        Assert.assertTrue(iterable4.containsNone(<name>Lists.mutable.with(unmatched)));
-        Assert.assertFalse(iterable4.containsNone(<name>Sets.immutable.with(array)));
-        Assert.assertFalse(iterable4.containsNone(<name>Sets.immutable.with(bigger)));
+        assertFalse(iterable4.containsNone(<name>Lists.immutable.with(array)));
+        assertTrue(iterable4.containsNone(<name>Lists.mutable.with(unmatched)));
+        assertFalse(iterable4.containsNone(<name>Sets.immutable.with(array)));
+        assertFalse(iterable4.containsNone(<name>Sets.immutable.with(bigger)));
     }
 
     @Test
@@ -480,7 +487,7 @@ public abstract class Abstract<name>IterableTestCase
 
         int size = this.classUnderTest().size();
         long sum1 = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum1, sum[0]<wideDelta.(type)>);
+        assertEquals(sum1, sum[0]<wideDelta.(type)>);
     }
 
     @Test
@@ -496,142 +503,142 @@ public abstract class Abstract<name>IterableTestCase
     {
         <name>Iterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 3 ? 3 : size, iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertEquals(2L, this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).count(<name>Predicates.greaterThan(<zero.(type)>)));
+        assertEquals(size >= 3 ? 3 : size, iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertEquals(2L, this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).count(<name>Predicates.greaterThan(<zero.(type)>)));
 
-        Assert.assertEquals(1, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysTrue()));
-        Assert.assertEquals(0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysFalse()));
+        assertEquals(1, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysTrue()));
+        assertEquals(0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysFalse()));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["-1", "-1", "-2", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["2", "-1", "-2", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "-1", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["-1", "-1", "-2", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["2", "-1", "-2", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "-1", "31", "32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["32"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
         <name>Iterable iterable = this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(iterable.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
-        Assert.assertFalse(iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertTrue(iterable.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
+        assertFalse(iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size > 3, iterable1.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size != 0, iterable1.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size > 3, iterable1.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size != 0, iterable1.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["1", "2", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.equal(<(literal.(type))("33")>)));
-        Assert.assertFalse(this.newWith(<["-32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.equal(<(literal.(type))("33")>)));
+        assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["1", "2", "31", "32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.equal(<(literal.(type))("33")>)));
+        assertFalse(this.newWith(<["-32"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.equal(<(literal.(type))("33")>)));
         <name>Iterable iterable = this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(iterable.allSatisfy(value -> <(lessThan.(type))({<(literal.(type))("3")>}, "value")>));
-        Assert.assertTrue(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertFalse(iterable.allSatisfy(value -> <(lessThan.(type))({<(literal.(type))("3")>}, "value")>));
+        assertTrue(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size == 0, iterable1.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size \< 3, iterable1.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size == 0, iterable1.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size \< 3, iterable1.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["1", "2", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["1", "0", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["1", "2", "31", "32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["32"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
         <name>Iterable iterable = this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(iterable.noneSatisfy(value -> <(lessThan.(type))({<(literal.(type))("1")>}, "value")>));
-        Assert.assertTrue(iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertFalse(iterable.noneSatisfy(value -> <(lessThan.(type))({<(literal.(type))("1")>}, "value")>));
+        assertTrue(iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size \<= 3, iterable1.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size == 0, iterable1.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size \<= 3, iterable1.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size == 0, iterable1.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = parameter -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function));
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Test
     public void collectWithTarget()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = parameter -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().collect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().collect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void flatCollectWithTarget()
     {
         <name>ToObjectFunction\<List\<<wrapperName>\>> function = parameter -> Lists.mutable.with(<(castIntToNarrowTypeWithParens.(type))("parameter - 1")>);
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void flatCollectIterableWithTarget()
     {
         <name>ToObjectFunction\<Iterable\<<wrapperName>\>> function = parameter -> Lists.mutable.with(<(castIntToNarrowTypeWithParens.(type))("parameter - 1")>).asLazy();
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void collectPrimitivesToLists()
     {
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 BooleanLists.mutable.with(true, true),
                 iterable.collectBoolean(each -> true, BooleanLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ByteLists.mutable.with((byte) 1, (byte) 1),
                 iterable.collectByte(each -> (byte) 1, ByteLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 CharLists.mutable.with('a', 'a'),
                 iterable.collectChar(each -> 'a', CharLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ShortLists.mutable.with((short) 1, (short) 1),
                 iterable.collectShort(each -> (short) 1, ShortLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(1, 1),
                 iterable.collectInt(each -> 1, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 FloatLists.mutable.with(1.0f, 1.0f),
                 iterable.collectFloat(each -> 1.0f, FloatLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 LongLists.mutable.with(1L, 1L),
                 iterable.collectLong(each -> 1L, LongLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 DoubleLists.mutable.with(1.0d, 1.0d),
                 iterable.collectDouble(each -> 1.0d, DoubleLists.mutable.empty()));
     }
@@ -640,28 +647,28 @@ public abstract class Abstract<name>IterableTestCase
     public void collectPrimitivesToSets()
     {
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 BooleanSets.mutable.with(false),
                 iterable.collectBoolean(each -> false, BooleanSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ByteSets.mutable.with((byte) 2),
                 iterable.collectByte(each -> (byte) 2, ByteSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 CharSets.mutable.with('b'),
                 iterable.collectChar(each -> 'b', CharSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ShortSets.mutable.with((short) 2),
                 iterable.collectShort(each -> (short) 2, ShortSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(2),
                 iterable.collectInt(each -> 2, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 FloatSets.mutable.with(2.0f),
                 iterable.collectFloat(each -> 2.0f, FloatSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 LongSets.mutable.with(2L),
                 iterable.collectLong(each -> 2L, LongSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 DoubleSets.mutable.with(2.0d),
                 iterable.collectDouble(each -> 2.0d, DoubleSets.mutable.empty()));
     }
@@ -674,8 +681,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size >= 3 ? 3 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         Verify.assertSize(size >= 2 ? 2 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
 
         <name>Iterable iterable2 = this.newWith(<["0"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(iterable2.size() == 1 ? 1 : 0, iterable2.select(<name>Predicates.alwaysTrue()));
@@ -690,8 +697,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size >= 3 ? 3 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>), <name>Sets.mutable.empty()));
         Verify.assertSize(size >= 2 ? 2 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>), <name>Sets.mutable.empty()));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
-        Assert.assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
     }
 
     @Test
@@ -702,8 +709,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size \<= 3 ? 0 : size - 3, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         Verify.assertSize(size \<= 2 ? 0 : size - 2, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
 
         <name>Iterable iterable2 = this.newWith(<["0"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(iterable2.size() == 1 ? 1 : 0, iterable2.reject(<name>Predicates.alwaysFalse()));
@@ -718,8 +725,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size \<= 3 ? 0 : size - 3, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>), <name>Sets.mutable.empty()));
         Verify.assertSize(size \<= 2 ? 0 : size - 2, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>), <name>Sets.mutable.empty()));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
-        Assert.assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
     }
 
     @Test
@@ -727,15 +734,15 @@ public abstract class Abstract<name>IterableTestCase
     {
         <name>Iterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size > 0 ? <(wideLiteral.(type))("1")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size > 0 ? <(wideLiteral.(type))("1")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
 
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<(delta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<(delta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<(delta.(type))>);
     }
 
     @Test
@@ -765,21 +772,21 @@ public abstract class Abstract<name>IterableTestCase
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, this.newWith().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, this.newWith().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
         int size = this.classUnderTest().size();
-        Assert.assertEquals(size == 0 ? <(literal.(type))("5")> : <(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(size == 0 ? <(literal.(type))("5")> : <(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, this.newWith().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, this.newWith().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
         int size = this.classUnderTest().size();
-        Assert.assertEquals(size == 0 ? <(literal.(type))("5")> : size, this.classUnderTest().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(size == 0 ? <(literal.(type))("5")> : size, this.classUnderTest().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -787,9 +794,9 @@ public abstract class Abstract<name>IterableTestCase
     {
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum, this.classUnderTest().sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(sum, this.classUnderTest().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Test
@@ -797,9 +804,9 @@ public abstract class Abstract<name>IterableTestCase
     {
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum, this.classUnderTest().summaryStatistics().getSum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<wideDelta.(type)>);
+        assertEquals(sum, this.classUnderTest().summaryStatistics().getSum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<wideDelta.(type)>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -813,7 +820,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -828,7 +835,7 @@ public void sumConsistentRounding()
             .collect<name>(i -> <["1.0"]:(decimalLiteral.(type))()> / (i.<type>Value() * i.<type>Value() * i.<type>Value() * i.<type>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -841,10 +848,10 @@ public void sumConsistentRounding()
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
         double average = sum / size;
-        Assert.assertEquals(average, this.classUnderTest().average(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(average, this.classUnderTest().average(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).average(), 0.0);
     }
 
     @Test
@@ -859,24 +866,24 @@ public void sumConsistentRounding()
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(2.5, this.newWith().averageIfEmpty(2.5), 0.0);
+        assertEquals(2.5, this.newWith().averageIfEmpty(2.5), 0.0);
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
         double average = sum / size;
-        Assert.assertEquals(average, this.classUnderTest().averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(average, this.classUnderTest().averageIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
     }
 
     @Test
@@ -891,29 +898,29 @@ public void sumConsistentRounding()
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(2.5, this.newWith().medianIfEmpty(2.5), 0.0);
-        Assert.assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith().medianIfEmpty(2.5), 0.0);
+        assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().toArray().length);
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().toArray().length);
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}, iterable.toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}, iterable.toArray())
                 || Arrays.equals(new <type>[]{<["2", "1"]:(literal.(type))(); separator=", ">}, iterable.toArray()));
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["0", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["0", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["1", "0"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray()));
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["1", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["31", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray()));
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["31", "35"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["31", "35"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["35", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray()));
-        Assert.assertArrayEquals(new <type>[]{}, this.newWith().toArray()<(delta.(type))>);
-        Assert.assertArrayEquals(new <type>[]{<(literal.(type))("32")>}, this.newWith(<(literal.(type))("32")>).toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{}, this.newWith().toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<(literal.(type))("32")>}, this.newWith(<(literal.(type))("32")>).toArray()<(delta.(type))>);
     }
 
     @Test
@@ -923,26 +930,26 @@ public void sumConsistentRounding()
 
         <type>[] target = new <type>[this.classUnderTest().size()];
 
-        Assert.assertSame(target, this.classUnderTest().toArray(target));
+        assertSame(target, this.classUnderTest().toArray(target));
         Arrays.sort(target);
-        Assert.assertTrue(Arrays.equals(originalAsSortedArray, target));
+        assertTrue(Arrays.equals(originalAsSortedArray, target));
 
         if (this.classUnderTest().size() > 0)
         {
             <type>[] targetTooSmall = new <type>[this.classUnderTest().size() - 1];
             <type>[] result = this.classUnderTest().toArray(targetTooSmall);
-            Assert.assertNotSame(targetTooSmall, result);
+            assertNotSame(targetTooSmall, result);
             Arrays.sort(result);
-            Assert.assertTrue(Arrays.equals(this.classUnderTest().toSortedArray(), result));
+            assertTrue(Arrays.equals(this.classUnderTest().toSortedArray(), result));
         }
 
         <type>[] targetTooBig = new <type>[this.classUnderTest().size() + 1];
         <type>[] bigResult = this.classUnderTest().toArray(targetTooBig);
-        Assert.assertSame(targetTooBig, bigResult);
+        assertSame(targetTooBig, bigResult);
         Arrays.sort(targetTooBig);
         for (int i = 0; i \< originalAsSortedArray.length; i++)
         {
-            Assert.assertEquals(originalAsSortedArray[i], bigResult[i + 1]<(delta.(type))>);
+            assertEquals(originalAsSortedArray[i], bigResult[i + 1]<(delta.(type))>);
         }
     }
 
@@ -957,8 +964,8 @@ public void sumConsistentRounding()
             array[i] = <(castIntToNarrowTypeWithParens.(type))("i + 1")>;
         }
 
-        Assert.assertArrayEquals(array, iterable.toSortedArray()<(delta.(type))>);
-        Assert.assertArrayEquals(new <type>[]{<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">},
+        assertArrayEquals(array, iterable.toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">},
                 this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">).toSortedArray()<(delta.(type))>);
     }
 
@@ -983,60 +990,60 @@ public void sumConsistentRounding()
         Verify.assertPostSerializedEqualsAndHashCode(iterable12);
         Verify.assertPostSerializedEqualsAndHashCode(iterable5);
         Verify.assertPostSerializedEqualsAndHashCode(iterable6);
-        Assert.assertNotEquals(iterable12, iterable11);
-        Assert.assertNotEquals(iterable1, iterable3);
-        Assert.assertNotEquals(iterable1, iterable4);
-        Assert.assertNotEquals(iterable6, iterable7);
-        Assert.assertNotEquals(iterable6, iterable8);
-        Assert.assertNotEquals(iterable9, iterable10);
-        Assert.assertNotEquals(iterable9, iterable11);
-        Assert.assertNotEquals(this.newWith(), this.newWith(<(literal.(type))("100")>));
+        assertNotEquals(iterable12, iterable11);
+        assertNotEquals(iterable1, iterable3);
+        assertNotEquals(iterable1, iterable4);
+        assertNotEquals(iterable6, iterable7);
+        assertNotEquals(iterable6, iterable8);
+        assertNotEquals(iterable9, iterable10);
+        assertNotEquals(iterable9, iterable11);
+        assertNotEquals(this.newWith(), this.newWith(<(literal.(type))("100")>));
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(this.newObjectCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertNotEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
+        assertEquals(this.newObjectCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32"]:(literal.(type))(); separator=", ">).hashCode());
+        assertNotEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[]", this.newWith().toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("1")>]", this.newWith(<(literal.(type))("1")>).toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("31")>]", this.newWith(<(literal.(type))("31")>).toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("32")>]", this.newWith(<(literal.(type))("32")>).toString());
+        assertEquals("[]", this.newWith().toString());
+        assertEquals("[<(toStringLiteral.(type))("1")>]", this.newWith(<(literal.(type))("1")>).toString());
+        assertEquals("[<(toStringLiteral.(type))("31")>]", this.newWith(<(literal.(type))("31")>).toString());
+        assertEquals("[<(toStringLiteral.(type))("32")>]", this.newWith(<(literal.(type))("32")>).toString());
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString())
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString())
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString()));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.toString(),
                 iterable1.toString().equals("[<["0", "31"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.toString(),
                 iterable2.toString().equals("[<["31", "32"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.toString(),
                 iterable3.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         <name>Iterable iterable4 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable4.toString(),
                 iterable4.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
@@ -1046,50 +1053,50 @@ public void sumConsistentRounding()
     public void makeString()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
@@ -1100,66 +1107,66 @@ public void sumConsistentRounding()
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -1167,21 +1174,21 @@ public void sumConsistentRounding()
     public void toList()
     {
         <name>Iterable iterable = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(<name>ArrayList.newListWith(<["31", "32"]:(literal.(type))(); separator=", ">).equals(iterable.toList())
+        assertTrue(<name>ArrayList.newListWith(<["31", "32"]:(literal.(type))(); separator=", ">).equals(iterable.toList())
                 || <name>ArrayList.newListWith(<["32", "31"]:(literal.(type))(); separator=", ">).equals(iterable.toList()));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.newWith(<(literal.(type))("0")>).toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), this.newWith(<(literal.(type))("31")>).toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("32")>), this.newWith(<(literal.(type))("32")>).toList());
-        Assert.assertEquals(new <name>ArrayList(), this.newWith().toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.newWith(<(literal.(type))("0")>).toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), this.newWith(<(literal.(type))("31")>).toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("32")>), this.newWith(<(literal.(type))("32")>).toList());
+        assertEquals(new <name>ArrayList(), this.newWith().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.newWith().toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWith(<(literal.(type))("1")>).toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "1"]:(literal.(type))(); separator=", ">).toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "32", "1"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(), this.newWith().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWith(<(literal.(type))("1")>).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "1"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "32", "1"]:(literal.(type))(); separator=", ">).toSortedList());
     }
 
     @Test
@@ -1191,11 +1198,11 @@ public void sumConsistentRounding()
 
         Mutable<name>List result = iterable.toSortedList((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1))); // odd/even comparator
 
-        Assert.assertNotSame(iterable, result);
+        assertNotSame(iterable, result);
 
         result
                 .collectBoolean(e -> e % 2 == 0, BooleanLists.mutable.of())
-                .forEachWithIndex((e, i) -> Assert.assertEquals("index " + i, i \< 5, e));
+                .forEachWithIndex((e, i) -> assertEquals("index " + i, i \< 5, e));
     }
 
     @Test
@@ -1206,8 +1213,8 @@ public void sumConsistentRounding()
 
         Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i));
 
-        Assert.assertNotSame(index, result);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), result);
+        assertNotSame(index, result);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -1218,52 +1225,52 @@ public void sumConsistentRounding()
 
         Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i), Comparators.naturalOrder().reversed());
 
-        Assert.assertNotSame(index, result);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), result);
+        assertNotSame(index, result);
+        assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(), this.newWith().toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(), this.newWith().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(new <name>HashBag(), this.newWith().toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(new <name>HashBag(), this.newWith().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
     }
 
     @Test
     public void asLazy()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(iterable.toBag(), iterable.asLazy().toBag());
+        assertEquals(iterable.toBag(), iterable.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
 
         <name>Iterable iterable1 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable1.toBag(), iterable1.asLazy().toBag());
+        assertEquals(iterable1.toBag(), iterable1.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable1.asLazy());
 
         <name>Iterable iterable2 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable2.toBag(), iterable2.asLazy().toBag());
+        assertEquals(iterable2.toBag(), iterable2.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable2.asLazy());
 
         <name>Iterable iterable3 = this.newWith();
-        Assert.assertEquals(iterable3.toBag(), iterable3.asLazy().toBag());
+        assertEquals(iterable3.toBag(), iterable3.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable3.asLazy());
 
         <name>Iterable iterable4 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable4.toBag(), iterable4.asLazy().toBag());
+        assertEquals(iterable4.toBag(), iterable4.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable4.asLazy());
     }
 
@@ -1272,15 +1279,15 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum1 = iterable1.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("36")>), sum1);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("36")>), sum1);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum2 = iterable2.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("37")>), sum2);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("37")>), sum2);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum3 = iterable3.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("38")>), sum3);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("38")>), sum3);
     }
 
     @Test
@@ -1288,11 +1295,11 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         boolean sum1 = iterable1.injectIntoBoolean(false, (boolean result, <type> value) -> (boolean) (result || value == <(literal.(type))("0")>));
-        Assert.assertEquals(true, sum1);
+        assertEquals(true, sum1);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         boolean sum2 = iterable2.injectIntoBoolean(false, (boolean result, <type> value) -> (boolean) (result || value == <(literal.(type))("0")>));
-        Assert.assertEquals(false, sum2);
+        assertEquals(false, sum2);
     }
 
     <injectIntoPrimitiveTest("Byte", "byte", false)>
@@ -1322,43 +1329,43 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum1 = iterable1.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum2 = iterable2.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum3 = iterable3.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
     }
 
     @Test
     public void reduceIfEmpty()
     {
         <(wideType.(type))> empty1 = this.newWith().reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, empty1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("1")>, empty1<if(primitive.floatingPoint)>, 0.001<endif>);
         <(wideType.(type))> empty2 = this.newWith().reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, empty2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("0")>, empty2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum1 = iterable1.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum2 = iterable2.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum3 = iterable3.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
     }
 
     @Test
     public void chunk()
     {
         <name>Iterable iterable = this.newWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">),
@@ -1367,35 +1374,35 @@ public void sumConsistentRounding()
                         this.newMutableCollectionWith(<["4"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(1).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(2).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(6).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(7).toSet());
-        Assert.assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
-        Assert.assertEquals(Lists.mutable.with(this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">)), this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(1));
-        Assert.assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
+        assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
+        assertEquals(Lists.mutable.with(this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">)), this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(1));
+        assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newMutableCollectionWith().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newMutableCollectionWith().chunk(-1));
     }
 }
 
@@ -1427,31 +1434,31 @@ maxTests ::= [
 ]
 
 intMaxTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "-2", "-9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(delta.(type))>);
+assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "-2", "-9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(delta.(type))>);
 >>
 
 charMaxTest(type, name) ::= <<
-Assert.assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(wideDelta.(type))>);
 >>
 
 floatMaxTest(type, name) ::= <<
 <intMaxTest(type, name)>
-Assert.assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(-1.5, this.newWith(<["-1.5", "-31.8", "-32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.POSITIVE_INFINITY, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).max()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.NaN, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN, 31.5f).max()<(wideDelta.(type))>);
-Assert.assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).max()<(wideDelta.(type))>);
+assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(-1.5, this.newWith(<["-1.5", "-31.8", "-32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<name>.POSITIVE_INFINITY, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).max()<(wideDelta.(type))>);
+assertEquals(<name>.NaN, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN, 31.5f).max()<(wideDelta.(type))>);
+assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).max()<(wideDelta.(type))>);
 >>
 
 minTests ::= [
@@ -1465,29 +1472,29 @@ minTests ::= [
 ]
 
 intMinTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("-2")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-2")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
 >>
 
 charMinTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
 >>
 
 floatMinTest(type, name) ::= <<
 <intMinTest(type, name)>
-Assert.assertEquals(-1.5, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(1.5, this.newWith(<["1.5", "31.0", "30.0"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).min()<(wideDelta.(type))>);
-Assert.assertEquals(31.5, this.newWith(<["31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN).min()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.NEGATIVE_INFINITY, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).min()<(wideDelta.(type))>);
+assertEquals(-1.5, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(1.5, this.newWith(<["1.5", "31.0", "30.0"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).min()<(wideDelta.(type))>);
+assertEquals(31.5, this.newWith(<["31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN).min()<(wideDelta.(type))>);
+assertEquals(<name>.NEGATIVE_INFINITY, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).min()<(wideDelta.(type))>);
 >>
 
 NaNTests(key) ::= <<
@@ -1496,9 +1503,9 @@ public void contains_<key>()
 {
     <name>Iterable primitiveIterable = this.newWith(<wrapperName>.<key>);
     Set\<<wrapperName>\> hashSet = new HashSet\<>();
-    Assert.assertTrue(hashSet.add(<wrapperName>.<key>));
-    Assert.assertTrue(hashSet.contains(<wrapperName>.<key>));
-    Assert.assertTrue(primitiveIterable.contains(<wrapperName>.<key>));
+    assertTrue(hashSet.add(<wrapperName>.<key>));
+    assertTrue(hashSet.contains(<wrapperName>.<key>));
+    assertTrue(primitiveIterable.contains(<wrapperName>.<key>));
 }
 
 >>
@@ -1526,19 +1533,19 @@ public void testEquals_NaN()
     Set\<<wrapperName>\> hashSet6 = new HashSet\<>();
     hashSet6.add(<wrapperName>.NEGATIVE_INFINITY);
 
-    Assert.assertEquals(hashSet1, hashSet2);
-    Assert.assertEquals(iterable1, iterable2);
-    Assert.assertEquals(hashSet3, hashSet4);
-    Assert.assertEquals(iterable3, iterable4);
-    Assert.assertEquals(hashSet5, hashSet6);
-    Assert.assertEquals(iterable5, iterable6);
+    assertEquals(hashSet1, hashSet2);
+    assertEquals(iterable1, iterable2);
+    assertEquals(hashSet3, hashSet4);
+    assertEquals(iterable3, iterable4);
+    assertEquals(hashSet5, hashSet6);
+    assertEquals(iterable5, iterable6);
 
-    Assert.assertNotEquals(hashSet1, hashSet3);
-    Assert.assertNotEquals(iterable1, iterable3);
-    Assert.assertNotEquals(hashSet3, hashSet5);
-    Assert.assertNotEquals(iterable3, iterable5);
-    Assert.assertNotEquals(hashSet5, hashSet1);
-    Assert.assertNotEquals(iterable5, iterable1);
+    assertNotEquals(hashSet1, hashSet3);
+    assertNotEquals(iterable1, iterable3);
+    assertNotEquals(hashSet3, hashSet5);
+    assertNotEquals(iterable3, iterable5);
+    assertNotEquals(hashSet5, hashSet1);
+    assertNotEquals(iterable5, iterable1);
 }
 
 >>
@@ -1552,7 +1559,7 @@ public void contains_different_NaNs()
     Set\<<wrapperName>\> hashSet = new HashSet\<>();
     hashSet.add(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1));
     <bitsType.(type)> nan2 = <NaNBits2.(type)>;
-    Assert.assertEquals(hashSet.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)), primitiveIterable.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
+    assertEquals(hashSet.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)), primitiveIterable.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
 }
 
 >>
@@ -1565,10 +1572,10 @@ public void contains_zero()
     Set\<<wrapperName>\> hashSet = new HashSet\<>();
     hashSet.add(<(literal.(type))("0")>);
 
-    Assert.assertTrue(hashSet.contains(<(literal.(type))("0")>));
-    Assert.assertFalse(hashSet.contains(-<(literal.(type))("0")>));
-    Assert.assertTrue(iterable.contains(<(literal.(type))("0")>));
-    Assert.assertFalse(iterable.contains(-<(literal.(type))("0")>));
+    assertTrue(hashSet.contains(<(literal.(type))("0")>));
+    assertFalse(hashSet.contains(-<(literal.(type))("0")>));
+    assertTrue(iterable.contains(<(literal.(type))("0")>));
+    assertFalse(iterable.contains(-<(literal.(type))("0")>));
 }
 
 >>
@@ -1591,14 +1598,14 @@ public void injectInto<toName>()
 {
     <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum1 = iterable1.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("36")>, sum1<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("36")>, sum1<if(toFloatingPoint)>, 0.001<endif>);
 
     <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum2 = iterable2.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("37")>, sum2<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("37")>, sum2<if(toFloatingPoint)>, 0.001<endif>);
 
     <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum3 = iterable3.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("38")>, sum3<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("38")>, sum3<if(toFloatingPoint)>, 0.001<endif>);
 }
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
@@ -29,10 +29,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.primitive.Synchronized<name>Iterable;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name>Iterable}s
@@ -79,13 +81,13 @@ public class Synchronized<name>IterableTest extends Abstract<name>IterableTestCa
         <name>Iterator iterator = iterable.<type>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveHashingStrategyMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveHashingStrategyMapsTest.stg
@@ -27,8 +27,9 @@ import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link Object<name>HashingStrategyMaps}
@@ -58,14 +59,14 @@ public class Object<name>HashingStrategyMapsTest
 
     private void assertMutableHashingStrategyMapFactory(MutableObject<name>HashingStrategyMapFactory mapFactory)
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), mapFactory.of(STRING_HASHING_STRATEGY));
+        assertEquals(Object<name>HashMap.newMap(), mapFactory.of(STRING_HASHING_STRATEGY));
         Verify.assertInstanceOf(MutableObject<name>Map.class, mapFactory.of(STRING_HASHING_STRATEGY));
     }
 
     @Test
     public void mapWith_mutable()
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), Object<name>HashingStrategyMaps.mutable.with(STRING_HASHING_STRATEGY));
+        assertEquals(Object<name>HashMap.newMap(), Object<name>HashingStrategyMaps.mutable.with(STRING_HASHING_STRATEGY));
         Verify.assertInstanceOf(MutableObject<name>Map.class, Object<name>HashingStrategyMaps.mutable.with(STRING_HASHING_STRATEGY));
     }
 
@@ -79,7 +80,7 @@ public class Object<name>HashingStrategyMapsTest
     public void mapWithInitialCapacity_mutable() throws Exception
     {
         MutableObject<name>Map\<String> map = Object<name>HashingStrategyMaps.mutable.withInitialCapacity(STRING_HASHING_STRATEGY, 15);
-        Assert.assertEquals(Object<name>HashMap.newMap(), map);
+        assertEquals(Object<name>HashMap.newMap(), map);
         Verify.assertInstanceOf(MutableObject<name>Map.class, map);
 
         Field keys = map.getClass().getDeclaredField("keys");
@@ -87,8 +88,8 @@ public class Object<name>HashingStrategyMapsTest
         Field values = map.getClass().getDeclaredField("values");
         values.setAccessible(true);
 
-        Assert.assertEquals(32L, ((Object[]) keys.get(map)).length);
-        Assert.assertEquals(32L, ((<type>[]) values.get(map)).length);
+        assertEquals(32L, ((Object[]) keys.get(map)).length);
+        assertEquals(32L, ((<type>[]) values.get(map)).length);
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveMapsTest.stg
@@ -27,8 +27,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.StringFunctions;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Junit test for {@link Object<name>Maps}
@@ -45,9 +47,9 @@ public class Object<name>MapsTest
 
     private void assertImmutableMapFactory(ImmutableObject<name>MapFactory mapFactory)
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), mapFactory.of());
+        assertEquals(Object<name>HashMap.newMap(), mapFactory.of());
         Verify.assertInstanceOf(ImmutableObject<name>Map.class, mapFactory.of());
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), mapFactory.of("1", <(literal.(type))("1")>));
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), mapFactory.of("1", <(literal.(type))("1")>));
     }
 
     @Test
@@ -59,22 +61,22 @@ public class Object<name>MapsTest
 
     private void assertMutableMapFactory(MutableObject<name>MapFactory mapFactory)
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), mapFactory.of());
+        assertEquals(Object<name>HashMap.newMap(), mapFactory.of());
         Verify.assertInstanceOf(MutableObject<name>Map.class, mapFactory.of());
     }
 
     @Test
     public void mapWith_immutable()
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), Object<name>Maps.immutable.with());
+        assertEquals(Object<name>HashMap.newMap(), Object<name>Maps.immutable.with());
         Verify.assertInstanceOf(ImmutableObject<name>Map.class, Object<name>Maps.immutable.with());
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), Object<name>Maps.immutable.with("1", <(literal.(type))("1")>));
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), Object<name>Maps.immutable.with("1", <(literal.(type))("1")>));
     }
 
     @Test
     public void mapWith_mutable()
     {
-        Assert.assertEquals(Object<name>HashMap.newMap(), Object<name>Maps.mutable.with());
+        assertEquals(Object<name>HashMap.newMap(), Object<name>Maps.mutable.with());
         Verify.assertInstanceOf(MutableObject<name>Map.class, Object<name>Maps.mutable.with());
     }
 
@@ -83,8 +85,8 @@ public class Object<name>MapsTest
     {
         Verify.assertEmpty(Object<name>Maps.immutable.of());
         Verify.assertEmpty(Object<name>Maps.immutable.empty());
-        Assert.assertSame(Object<name>Maps.immutable.of(), Object<name>Maps.immutable.of());
-        Assert.assertSame(Object<name>Maps.immutable.empty(), Object<name>Maps.immutable.empty());
+        assertSame(Object<name>Maps.immutable.of(), Object<name>Maps.immutable.of());
+        assertSame(Object<name>Maps.immutable.empty(), Object<name>Maps.immutable.empty());
         Verify.assertPostSerializedIdentity(Object<name>Maps.immutable.of());
         Verify.assertPostSerializedIdentity(Object<name>Maps.immutable.empty());
     }
@@ -100,52 +102,52 @@ public class Object<name>MapsTest
     public void newMapOfAll_immutable()
     {
         ImmutableObject<name>Map\<String> map = Object<name>Maps.immutable.of();
-        Assert.assertEquals(map, Object<name>Maps.immutable.ofAll(Object<name>HashMap.newMap()));
-        Assert.assertEquals(map = map.newWithKeyValue("1", <(literal.(type))("1")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>)));
-        Assert.assertEquals(map = map.newWithKeyValue("2", <(literal.(type))("2")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>)));
-        Assert.assertEquals(map = map.newWithKeyValue("3", <(literal.(type))("3")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>)));
-        Assert.assertEquals(map = map.newWithKeyValue("4", <(literal.(type))("4")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>, "4", <(literal.(type))("4")>)));
+        assertEquals(map, Object<name>Maps.immutable.ofAll(Object<name>HashMap.newMap()));
+        assertEquals(map = map.newWithKeyValue("1", <(literal.(type))("1")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>)));
+        assertEquals(map = map.newWithKeyValue("2", <(literal.(type))("2")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>)));
+        assertEquals(map = map.newWithKeyValue("3", <(literal.(type))("3")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>)));
+        assertEquals(map = map.newWithKeyValue("4", <(literal.(type))("4")>), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>, "4", <(literal.(type))("4")>)));
     }
 
     @Test
     public void newMapOfAll_mutable()
     {
         MutableObject<name>Map\<String> map = Object<name>Maps.mutable.of();
-        Assert.assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newMap()));
+        assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newMap()));
         map.put("1", <(literal.(type))("1")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>)));
+        assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>)));
         map.put("2", <(literal.(type))("2")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>)));
+        assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>)));
         map.put("3", <(literal.(type))("3")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>)));
+        assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>)));
         map.put("4", <(literal.(type))("4")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>, "4", <(literal.(type))("4")>)));
+        assertEquals(map, Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>, "4", <(literal.(type))("4")>)));
     }
 
     @Test
     public void newMapFrom_immutable()
     {
         ImmutableObject<name>Map\<String> map = Object<name>Maps.immutable.of();
-        Assert.assertEquals(map, Object<name>Maps.immutable.from(Lists.mutable.\<String>empty(), String::valueOf, StringFunctions.toPrimitive<name>()));
-        Assert.assertEquals(map = map.newWithKeyValue("1", <(literal.(type))("1")>), Object<name>Maps.immutable.from(Lists.mutable.of("1"), String::valueOf, StringFunctions.toPrimitive<name>()));
-        Assert.assertEquals(map = map.newWithKeyValue("2", <(literal.(type))("2")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2"), String::valueOf, StringFunctions.toPrimitive<name>()));
-        Assert.assertEquals(map = map.newWithKeyValue("3", <(literal.(type))("3")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2", "3"), String::valueOf, StringFunctions.toPrimitive<name>()));
-        Assert.assertEquals(map = map.newWithKeyValue("4", <(literal.(type))("4")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2", "3", "4"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.immutable.from(Lists.mutable.\<String>empty(), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map = map.newWithKeyValue("1", <(literal.(type))("1")>), Object<name>Maps.immutable.from(Lists.mutable.of("1"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map = map.newWithKeyValue("2", <(literal.(type))("2")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map = map.newWithKeyValue("3", <(literal.(type))("3")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2", "3"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map = map.newWithKeyValue("4", <(literal.(type))("4")>), Object<name>Maps.immutable.from(Lists.mutable.of("1", "2", "3", "4"), String::valueOf, StringFunctions.toPrimitive<name>()));
     }
 
     @Test
     public void newMapFrom_mutable()
     {
         MutableObject<name>Map\<String> map = Object<name>Maps.mutable.of();
-        Assert.assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.\<String>empty(), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.\<String>empty(), String::valueOf, StringFunctions.toPrimitive<name>()));
         map.put("1", <(literal.(type))("1")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1"), String::valueOf, StringFunctions.toPrimitive<name>()));
         map.put("2", <(literal.(type))("2")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2"), String::valueOf, StringFunctions.toPrimitive<name>()));
         map.put("3", <(literal.(type))("3")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2", "3"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2", "3"), String::valueOf, StringFunctions.toPrimitive<name>()));
         map.put("4", <(literal.(type))("4")>);
-        Assert.assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2", "3", "4"), String::valueOf, StringFunctions.toPrimitive<name>()));
+        assertEquals(map, Object<name>Maps.mutable.from(Lists.mutable.of("1", "2", "3", "4"), String::valueOf, StringFunctions.toPrimitive<name>()));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveBagsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveBagsTest.stg
@@ -24,8 +24,10 @@ import org.eclipse.collections.api.factory.bag.primitive.Mutable<name>BagFactory
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Junit test for {@link <name>Bags}
@@ -42,29 +44,29 @@ public class <name>BagsTest
 
     private void assertImmutableBagFactory(Immutable<name>BagFactory bagFactory)
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(), bagFactory.of());
+        assertEquals(<name>HashBag.newBagWith(), bagFactory.of());
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of());
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), bagFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), bagFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Immutable<name>Bag.class, bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -77,81 +79,81 @@ public class <name>BagsTest
 
     private void assertMutableBagFactory(Mutable<name>BagFactory bagFactory)
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(), bagFactory.of());
+        assertEquals(<name>HashBag.newBagWith(), bagFactory.of());
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of());
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), bagFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), bagFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Mutable<name>Bag.class, bagFactory.ofAll(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void emptyBag()
     {
-        Assert.assertTrue(<name>Bags.immutable.of().isEmpty());
-        Assert.assertTrue(<name>Bags.mutable.of().isEmpty());
+        assertTrue(<name>Bags.immutable.of().isEmpty());
+        assertTrue(<name>Bags.mutable.of().isEmpty());
     }
 
     @Test
     public void newBagWith_immutable()
     {
         Immutable<name>Bag bag = <name>Bags.immutable.of();
-        Assert.assertEquals(bag, <name>Bags.immutable.of(bag.toArray()));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("1")>), <name>Bags.immutable.of(<(literal.(type))("1")>));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("2")>), <name>Bags.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("3")>), <name>Bags.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("4")>), <name>Bags.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("5")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("6")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("7")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("8")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("9")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("10")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.immutable.of(bag.toArray()));
+        assertEquals(bag = bag.newWith(<(literal.(type))("1")>), <name>Bags.immutable.of(<(literal.(type))("1")>));
+        assertEquals(bag = bag.newWith(<(literal.(type))("2")>), <name>Bags.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("3")>), <name>Bags.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("4")>), <name>Bags.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("5")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("6")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("7")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("8")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("9")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag = bag.newWith(<(literal.(type))("10")>), <name>Bags.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void newBagWith_mutable()
     {
         Mutable<name>Bag bag = <name>Bags.mutable.of();
-        Assert.assertEquals(bag, <name>Bags.mutable.of(bag.toArray()));
+        assertEquals(bag, <name>Bags.mutable.of(bag.toArray()));
         bag.add(<(literal.(type))("1")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<(literal.(type))("1")>));
+        assertEquals(bag, <name>Bags.mutable.of(<(literal.(type))("1")>));
         bag.add(<(literal.(type))("2")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("3")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("4")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("5")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("6")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("7")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("8")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("9")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         bag.add(<(literal.(type))("10")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(bag, <name>Bags.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -159,16 +161,16 @@ public class <name>BagsTest
     public void newBagWithArray_immutable()
     {
         Immutable<name>Bag bag = <name>Bags.immutable.of();
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("1")>), <name>Bags.immutable.of(new <type>[]{<(literal.(type))("1")>}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("2")>), <name>Bags.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("3")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("4")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("5")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("6")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("7")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("8")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("9")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("10")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("1")>), <name>Bags.immutable.of(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("2")>), <name>Bags.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("3")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("4")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("5")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("6")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("7")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("8")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("9")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag = bag.newWith(<(literal.(type))("10")>), <name>Bags.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -176,28 +178,28 @@ public class <name>BagsTest
     public void newBagWithArray_mutable()
     {
         Mutable<name>Bag bag = <name>Bags.mutable.of();
-        Assert.assertEquals(bag, <name>Bags.mutable.of(null));
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{}));
+        assertEquals(bag, <name>Bags.mutable.of(null));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{}));
         bag.add(<(literal.(type))("1")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<(literal.(type))("1")>}));
         bag.add(<(literal.(type))("2")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("3")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("4")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("5")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("6")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("7")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("8")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("9")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
         bag.add(<(literal.(type))("10")>);
-        Assert.assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(bag, <name>Bags.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @Test
@@ -205,39 +207,39 @@ public class <name>BagsTest
     {
         Immutable<name>Bag bag = <name>Bags.immutable.of();
         <name>HashBag hashBag = <name>HashBag.newBagWith(<(literal.(type))("1")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("1")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("1")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("2")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("2")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("2")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("3")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("3")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("3")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("4")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("4")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("4")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("5")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("5")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("5")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("6")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("6")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("6")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("7")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("7")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("7")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("8")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("8")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("8")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("9")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("9")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("9")>), hashBag.toImmutable());
         hashBag.add(<(literal.(type))("10")>);
-        Assert.assertEquals(bag = bag.newWith(<(literal.(type))("10")>), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith(<(literal.(type))("10")>), hashBag.toImmutable());
     }
 
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new <name>HashBag(), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>HashBag(), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Bags.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>HashBag(), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>HashBag(), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Bags.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveListsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveListsTest.stg
@@ -24,8 +24,10 @@ import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link <name>Lists}.
@@ -42,29 +44,29 @@ public class <name>ListsTest
 
     private void assertImmutableListFactory(Immutable<name>ListFactory listFactory)
     {
-        Assert.assertEquals(new <name>ArrayList(), listFactory.of());
+        assertEquals(new <name>ArrayList(), listFactory.of());
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), listFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), listFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Immutable<name>List.class, listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -77,29 +79,29 @@ public class <name>ListsTest
 
     private void assertMutableListFactory(Mutable<name>ListFactory listFactory)
     {
-        Assert.assertEquals(new <name>ArrayList(), listFactory.of());
+        assertEquals(new <name>ArrayList(), listFactory.of());
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), listFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), listFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Mutable<name>List.class, listFactory.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -107,7 +109,7 @@ public class <name>ListsTest
     public void emptyList()
     {
         Verify.assertEmpty(<name>Lists.immutable.of());
-        Assert.assertSame(<name>Lists.immutable.of(), <name>Lists.immutable.of());
+        assertSame(<name>Lists.immutable.of(), <name>Lists.immutable.of());
         Verify.assertPostSerializedIdentity(<name>Lists.immutable.of());
     }
 
@@ -115,19 +117,19 @@ public class <name>ListsTest
     public void newListWith()
     {
         Immutable<name>List list = <name>Lists.immutable.of();
-        Assert.assertEquals(list, <name>Lists.immutable.of(list.toArray()));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("1")>), <name>Lists.immutable.of(<(literal.(type))("1")>));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("2")>), <name>Lists.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("3")>), <name>Lists.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("4")>), <name>Lists.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("5")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("6")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("7")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("8")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("9")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("10")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("11")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("12")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]:(literal.(type))(); separator=", ">));
+        assertEquals(list, <name>Lists.immutable.of(list.toArray()));
+        assertEquals(list = list.newWith(<(literal.(type))("1")>), <name>Lists.immutable.of(<(literal.(type))("1")>));
+        assertEquals(list = list.newWith(<(literal.(type))("2")>), <name>Lists.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("3")>), <name>Lists.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("4")>), <name>Lists.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("5")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("6")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("7")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("8")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("9")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("10")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("11")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">));
+        assertEquals(list = list.newWith(<(literal.(type))("12")>), <name>Lists.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]:(literal.(type))(); separator=", ">));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -135,17 +137,17 @@ public class <name>ListsTest
     public void newListWithArray_immutable()
     {
         Immutable<name>List list = <name>Lists.immutable.of();
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("1")>), <name>Lists.immutable.of(new <type>[]{1}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("2")>), <name>Lists.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("3")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("4")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("5")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("6")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("7")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("8")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("9")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("10")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("11")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("1")>), <name>Lists.immutable.of(new <type>[]{1}));
+        assertEquals(list = list.newWith(<(literal.(type))("2")>), <name>Lists.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("3")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("4")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("5")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("6")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("7")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("8")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("9")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("10")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list = list.newWith(<(literal.(type))("11")>), <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">}));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -153,30 +155,30 @@ public class <name>ListsTest
     public void newListWithArray_mutable()
     {
         Mutable<name>List list = <name>Lists.mutable.of();
-        Assert.assertEquals(list, <name>Lists.mutable.of(null));
-        Assert.assertEquals(list, <name>Lists.mutable.of(new <type>[]{}));
+        assertEquals(list, <name>Lists.mutable.of(null));
+        assertEquals(list, <name>Lists.mutable.of(new <type>[]{}));
         list.add(<(literal.(type))("1")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{1}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{1}));
         list.add(<(literal.(type))("2")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("3")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("4")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("5")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("6")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("7")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("8")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("9")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("10")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
         list.add(<(literal.(type))("11")>);
-        Assert.assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">}));
+        assertEquals(list, <name>Lists.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]:(literal.(type))(); separator=", ">}));
     }
 
     @Test
@@ -186,7 +188,7 @@ public class <name>ListsTest
         Mutable<name>List actual = <name>Lists.mutable.wrapCopy(array);
         Mutable<name>List expected = <name>ArrayList.newListWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         array[0] = <(literal.(type))("1")>;
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -194,26 +196,26 @@ public class <name>ListsTest
     {
         Immutable<name>List list = <name>Lists.immutable.of();
         <name>ArrayList <type>ArrayList = <name>ArrayList.newListWith(<(literal.(type))("1")>);
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("1")>), <type>ArrayList.toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("2")>), <type>ArrayList.with(<(literal.(type))("2")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("3")>), <type>ArrayList.with(<(literal.(type))("3")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("4")>), <type>ArrayList.with(<(literal.(type))("4")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("5")>), <type>ArrayList.with(<(literal.(type))("5")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("6")>), <type>ArrayList.with(<(literal.(type))("6")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("7")>), <type>ArrayList.with(<(literal.(type))("7")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("8")>), <type>ArrayList.with(<(literal.(type))("8")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("9")>), <type>ArrayList.with(<(literal.(type))("9")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("10")>), <type>ArrayList.with(<(literal.(type))("10")>).toImmutable());
-        Assert.assertEquals(list = list.newWith(<(literal.(type))("11")>), <type>ArrayList.with(<(literal.(type))("11")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("1")>), <type>ArrayList.toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("2")>), <type>ArrayList.with(<(literal.(type))("2")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("3")>), <type>ArrayList.with(<(literal.(type))("3")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("4")>), <type>ArrayList.with(<(literal.(type))("4")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("5")>), <type>ArrayList.with(<(literal.(type))("5")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("6")>), <type>ArrayList.with(<(literal.(type))("6")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("7")>), <type>ArrayList.with(<(literal.(type))("7")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("8")>), <type>ArrayList.with(<(literal.(type))("8")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("9")>), <type>ArrayList.with(<(literal.(type))("9")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("10")>), <type>ArrayList.with(<(literal.(type))("10")>).toImmutable());
+        assertEquals(list = list.newWith(<(literal.(type))("11")>), <type>ArrayList.with(<(literal.(type))("11")>).toImmutable());
     }
 
     @Test
     public void newListWithWithList()
     {
-        Assert.assertEquals(new <name>ArrayList(), <name>Lists.immutable.ofAll(new <name>ArrayList()));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayList(), <name>Lists.immutable.ofAll(new <name>ArrayList()));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -225,28 +227,28 @@ public class <name>ListsTest
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new <name>ArrayList(), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayList(), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>ArrayList(), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayList(), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Lists.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 <if(primitive.specializedStream)>
 
     @Test
     public void primitiveStream()
     {
-        Assert.assertEquals(false, <name>Lists.immutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).primitiveStream().isParallel());
+        assertEquals(false, <name>Lists.immutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).primitiveStream().isParallel());
     }
 
     @Test
     public void primitiveParallelStream()
     {
-        Assert.assertEquals(true, <name>Lists.immutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).primitiveParallelStream().isParallel());
+        assertEquals(true, <name>Lists.immutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).primitiveParallelStream().isParallel());
     }
 <endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMapsTest.stg
@@ -22,8 +22,9 @@ import org.eclipse.collections.api.factory.map.primitive.Immutable<name>ObjectMa
 import org.eclipse.collections.api.factory.map.primitive.Mutable<name>ObjectMapFactory;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file primitiveObjectMapsTest.stg.
@@ -39,12 +40,12 @@ public class <name>ObjectMapFactoryTest
 
     private void assertImmutable<name>ObjectMapFactory(Immutable<name>ObjectMapFactory mapFactory)
     {
-        Assert.assertSame(<name>ObjectHashMap.newMap().toImmutable(), mapFactory.with());
-        Assert.assertSame(<name>ObjectHashMap.newMap().toImmutable(), mapFactory.of());
-        Assert.assertEquals(<name>ObjectMaps.immutable.of(<(literal.(type))("1")>, <(literal.(type))("1")>), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, <(literal.(type))("1")>).toImmutable());
+        assertSame(<name>ObjectHashMap.newMap().toImmutable(), mapFactory.with());
+        assertSame(<name>ObjectHashMap.newMap().toImmutable(), mapFactory.of());
+        assertEquals(<name>ObjectMaps.immutable.of(<(literal.(type))("1")>, <(literal.(type))("1")>), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, <(literal.(type))("1")>).toImmutable());
         <name>ObjectHashMap sourceMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, <(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("2")>);
-        Assert.assertEquals(sourceMap.toImmutable(), mapFactory.ofAll(sourceMap));
-        Assert.assertEquals(sourceMap.toImmutable(), mapFactory.withAll(sourceMap));
+        assertEquals(sourceMap.toImmutable(), mapFactory.ofAll(sourceMap));
+        assertEquals(sourceMap.toImmutable(), mapFactory.withAll(sourceMap));
     }
 
     public void mutables()
@@ -55,11 +56,11 @@ public class <name>ObjectMapFactoryTest
 
     private void assertMutable<name>ObjectMapFactory(Mutable<name>ObjectMapFactory mapFactory)
     {
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), mapFactory.with());
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), mapFactory.of());
+        assertEquals(<name>ObjectHashMap.newMap(), mapFactory.with());
+        assertEquals(<name>ObjectHashMap.newMap(), mapFactory.of());
         <name>ObjectHashMap sourceMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, <(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("2")>);
-        Assert.assertEquals(sourceMap, mapFactory.ofAll(sourceMap));
-        Assert.assertEquals(sourceMap, mapFactory.withAll(sourceMap));
+        assertEquals(sourceMap, mapFactory.ofAll(sourceMap));
+        assertEquals(sourceMap, mapFactory.withAll(sourceMap));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
@@ -19,10 +19,11 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.api.factory.map.primitive;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.eclipse.collections.api.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link Mutable<name>ObjectMapFactory}
@@ -33,32 +34,32 @@ public class Mutable<name>ObjectMapFactoryTest
     @Test
     public void with()
     {
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), <name>ObjectMaps.mutable.with());
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one"));
+        assertEquals(<name>ObjectHashMap.newMap(), <name>ObjectMaps.mutable.with());
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"),
                 <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
                 <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
                 <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"));
     }
 
     @Test
     public void of()
     {
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), <name>ObjectMaps.mutable.of());
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one"));
+        assertEquals(<name>ObjectHashMap.newMap(), <name>ObjectMaps.mutable.of());
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"),
                 <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
                 <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
                 <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"));
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMapsTest.stg
@@ -25,8 +25,10 @@ package org.eclipse.collections.impl.factory.primitive;
 import org.eclipse.collections.api.factory.map.primitive.Immutable<name1><name2>MapFactory;
 import org.eclipse.collections.api.factory.map.primitive.Mutable<name1><name2>MapFactory;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Junit test for {@link <name1><name2>Maps}
@@ -43,12 +45,12 @@ public class <name1><name2>MapsTest
 
     private void assertImmutableMapFactory(Immutable<name1><name2>MapFactory mapFactory)
     {
-        Assert.assertSame(new <name1><name2>HashMap().toImmutable(), mapFactory.with());
-        Assert.assertSame(new <name1><name2>HashMap().toImmutable(), mapFactory.of());
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toImmutable(), mapFactory.of(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
+        assertSame(new <name1><name2>HashMap().toImmutable(), mapFactory.with());
+        assertSame(new <name1><name2>HashMap().toImmutable(), mapFactory.of());
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toImmutable(), mapFactory.of(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
         <name1><name2>HashMap sourceMap = <name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>);
-        Assert.assertEquals(sourceMap.toImmutable(), mapFactory.ofAll(sourceMap));
-        Assert.assertEquals(sourceMap.toImmutable(), mapFactory.withAll(sourceMap));
+        assertEquals(sourceMap.toImmutable(), mapFactory.ofAll(sourceMap));
+        assertEquals(sourceMap.toImmutable(), mapFactory.withAll(sourceMap));
     }
 
     @Test
@@ -60,11 +62,11 @@ public class <name1><name2>MapsTest
 
     private void assertMutableMapFactory(Mutable<name1><name2>MapFactory mapFactory)
     {
-        Assert.assertEquals(new <name1><name2>HashMap(), mapFactory.with());
-        Assert.assertEquals(new <name1><name2>HashMap(), mapFactory.of());
+        assertEquals(new <name1><name2>HashMap(), mapFactory.with());
+        assertEquals(new <name1><name2>HashMap(), mapFactory.of());
         <name1><name2>HashMap sourceMap = <name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>);
-        Assert.assertEquals(sourceMap, mapFactory.ofAll(sourceMap));
-        Assert.assertEquals(sourceMap, mapFactory.withAll(sourceMap));
+        assertEquals(sourceMap, mapFactory.ofAll(sourceMap));
+        assertEquals(sourceMap, mapFactory.withAll(sourceMap));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMutableMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMutableMapFactoryTest.stg
@@ -24,8 +24,9 @@ package org.eclipse.collections.api.factory.map.primitive;
 
 import org.eclipse.collections.api.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link Mutable<name1><name2>MapFactory}
@@ -36,34 +37,34 @@ public class Mutable<name1><name2>MapFactoryTest
     @Test
     public void with()
     {
-        Assert.assertEquals(new <name1><name2>HashMap(), <name1><name2>Maps.mutable.with());
+        assertEquals(new <name1><name2>HashMap(), <name1><name2>Maps.mutable.with());
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), <name1><name2>Maps.mutable.with(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), <name1><name2>Maps.mutable.with(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>),
                 <name1><name2>Maps.mutable.with(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>),
                 <name1><name2>Maps.mutable.with(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>),
                 <name1><name2>Maps.mutable.with(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>));
     }
 
     @Test
     public void of()
     {
-        Assert.assertEquals(new <name1><name2>HashMap(), <name1><name2>Maps.mutable.of());
+        assertEquals(new <name1><name2>HashMap(), <name1><name2>Maps.mutable.of());
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), <name1><name2>Maps.mutable.of(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), <name1><name2>Maps.mutable.of(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>),
                 <name1><name2>Maps.mutable.of(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>),
                 <name1><name2>Maps.mutable.of(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>));
 
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>),
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>),
                 <name1><name2>Maps.mutable.of(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("5")>, <(literal.(type2))("6")>, <(literal.(type1))("7")>, <(literal.(type2))("8")>));
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveSetsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveSetsTest.stg
@@ -30,8 +30,10 @@ import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Junit test for {@link <name>Sets}
@@ -48,29 +50,29 @@ public class <name>SetsTest
 
     private void assertImmutableSetFactory(Immutable<name>SetFactory setFactory)
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(), setFactory.empty());
+        assertEquals(<name>HashSet.newSetWith(), setFactory.empty());
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.empty());
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), setFactory.with(<(literal.(type))("1")>));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), setFactory.with(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Immutable<name>Set.class, setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -83,53 +85,53 @@ public class <name>SetsTest
 
     private void assertMutableSetFactory(Mutable<name>SetFactory setFactory)
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(), setFactory.empty());
+        assertEquals(<name>HashSet.newSetWith(), setFactory.empty());
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.empty());
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), setFactory.with(<(literal.(type))("1")>));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), setFactory.with(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Mutable<name>Set.class, setFactory.withAll(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void emptySet()
     {
-        Assert.assertTrue(<name>Sets.immutable.empty().isEmpty());
+        assertTrue(<name>Sets.immutable.empty().isEmpty());
     }
 
     @Test
     public void newSetWith()
     {
         Immutable<name>Set set = <name>Sets.immutable.empty();
-        Assert.assertEquals(set, <name>Sets.immutable.of(set.toArray()));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("1")>), <name>Sets.immutable.with(<(literal.(type))("1")>));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("2")>), <name>Sets.immutable.with(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("3")>), <name>Sets.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("4")>), <name>Sets.immutable.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("5")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("6")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("7")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("8")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("9")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("10")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(set, <name>Sets.immutable.of(set.toArray()));
+        assertEquals(set = set.newWith(<(literal.(type))("1")>), <name>Sets.immutable.with(<(literal.(type))("1")>));
+        assertEquals(set = set.newWith(<(literal.(type))("2")>), <name>Sets.immutable.with(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("3")>), <name>Sets.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("4")>), <name>Sets.immutable.with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("5")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("6")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("7")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("8")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("9")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(set = set.newWith(<(literal.(type))("10")>), <name>Sets.immutable.with(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -137,16 +139,16 @@ public class <name>SetsTest
     public void newSetWithArray_immutable()
     {
         Immutable<name>Set set = <name>Sets.immutable.empty();
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("1")>), <name>Sets.immutable.with(new <type>[]{<(literal.(type))("1")>}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("2")>), <name>Sets.immutable.with(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("3")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("4")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("5")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("6")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("7")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("8")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("9")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("10")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("1")>), <name>Sets.immutable.with(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(set = set.newWith(<(literal.(type))("2")>), <name>Sets.immutable.with(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("3")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("4")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("5")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("6")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("7")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("8")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("9")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set = set.newWith(<(literal.(type))("10")>), <name>Sets.immutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -154,28 +156,28 @@ public class <name>SetsTest
     public void newSetWithArray_mutable()
     {
         Mutable<name>Set set = <name>Sets.mutable.empty();
-        Assert.assertEquals(set, <name>Sets.mutable.with(null));
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{}));
+        assertEquals(set, <name>Sets.mutable.with(null));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{}));
         set.add(<(literal.(type))("1")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<(literal.(type))("1")>}));
         set.add(<(literal.(type))("2")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("3")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("4")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("5")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("6")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("7")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("8")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("9")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
         set.add(<(literal.(type))("10")>);
-        Assert.assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(set, <name>Sets.mutable.with(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @Test
@@ -183,39 +185,39 @@ public class <name>SetsTest
     {
         Immutable<name>Set set = <name>Sets.immutable.empty();
         <name>HashSet hashSet = <name>HashSet.newSetWith(<(literal.(type))("1")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("1")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("1")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("2")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("2")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("2")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("3")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("3")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("3")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("4")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("4")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("4")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("5")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("5")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("5")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("6")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("6")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("6")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("7")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("7")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("7")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("8")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("8")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("8")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("9")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("9")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("9")>), hashSet.toImmutable());
         hashSet.add(<(literal.(type))("10")>);
-        Assert.assertEquals(set = set.newWith(<(literal.(type))("10")>), hashSet.toImmutable());
+        assertEquals(set = set.newWith(<(literal.(type))("10")>), hashSet.toImmutable());
     }
 
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new <name>HashSet(), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>HashSet(), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Sets.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>HashSet(), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>HashSet(), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>Sets.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -240,7 +242,7 @@ public class <name>SetsTest
                 PrimitiveTuples.pair(<["2", "4"]:(literal.(type))(); separator=", ">),
                 PrimitiveTuples.pair(<["2", "5"]:(literal.(type))(); separator=", ">));
 
-        Assert.assertEquals(expected1, <type><name>Pairs1.toSet());
+        assertEquals(expected1, <type><name>Pairs1.toSet());
 
         LazyIterable\<<name><name>Pair> <type><name>Pairs2 =
                 <name>Sets.cartesianProduct(
@@ -255,7 +257,7 @@ public class <name>SetsTest
                 PrimitiveTuples.pair(<["5", "1"]:(literal.(type))(); separator=", ">),
                 PrimitiveTuples.pair(<["5", "2"]:(literal.(type))(); separator=", ">));
 
-        Assert.assertEquals(expected2, <type><name>Pairs2.toSet());
+        assertEquals(expected2, <type><name>Pairs2.toSet());
     }
 
     @Test
@@ -272,7 +274,7 @@ public class <name>SetsTest
                 PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                 PrimitiveTuples.pair(<["2", "1"]:(literal.(type))(); separator=", ">));
 
-        Assert.assertEquals(expected, <type><name>Pairs.toSet());
+        assertEquals(expected, <type><name>Pairs.toSet());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveStacksTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveStacksTest.stg
@@ -24,8 +24,10 @@ import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Junit test for {@link <name>Stacks}
@@ -42,29 +44,29 @@ public class <name>StacksTest
 
     private void assertImmutableStackFactory(Immutable<name>StackFactory stackFactory)
     {
-        Assert.assertEquals(<name>ArrayStack.newStackWith(), stackFactory.of());
+        assertEquals(<name>ArrayStack.newStackWith(), stackFactory.of());
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of());
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), stackFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), stackFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">), stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">), stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Immutable<name>Stack.class, stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -77,81 +79,81 @@ public class <name>StacksTest
 
     private void assertMutableStackFactory(Mutable<name>StackFactory stackFactory)
     {
-        Assert.assertEquals(<name>ArrayStack.newStackWith(), stackFactory.of());
+        assertEquals(<name>ArrayStack.newStackWith(), stackFactory.of());
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of());
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), stackFactory.of(<(literal.(type))("1")>));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), stackFactory.of(<(literal.(type))("1")>));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">), stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">), stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">), stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Verify.assertInstanceOf(Mutable<name>Stack.class, stackFactory.ofAll(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(<name>Stacks.immutable.of().isEmpty());
-        Assert.assertTrue(<name>Stacks.mutable.of().isEmpty());
+        assertTrue(<name>Stacks.immutable.of().isEmpty());
+        assertTrue(<name>Stacks.mutable.of().isEmpty());
     }
 
     @Test
     public void newStackWith_immutable()
     {
         Immutable<name>Stack stack = <name>Stacks.immutable.of();
-        Assert.assertEquals(stack, <name>Stacks.immutable.of(stack.toArray()));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("1")>), <name>Stacks.immutable.of(<(literal.(type))("1")>));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("2")>), <name>Stacks.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("3")>), <name>Stacks.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("4")>), <name>Stacks.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("5")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("6")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("7")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("8")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("9")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("10")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.immutable.of(stack.toArray()));
+        assertEquals(stack = stack.push(<(literal.(type))("1")>), <name>Stacks.immutable.of(<(literal.(type))("1")>));
+        assertEquals(stack = stack.push(<(literal.(type))("2")>), <name>Stacks.immutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("3")>), <name>Stacks.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("4")>), <name>Stacks.immutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("5")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("6")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("7")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("8")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("9")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack = stack.push(<(literal.(type))("10")>), <name>Stacks.immutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void newStackWith_mutable()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.of();
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(stack.toArray()));
+        assertEquals(stack, <name>Stacks.mutable.of(stack.toArray()));
         stack.push(<(literal.(type))("1")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<(literal.(type))("1")>));
+        assertEquals(stack, <name>Stacks.mutable.of(<(literal.(type))("1")>));
         stack.push(<(literal.(type))("2")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("3")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("4")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("5")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("6")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("7")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("8")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("9")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">));
         stack.push(<(literal.(type))("10")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
+        assertEquals(stack, <name>Stacks.mutable.of(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -159,16 +161,16 @@ public class <name>StacksTest
     public void newStackWithArray_immutable()
     {
         Immutable<name>Stack stack = <name>Stacks.immutable.of();
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("1")>), <name>Stacks.immutable.of(new <type>[]{<(literal.(type))("1")>}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("2")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("3")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("4")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("5")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("6")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("7")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("8")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("9")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
-        Assert.assertEquals(stack = stack.push(<(literal.(type))("10")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("1")>), <name>Stacks.immutable.of(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(stack = stack.push(<(literal.(type))("2")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("3")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("4")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("5")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("6")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("7")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("8")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("9")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack = stack.push(<(literal.(type))("10")>), <name>Stacks.immutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -176,69 +178,69 @@ public class <name>StacksTest
     public void newStackWithArray_mutable()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.of();
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{}));
         stack.push(<(literal.(type))("1")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<(literal.(type))("1")>}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<(literal.(type))("1")>}));
         stack.push(<(literal.(type))("2")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("3")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("4")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("5")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("6")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("7")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("8")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("9")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">}));
         stack.push(<(literal.(type))("10")>);
-        Assert.assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
+        assertEquals(stack, <name>Stacks.mutable.of(new <type>[]{<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]:(literal.(type))(); separator=", ">}));
     }
 
     @Test
     public void ofAll<name>Iterable()
     {
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackWith(<(literal.(type))("1")>), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAll(Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void ofAllReversed()
     {
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<(literal.(type))("1")>), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<(literal.(type))("1")>), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.immutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
 
-        Assert.assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>empty()));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<(literal.(type))("1")>), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(new <name>ArrayStack(), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>empty()));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<(literal.(type))("1")>), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<(literal.(type))("1")>)));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">), <name>Stacks.mutable.ofAllReversed(<name>Lists.mutable.\<<wrapperName>\>with(<["1", "2", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
@@ -40,10 +40,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Lazy<name>Iterable}.
@@ -65,7 +70,7 @@ public abstract class AbstractLazy<name>IterableTestCase
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum<(wideDelta.(type))>);
     }
 
     @Test
@@ -85,7 +90,7 @@ public abstract class AbstractLazy<name>IterableTestCase
     {
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEach(each -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -104,57 +109,57 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyIterable().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertFalse(this.getEmptyIterable().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertEquals(2L, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(2L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("34")>)));
-        Assert.assertEquals(0L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(1L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(2L, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(2L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("34")>)));
+        assertEquals(0L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
-        Assert.assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
+        assertTrue(this.classUnderTest().anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.classUnderTest().anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).anySatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
-        Assert.assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("34")>)));
+        assertTrue(this.classUnderTest().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertTrue(this.classUnderTest().allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
+        assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).allSatisfy(<name>Predicates.lessThan(<(literal.(type))("34")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
-        Assert.assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
+        assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertTrue(this.classUnderTest().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertFalse(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertTrue(this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertTrue(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("33")>)));
     }
 
     @Test
@@ -180,12 +185,12 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["34", "35"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["34", "35"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -200,9 +205,9 @@ public abstract class AbstractLazy<name>IterableTestCase
         StringBuilder tapStringBuilder = new StringBuilder();
         StringBuilder eachStringBuilder = new StringBuilder();
         Lazy<name>Iterable lazy = this.classUnderTest().tap(tapStringBuilder::append);
-        Assert.assertEquals(lazy.makeString(""), tapStringBuilder.toString());
+        assertEquals(lazy.makeString(""), tapStringBuilder.toString());
         lazy.tap(eachStringBuilder::append).forEach(eachStringBuilder::append);
-        Assert.assertEquals(CharAdapter.adapt(eachStringBuilder.toString()).toBag(), CharAdapter.adapt(tapStringBuilder.toString()).toBag());
+        assertEquals(CharAdapter.adapt(eachStringBuilder.toString()).toBag(), CharAdapter.adapt(tapStringBuilder.toString()).toBag());
     }
 
     @Test
@@ -214,22 +219,22 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void lazyCollectPrimitives()
     {
-        Assert.assertEquals(BooleanLists.immutable.of(false, true, false), this.classUnderTest().collectBoolean(e -> e % 2 == 0).toList());
-        Assert.assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), this.classUnderTest().asLazy().collectChar(e -> (char) (e + 1)).toList());
-        Assert.assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), this.classUnderTest().asLazy().collectByte(e -> (byte) (e + 1)).toList());
-        Assert.assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), this.classUnderTest().asLazy().collectShort(e -> (short) (e + 1)).toList());
-        Assert.assertEquals(IntLists.immutable.of(2, 3, 4), this.classUnderTest().asLazy().collectInt(e -> (int) (e + 1)).toList());
-        Assert.assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), this.classUnderTest().asLazy().collectFloat(e -> (float) (e + 1)).toList());
-        Assert.assertEquals(LongLists.immutable.of(2L, 3L, 4L), this.classUnderTest().asLazy().collectLong(e -> (long) (e + 1)).toList());
-        Assert.assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), this.classUnderTest().asLazy().collectDouble(e -> (double) (e + 1)).toList());
+        assertEquals(BooleanLists.immutable.of(false, true, false), this.classUnderTest().collectBoolean(e -> e % 2 == 0).toList());
+        assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), this.classUnderTest().asLazy().collectChar(e -> (char) (e + 1)).toList());
+        assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), this.classUnderTest().asLazy().collectByte(e -> (byte) (e + 1)).toList());
+        assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), this.classUnderTest().asLazy().collectShort(e -> (short) (e + 1)).toList());
+        assertEquals(IntLists.immutable.of(2, 3, 4), this.classUnderTest().asLazy().collectInt(e -> (int) (e + 1)).toList());
+        assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), this.classUnderTest().asLazy().collectFloat(e -> (float) (e + 1)).toList());
+        assertEquals(LongLists.immutable.of(2L, 3L, 4L), this.classUnderTest().asLazy().collectLong(e -> (long) (e + 1)).toList());
+        assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), this.classUnderTest().asLazy().collectDouble(e -> (double) (e + 1)).toList());
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, this.classUnderTest().sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["0", "33"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, this.classUnderTest().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["0", "33"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
     }
 
     @Test
@@ -247,27 +252,27 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("33")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("100")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("33")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("100")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.newWith(<["2", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("0")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.newWith(<["2", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.classUnderTest().select(<name>Predicates.lessThan(<(literal.(type))("0")>)).minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -275,9 +280,9 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.classUnderTest().select(<name>Predicates.lessThan(<(literal.(type))("0")>)).maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -297,7 +302,7 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void average()
     {
-        Assert.assertEquals(2.0d, this.classUnderTest().average(), 0.0);
+        assertEquals(2.0d, this.classUnderTest().average(), 0.0);
     }
 
     @Test
@@ -309,8 +314,8 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void median()
     {
-        Assert.assertEquals(2.0d, this.classUnderTest().median(), 0.0);
-        Assert.assertEquals(16.0d, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(2.0d, this.classUnderTest().median(), 0.0);
+        assertEquals(16.0d, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).median(), 0.0);
     }
 
     @Test
@@ -322,72 +327,72 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void toArray()
     {
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["0", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["0", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["1", "0"]:(literal.(type))(); separator=", ">}, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).toArray()));
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["1", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["31", "1"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).toArray()));
-        Assert.assertTrue(Arrays.equals(new <type>[]{<["31", "35"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<["31", "35"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray())
                 || Arrays.equals(new <type>[]{<["35", "31"]:(literal.(type))(); separator=", ">}, this.newWith(<["31", "35"]:(literal.(type))(); separator=", ">).toArray()));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("2")>));
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("3")>));
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("4")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("2")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("3")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("4")>));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(<["1"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(this.classUnderTest().containsAll(<["2"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(this.classUnderTest().containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(this.classUnderTest().containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(this.classUnderTest().containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(this.classUnderTest().containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.classUnderTest().containsAll(<["1"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.classUnderTest().containsAll(<["2"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.classUnderTest().containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.classUnderTest().containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(this.classUnderTest().containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertFalse(this.classUnderTest().containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void testToString()
     {
         Lazy<name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString())
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString())
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString()));
 
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.toString(),
                 iterable1.toString().equals("[<["0", "31"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.toString(),
                 iterable2.toString().equals("[<["31", "32"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.toString(),
                 iterable3.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable4 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable4.toString(),
                 iterable4.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
@@ -397,41 +402,41 @@ public abstract class AbstractLazy<name>IterableTestCase
     public void makeString()
     {
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
 
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
 
         Lazy<name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
 
         Lazy<name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         Lazy<name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
@@ -443,46 +448,46 @@ public abstract class AbstractLazy<name>IterableTestCase
         StringBuilder appendable2 = new StringBuilder();
         Lazy<name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         Lazy<name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         Lazy<name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -490,41 +495,41 @@ public abstract class AbstractLazy<name>IterableTestCase
     public void toList()
     {
         Lazy<name>Iterable iterable = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(<name>ArrayList.newListWith(<["31", "32"]:(literal.(type))(); separator=", ">).equals(iterable.toList())
+        assertTrue(<name>ArrayList.newListWith(<["31", "32"]:(literal.(type))(); separator=", ">).equals(iterable.toList())
                 || <name>ArrayList.newListWith(<["32", "31"]:(literal.(type))(); separator=", ">).equals(iterable.toList()));
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{1, 2, 3}, this.classUnderTest().toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{1, 2, 3}, this.classUnderTest().toSortedArray()<(delta.(type))>);
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
     }
 
     @Test
     public void asLazy()
     {
         Lazy<name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(iterable.toSet(), iterable.asLazy().toSet());
+        assertEquals(iterable.toSet(), iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
-        Assert.assertSame(iterable, iterable.asLazy());
+        assertSame(iterable, iterable.asLazy());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
@@ -34,10 +34,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * This file was automatically generated from template file collectPrimitiveIterableTest.stg.
@@ -55,20 +59,20 @@ public class Collect<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum<(delta.(type))>);
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(3L, this.<type>Iterable.size());
+        assertEquals(3L, this.<type>Iterable.size());
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.<type>Iterable.notEmpty());
-        Assert.assertFalse(this.<type>Iterable.isEmpty());
+        assertTrue(this.<type>Iterable.notEmpty());
+        assertFalse(this.<type>Iterable.isEmpty());
     }
 
     @Test
@@ -79,64 +83,64 @@ public class Collect<name>IterableTest
         {
             value[0] += each;
         });
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, value[0]<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, value[0]<(delta.(type))>);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1, this.<type>Iterable.count(<name>Predicates.equal(<(literal.(type))("1")>)));
-        Assert.assertEquals(3, this.<type>Iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertEquals(2, this.<type>Iterable.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(1, this.<type>Iterable.count(<name>Predicates.equal(<(literal.(type))("1")>)));
+        assertEquals(3, this.<type>Iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertEquals(2, this.<type>Iterable.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.<type>Iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.<type>Iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("1")>)));
-        Assert.assertFalse(this.<type>Iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(this.<type>Iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertTrue(this.<type>Iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("1")>)));
+        assertFalse(this.<type>Iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.<type>Iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.<type>Iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertFalse(this.<type>Iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("2")>)));
+        assertTrue(this.<type>Iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.<type>Iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertFalse(this.<type>Iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertTrue(this.<type>Iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertFalse(this.<type>Iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(3L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
-        Assert.assertEquals(2L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
+        assertEquals(3L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
+        assertEquals(2L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(0L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
-        Assert.assertEquals(1L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
+        assertEquals(0L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
+        assertEquals(1L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.<type>Iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.<type>Iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.<type>Iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, this.<type>Iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, this.<type>Iterable.sum()<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, this.<type>Iterable.sum()<(delta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -149,7 +153,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -163,7 +167,7 @@ public void sumConsistentRounding()
             .shuffleThis()
             .collect<name>(i -> <["1.0"]:(decimalLiteral.(type))()> / (i.<type>Value() * i.<type>Value() * i.<type>Value() * i.<type>Value()));
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -173,27 +177,27 @@ public void sumConsistentRounding()
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max()<(delta.(type))>);
+        assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max()<(delta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min()<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min()<(delta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
@@ -213,7 +217,7 @@ public void sumConsistentRounding()
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average(), 0.001);
+        assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average(), 0.001);
     }
 
     @Test
@@ -226,8 +230,8 @@ public void sumConsistentRounding()
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
-        Assert.assertEquals(4.0, Interval.oneTo(7).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
+        assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
+        assertEquals(4.0, Interval.oneTo(7).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
     }
 
     @Test
@@ -240,14 +244,14 @@ public void sumConsistentRounding()
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>},
+        assertArrayEquals(new <type>[]{<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>},
                 Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).toArray()<(delta.(type))>);
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>},
+        assertArrayEquals(new <type>[]{<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>},
                 Interval.fromTo(4, 1).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).toSortedArray()<(delta.(type))>);
     }
 
@@ -255,50 +259,50 @@ public void sumConsistentRounding()
     public void contains()
     {
         <name>Iterable <type>Iterable = Interval.fromTo(4, 1).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>());
-        Assert.assertTrue(<type>Iterable.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(<type>Iterable.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(<type>Iterable.contains(<(literal.(type))("4")>));
-        Assert.assertFalse(<type>Iterable.contains(<(literal.(type))("5")>));
+        assertTrue(<type>Iterable.contains(<(literal.(type))("1")>));
+        assertTrue(<type>Iterable.contains(<(literal.(type))("3")>));
+        assertTrue(<type>Iterable.contains(<(literal.(type))("4")>));
+        assertFalse(<type>Iterable.contains(<(literal.(type))("5")>));
     }
 
     @Test
     public void containsAllArray()
     {
         <name>Iterable <type>Iterable = Interval.fromTo(4, 1).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>());
-        Assert.assertTrue(<type>Iterable.containsAll(<(literal.(type))("1")>));
-        Assert.assertTrue(<type>Iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>));
-        Assert.assertFalse(<type>Iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>, <(literal.(type))("5")>));
-        Assert.assertFalse(<type>Iterable.containsAll(<(literal.(type))("7")>, <(literal.(type))("6")>, <(literal.(type))("5")>));
+        assertTrue(<type>Iterable.containsAll(<(literal.(type))("1")>));
+        assertTrue(<type>Iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>));
+        assertFalse(<type>Iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>, <(literal.(type))("5")>));
+        assertFalse(<type>Iterable.containsAll(<(literal.(type))("7")>, <(literal.(type))("6")>, <(literal.(type))("5")>));
     }
 
     @Test
     public void containsAllIterable()
     {
         <name>Iterable <type>Iterable = Interval.fromTo(4, 1).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>());
-        Assert.assertTrue(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertTrue(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>)));
-        Assert.assertFalse(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("7")>, <(literal.(type))("6")>, <(literal.(type))("5")>)));
+        assertTrue(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertTrue(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>)));
+        assertFalse(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("4")>, <(literal.(type))("5")>)));
+        assertFalse(<type>Iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("7")>, <(literal.(type))("6")>, <(literal.(type))("5")>)));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("2")>", "<(toStringLiteral.(type))("3")>"), this.<type>Iterable.collect(String::valueOf).toList());
+        assertEquals(FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("2")>", "<(toStringLiteral.(type))("3")>"), this.<type>Iterable.collect(String::valueOf).toList());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.<type>Iterable.makeString());
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.<type>Iterable.makeString("/"));
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.makeString("[", ", ", "]"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.<type>Iterable.makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.<type>Iterable.makeString("/"));
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -306,43 +310,43 @@ public void sumConsistentRounding()
     {
         StringBuilder appendable = new StringBuilder();
         this.<type>Iterable.appendString(appendable);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         this.<type>Iterable.appendString(appendable2, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.<type>Iterable.appendString(appendable3, "[", ", ", "]");
-        Assert.assertEquals(this.<type>Iterable.toString(), appendable3.toString());
+        assertEquals(this.<type>Iterable.toString(), appendable3.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.<type>Iterable.toSet(), this.<type>Iterable.asLazy().toSet());
+        assertEquals(this.<type>Iterable.toSet(), this.<type>Iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, this.<type>Iterable.asLazy());
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
@@ -28,10 +28,12 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This file was automatically generated from template file collectPrimitiveToObjectIterableTest.stg.
@@ -49,7 +51,7 @@ public class Collect<name>ToObjectIterableTest
         InternalIterable\<<wrapperName>\> collect = this.newPrimitiveWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">);
         MutableList\<<wrapperName>\> result = Lists.mutable.of();
         collect.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -62,8 +64,8 @@ public class Collect<name>ToObjectIterableTest
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), elements);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4, 5), indexes);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), elements);
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4, 5), indexes);
     }
 
     @Test
@@ -75,7 +77,7 @@ public class Collect<name>ToObjectIterableTest
         {
             result.add(each);
         }
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -85,13 +87,13 @@ public class Collect<name>ToObjectIterableTest
         MutableList\<<wrapperName>\> result = Lists.mutable.of();
 
         collect.forEachWith((argument1, argument2) -> result.add((<type>) (argument1 + argument2)), 1);
-        Assert.assertEquals(FastList.newListWith(<["2", "3", "4", "5", "6", "6"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["2", "3", "4", "5", "6", "6"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">),
                 this.newPrimitiveWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).selectInstancesOf(<wrapperName>.class).toList());
     }
@@ -101,7 +103,7 @@ public class Collect<name>ToObjectIterableTest
     {
         Verify.assertIterableSize(2, this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertIterableEmpty(this.newPrimitiveWith());
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
@@ -30,10 +30,14 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 /**
  * This file was automatically generated from template file flatCollectPrimitiveToObjectIterableTest.stg.
@@ -51,7 +55,7 @@ public class FlatCollect<name>ToObjectIterableTest
         InternalIterable\<<wrapperName>\> collect = this.newPrimitiveWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">);
         MutableList\<<wrapperName>\> result = Lists.mutable.empty();
         collect.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -64,8 +68,8 @@ public class FlatCollect<name>ToObjectIterableTest
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), elements);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4, 5), indexes);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), elements);
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4, 5), indexes);
     }
 
     @Test
@@ -77,7 +81,7 @@ public class FlatCollect<name>ToObjectIterableTest
         {
             result.add(each);
         }
-        Assert.assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["1", "2", "3", "4", "5", "5"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -87,13 +91,13 @@ public class FlatCollect<name>ToObjectIterableTest
         MutableList\<<wrapperName>\> result = Lists.mutable.of();
 
         collect.forEachWith((argument1, argument2) -> result.add((<type>) (argument1 + argument2)), 1);
-        Assert.assertEquals(FastList.newListWith(<["2", "3", "4", "5", "6", "6"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(FastList.newListWith(<["2", "3", "4", "5", "6", "6"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">),
                 this.newPrimitiveWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).selectInstancesOf(<wrapperName>.class).toList());
     }
@@ -103,7 +107,7 @@ public class FlatCollect<name>ToObjectIterableTest
     {
         Verify.assertIterableSize(2, this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">));
         Verify.assertIterableEmpty(this.newPrimitiveWith());
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
+        assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
     }
 
     @Test
@@ -115,57 +119,57 @@ public class FlatCollect<name>ToObjectIterableTest
     @Test
     public void detect()
     {
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("2")>), this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detect(Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertNull(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detect(Predicates.equal(<(literal.(type))("4")>)));
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("2")>), this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detect(Predicates.equal(<(literal.(type))("2")>)));
+        assertNull(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detect(Predicates.equal(<(literal.(type))("4")>)));
     }
 
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("2")>), this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detectOptional(Predicates.equal(<(literal.(type))("2")>)).get());
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detectOptional(Predicates.equal(<(literal.(type))("4")>)).isPresent());
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("2")>), this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detectOptional(Predicates.equal(<(literal.(type))("2")>)).get());
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).detectOptional(Predicates.equal(<(literal.(type))("4")>)).isPresent());
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfy(Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfy(Predicates.equal(<(literal.(type))("4")>)));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfy(Predicates.equal(<(literal.(type))("2")>)));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfy(Predicates.equal(<(literal.(type))("4")>)));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfyWith(Predicates2.equal(), <(literal.(type))("4")>));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).anySatisfyWith(Predicates2.equal(), <(literal.(type))("4")>));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(Predicates.equal(<(literal.(type))("2")>)));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfy(Predicates.greaterThan(<(literal.(type))("0")>)));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfyWith(Predicates2.greaterThan(), <(literal.(type))("0")>));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).allSatisfyWith(Predicates2.greaterThan(), <(literal.(type))("0")>));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(Predicates.equal(<(literal.(type))("2")>)));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfy(Predicates.lessThan(<(literal.(type))("0")>)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
-        Assert.assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfyWith(Predicates2.lessThan(), <(literal.(type))("0")>));
+        assertFalse(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfyWith(Predicates2.equal(), <(literal.(type))("2")>));
+        assertTrue(this.newPrimitiveWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).noneSatisfyWith(Predicates2.lessThan(), <(literal.(type))("0")>));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/lazyPrimitiveIterableAdapterTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/lazyPrimitiveIterableAdapterTest.stg
@@ -22,8 +22,10 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.primitive.Lazy<name>Iterate;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link Lazy<name>IterableAdapter}.
@@ -54,7 +56,7 @@ public class Lazy<name>IterableAdapterTest extends AbstractLazy<name>IterableTes
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.classUnderTest().toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.classUnderTest().toString());
     }
 
     @Override
@@ -62,9 +64,9 @@ public class Lazy<name>IterableAdapterTest extends AbstractLazy<name>IterableTes
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.classUnderTest().makeString());
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.classUnderTest().makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.classUnderTest().makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.classUnderTest().makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Override
@@ -74,13 +76,13 @@ public class Lazy<name>IterableAdapterTest extends AbstractLazy<name>IterableTes
         super.appendString();
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -88,7 +90,7 @@ public class Lazy<name>IterableAdapterTest extends AbstractLazy<name>IterableTes
     public void toArray()
     {
         super.toArray();
-        Assert.assertArrayEquals(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}, this.classUnderTest().toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}, this.classUnderTest().toArray()<(delta.(type))>);
     }
 
     @Override
@@ -96,7 +98,7 @@ public class Lazy<name>IterableAdapterTest extends AbstractLazy<name>IterableTes
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toList());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
@@ -29,10 +29,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link Select<name>Iterable}.
@@ -51,7 +56,7 @@ public class Select<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, sum<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, sum<(wideDelta.(type))>);
     }
 
     @Test
@@ -59,7 +64,7 @@ public class Select<name>IterableTest
     {
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.iterable.forEach((<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -71,40 +76,40 @@ public class Select<name>IterableTest
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.iterable.notEmpty());
+        assertTrue(this.iterable.notEmpty());
         Verify.assertNotEmpty(this.iterable);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(1L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.iterable.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(this.iterable.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertTrue(this.iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertTrue(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertTrue(this.iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertTrue(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -124,8 +129,8 @@ public class Select<name>IterableTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -137,7 +142,7 @@ public class Select<name>IterableTest
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.iterable.sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.iterable.sum()<(wideDelta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -153,7 +158,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -170,7 +175,7 @@ public void sumConsistentRounding()
                     .toArray());
     Select<name>Iterable iterable = new Select<name>Iterable(list, <name>Predicates.alwaysTrue());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -180,20 +185,20 @@ public void sumConsistentRounding()
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.iterable.max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, this.iterable.max()<(wideDelta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.iterable.min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.iterable.min()<(wideDelta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("1")>, this.iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.iterable.select(<name>Predicates.lessThan(<(literal.(type))("0")>)).minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -201,8 +206,8 @@ public void sumConsistentRounding()
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("2")>, this.iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.iterable.select(<name>Predicates.lessThan(<(literal.(type))("0")>)).maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -225,7 +230,7 @@ public void sumConsistentRounding()
     @Test
     public void average()
     {
-        Assert.assertEquals(1.5d, this.iterable.average(), 0.0);
+        assertEquals(1.5d, this.iterable.average(), 0.0);
     }
 
     @Test
@@ -238,7 +243,7 @@ public void sumConsistentRounding()
     @Test
     public void median()
     {
-        Assert.assertEquals(1.5d, this.iterable.median(), 0.0);
+        assertEquals(1.5d, this.iterable.median(), 0.0);
     }
 
     @Test
@@ -251,80 +256,80 @@ public void sumConsistentRounding()
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new <type>[]{1, 2}, this.iterable.toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{1, 2}, this.iterable.toArray()<(delta.(type))>);
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.iterable.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(this.iterable.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(this.iterable.contains(<(literal.(type))("3")>));
+        assertTrue(this.iterable.contains(<(literal.(type))("1")>));
+        assertTrue(this.iterable.contains(<(literal.(type))("2")>));
+        assertFalse(this.iterable.contains(<(literal.(type))("3")>));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.iterable.containsAll(<["1"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(this.iterable.containsAll(<["2"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(this.iterable.containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(this.iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(this.iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.iterable.containsAll(<["1"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.iterable.containsAll(<["2"]:(literal.(type))(); separator=", ">));
+        assertTrue(this.iterable.containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertFalse(this.iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(this.iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(this.iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(this.iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
+        assertTrue(this.iterable.containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertFalse(this.iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(this.iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{1, 2}, this.iterable.toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{1, 2}, this.iterable.toSortedArray()<(delta.(type))>);
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
+        assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, this.iterable.asLazy());
-        Assert.assertSame(this.iterable, this.iterable.asLazy());
+        assertSame(this.iterable, this.iterable.asLazy());
     }
 
     @Test
     public void injectInto()
     {
         Mutable<wrapperName> result = this.iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("3")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("3")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
@@ -30,10 +30,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link Tap<name>Iterable}.
@@ -54,8 +59,8 @@ public class Tap<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, sum<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, sum<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -66,8 +71,8 @@ public class Tap<name>IterableTest
 
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         iterable.forEach((<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, sum[0]<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -77,7 +82,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Verify.assertSize(5, iterable);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -86,9 +91,9 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.notEmpty());
+        assertTrue(iterable.notEmpty());
         Verify.assertNotEmpty(iterable);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -97,8 +102,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(1L, iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(1L, iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -107,8 +112,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(iterable.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertTrue(iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -117,10 +122,10 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertTrue(iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertFalse(iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -129,10 +134,10 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertTrue(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertFalse(iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
+        assertTrue(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertFalse(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertTrue(iterable.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertFalse(iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("4")>)));
     }
 
     @Test
@@ -161,8 +166,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("4")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -172,7 +177,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Verify.assertIterableSize(5, iterable.collect(String::valueOf));
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -181,8 +186,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, iterable.sum()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, iterable.sum()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -191,8 +196,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("5")>, iterable.max()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("5")>, iterable.max()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -201,8 +206,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("1")>, iterable.min()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("1")>, iterable.min()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -211,8 +216,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("1")>, iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("1")>, iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -221,8 +226,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("5")>, iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("5")>, iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -245,8 +250,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(3.0d, iterable.average(), 0.0);
-        Assert.assertEquals(list.makeString("") + list.makeString(""), builder.toString());
+        assertEquals(3.0d, iterable.average(), 0.0);
+        assertEquals(list.makeString("") + list.makeString(""), builder.toString());
     }
 
     @Test
@@ -262,8 +267,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(3.0d, iterable.median(), 0.0);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(3.0d, iterable.median(), 0.0);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -278,8 +283,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toArray()<(delta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toArray()<(delta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -288,9 +293,9 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(iterable.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(iterable.contains(<(literal.(type))("6")>));
+        assertTrue(iterable.contains(<(literal.(type))("1")>));
+        assertTrue(iterable.contains(<(literal.(type))("2")>));
+        assertFalse(iterable.contains(<(literal.(type))("6")>));
     }
 
     @Test
@@ -299,11 +304,11 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.containsAll(<["1"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsAll(<["2"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<["1"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<["2"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<["1", "2"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
@@ -312,11 +317,11 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["2"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -325,8 +330,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toSortedArray()<(delta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toSortedArray()<(delta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -335,8 +340,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toList());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toList());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -345,8 +350,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSortedList());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSortedList());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -355,8 +360,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSet());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSet());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -365,8 +370,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toBag());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toBag());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -375,9 +380,9 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(iterable.toSet(), iterable.asLazy().toSet());
+        assertEquals(iterable.toSet(), iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
-        Assert.assertSame(iterable, iterable.asLazy());
+        assertSame(iterable, iterable.asLazy());
     }
 
     @Test
@@ -387,7 +392,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("15")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("15")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
@@ -28,10 +28,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link Reverse<name>Iterable}.
@@ -51,26 +55,26 @@ public class Reverse<name>IterableTest
     public void contains()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertFalse(iterable.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(iterable.contains(<(literal.(type))("1")>));
+        assertFalse(iterable.contains(<(literal.(type))("0")>));
+        assertTrue(iterable.contains(<(literal.(type))("1")>));
     }
 
     @Test
     public void containsAllArray()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertTrue(iterable.containsAll(<(literal.(type))("1")>));
-        Assert.assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertFalse(iterable.containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertTrue(iterable.containsAll(<(literal.(type))("1")>));
+        assertTrue(iterable.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertFalse(iterable.containsAll(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void containsAllIterable()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertTrue(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertFalse(iterable.containsAll(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -78,13 +82,13 @@ public class Reverse<name>IterableTest
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
         <name>Iterator iterator = iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -107,7 +111,7 @@ public class Reverse<name>IterableTest
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         iterable.forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -122,35 +126,35 @@ public class Reverse<name>IterableTest
     public void empty()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertTrue(iterable.notEmpty());
+        assertTrue(iterable.notEmpty());
         Verify.assertNotEmpty(iterable);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, <name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().count(<name>Predicates.greaterThan(<zero.(type)>)));
+        assertEquals(2L, <name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().count(<name>Predicates.greaterThan(<zero.(type)>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(<name>ArrayList.newListWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).asReversed().anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(<name>ArrayList.newListWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).asReversed().anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertTrue(<name>ArrayList.newListWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).asReversed().anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(<name>ArrayList.newListWith(<["1", "-1", "2"]:(literal.(type))(); separator=", ">).asReversed().anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(<name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asReversed().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(<name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asReversed().allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(<name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asReversed().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertFalse(<name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asReversed().noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
     }
 
     @Test
@@ -173,8 +177,8 @@ public class Reverse<name>IterableTest
     public void detectIfNone()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -187,7 +191,7 @@ public class Reverse<name>IterableTest
     @Test
     public void max()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().max()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().max()<(wideDelta.(type))>);
     }
 
     @Test
@@ -199,7 +203,7 @@ public class Reverse<name>IterableTest
     @Test
     public void min()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().min()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().min()<(wideDelta.(type))>);
     }
 
     @Test
@@ -211,23 +215,23 @@ public class Reverse<name>IterableTest
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().sum()<(wideDelta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -242,7 +246,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -258,7 +262,7 @@ public void sumConsistentRounding()
             .asReversed()
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -268,45 +272,45 @@ public void sumConsistentRounding()
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().average(), 0.0);
+        assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().average(), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
-        Assert.assertEquals(3.0, <name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
+        assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
+        assertEquals(3.0, <name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<["3", "4", "2", "1"]:(literal.(type))(); separator=", ">}, <name>ArrayList.newListWith(<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">).asReversed().toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["3", "4", "2", "1"]:(literal.(type))(); separator=", ">}, <name>ArrayList.newListWith(<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">).asReversed().toArray()<(delta.(type))>);
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">}, <name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">}, <name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().toSortedArray()<(delta.(type))>);
     }
 
     @Test
     public void testToString()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", iterable.toString());
-        Assert.assertEquals("[]", new <name>ArrayList().asReversed().toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", iterable.toString());
+        assertEquals("[]", new <name>ArrayList().asReversed().toString());
     }
 
     @Test
     public void makeString()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", iterable.makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", <name>ArrayList.newListWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", iterable.makeString("/"));
-        Assert.assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
-        Assert.assertEquals("", new <name>ArrayList().asReversed().makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", iterable.makeString());
+        assertEquals("<(toStringLiteral.(type))("1")>", <name>ArrayList.newListWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", iterable.makeString("/"));
+        assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
+        assertEquals("", new <name>ArrayList().asReversed().makeString());
     }
 
     @Test
@@ -315,46 +319,46 @@ public void sumConsistentRounding()
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
         StringBuilder appendable = new StringBuilder();
         new <name>ArrayList().asReversed().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         iterable.appendString(appendable2);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["2", "1"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">).asReversed().toList());
+        assertEquals(<name>ArrayList.newListWith(<["2", "1"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">).asReversed().toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().asLazy().toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().asLazy().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["2", "3", "1"]:(literal.(type))(); separator=", ">).asReversed().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["2", "3", "1"]:(literal.(type))(); separator=", ">).asReversed().toSortedList());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
@@ -35,7 +35,7 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
 <if(primitive.specializedStream)>
 import java.util.stream.Collectors;
@@ -43,6 +43,11 @@ import java.util.Arrays;
 import java.util.Collections;<endif>
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>List}.
@@ -77,7 +82,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i + 1, list.get(i)<(wideDelta.(type))>);
+            assertEquals(i + 1, list.get(i)<(wideDelta.(type))>);
         }
     }
 
@@ -96,14 +101,14 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
     }
 
     @Test
     public void getLast()
     {
         Immutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(list.size(), list.getLast()<(wideDelta.(type))>);
+        assertEquals(list.size(), list.getLast()<(wideDelta.(type))>);
     }
 
     @Test
@@ -112,14 +117,14 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
+            assertEquals(i, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
         }
-        Assert.assertEquals(-1L, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
+        assertEquals(-1L, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
 
         Immutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
+        assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
     }
 
     @Test
@@ -128,14 +133,14 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
+            assertEquals(i, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
         }
-        Assert.assertEquals(-1L, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
+        assertEquals(-1L, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
 
         Immutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
+        assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
     }
 
     @Override
@@ -145,15 +150,15 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
         for (int i = 0; iterator.hasNext(); i++)
         {
-            Assert.assertEquals(i + 1, iterator.next()<(wideDelta.(type))>);
+            assertEquals(i + 1, iterator.next()<(wideDelta.(type))>);
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void subList()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
     }
 
     @Override
@@ -163,10 +168,10 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         super.toArray();
         Immutable<name>List list = this.classUnderTest();
         <type>[] array = list.toArray();
-        Assert.assertEquals(list.size(), array.length);
+        assertEquals(list.size(), array.length);
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(list.get(i), array[i]<(wideDelta.(type))>);
+            assertEquals(list.get(i), array[i]<(wideDelta.(type))>);
         }
     }
 
@@ -178,7 +183,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
 
         Immutable<name>List iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 
     @Test
@@ -188,7 +193,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>),
                 (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
     }
 
     /**
@@ -200,7 +205,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Immutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -212,7 +217,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -224,7 +229,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Immutable<name>List rejected = list.rejectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -236,7 +241,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List rejected = list.rejectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -247,10 +252,10 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         ImmutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
     }
@@ -263,17 +268,17 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         MutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
 
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Sets.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Sets.mutable.empty()));
     }
@@ -283,18 +288,18 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         Immutable<name>List list1 = this.newWith(<["1", "2", "2", "3", "3", "3", "4", "4", "4", "4"]:(literal.(type))(); separator=", ">).distinct();
         Immutable<name>List list2 = this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(list1, list2);
+        assertEquals(list1, list2);
     }
 
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(Immutable<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>), this.newWith(<(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
+        assertEquals(Immutable<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>), this.newWith(<(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
         Immutable<name>List list1 = this.newWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>);
-        Assert.assertNotSame(list1, list1.toReversed());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>), this.newWith(<(literal.(type))("8")>, <(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
+        assertNotSame(list1, list1.toReversed());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>), this.newWith(<(literal.(type))("8")>, <(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
         Immutable<name>List list2 = this.newWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>);
-        Assert.assertNotSame(list2, list2.toReversed());
+        assertNotSame(list2, list2.toReversed());
     }
 
     @Test
@@ -303,7 +308,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
     }
 
     @Override
@@ -313,7 +318,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         super.testEquals();
         Immutable<name>List list1 = this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
         Immutable<name>List list2 = this.newWith(<["4", "3", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertNotEquals(list1, list2);
+        assertNotEquals(list1, list2);
     }
 
     @Override
@@ -329,7 +334,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
             expectedString.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : ", ");
         }
         expectedString.append(']');
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Override
@@ -348,9 +353,9 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
             expectedString.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : ", ");
             expectedString1.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), list.makeString());
-        Assert.assertEquals(expectedString1.toString(), list.makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals(expectedString.toString(), list.makeString());
+        assertEquals(expectedString1.toString(), list.makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Override
@@ -371,13 +376,13 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         StringBuilder appendable2 = new StringBuilder();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -388,7 +393,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List immutableList = this.classUnderTest();
         Mutable<name>List list = immutableList.toList();
         Verify.assertEqualsAndHashCode(immutableList, list);
-        Assert.assertNotSame(immutableList, list);
+        assertNotSame(immutableList, list);
     }
 
     @Test
@@ -397,43 +402,43 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>List list2 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
         ImmutableList\<<name><name>Pair> zipSame = list1.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSame);
         ImmutableList\<<name><name>Pair> zipSameLazy = list1.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSameLazy);
         ImmutableList\<<name><name>Pair> zipLess = list1.zip<name>(list2);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipLess);
         ImmutableList\<<name><name>Pair> zipLessLazy = list1.zip<name>(list2.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipLessLazy);
         ImmutableList\<<name><name>Pair> zipMore = list2.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipMore);
         ImmutableList\<<name><name>Pair> zipMoreLazy = list2.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipMoreLazy);
         ImmutableList\<<name><name>Pair> zipEmpty1 = list1.zip<name>(this.newWith());
-        Assert.assertTrue(zipEmpty1.isEmpty());
+        assertTrue(zipEmpty1.isEmpty());
         ImmutableList\<<name><name>Pair> zipEmpty2 = this.newWith().zip<name>(list1);
-        Assert.assertTrue(zipEmpty2.isEmpty());
+        assertTrue(zipEmpty2.isEmpty());
     }
 
     @Test
@@ -444,60 +449,60 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         ImmutableList\<String> list3 = Lists.immutable.with("1", "2", "3");
         ImmutableList\<String> list4 = Lists.immutable.with("1");
         ImmutableList\<<name>ObjectPair\<String\>> zipSame = list1.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSame);
         ImmutableList\<<name>ObjectPair\<String\>> zipSameLazy = list1.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSameLazy);
         ImmutableList\<<name>ObjectPair\<String\>> zipLess = list1.zip(list4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipLess);
         ImmutableList\<<name>ObjectPair\<String\>> zipLessLazy = list1.zip(list4.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipLessLazy);
         ImmutableList\<<name>ObjectPair\<String\>> zipMore = list2.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipMore);
         ImmutableList\<<name>ObjectPair\<String\>> zipMoreLazy = list2.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipMoreLazy);
         ImmutableList\<<name>ObjectPair\<String\>> zipEmpty1 = list1.zip(Lists.immutable.empty());
-        Assert.assertTrue(zipEmpty1.isEmpty());
+        assertTrue(zipEmpty1.isEmpty());
         ImmutableList\<<name>ObjectPair\<String\>> zipEmpty2 = this.newWith().zip(Lists.immutable.with("1", "2"));
-        Assert.assertTrue(zipEmpty2.isEmpty());
+        assertTrue(zipEmpty2.isEmpty());
     }
 <if(primitive.specializedStream)>
 
     @Test
     public void stream()
     {
-        Assert.assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void parallelStream()
     {
-        Assert.assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 <endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
@@ -23,10 +23,11 @@ import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>ArrayList}.
@@ -45,7 +46,7 @@ public class Immutable<name>ArrayListTest extends AbstractImmutable<name>ListTes
     public void newCollection()
     {
         super.newCollection();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newList(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newList(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -73,7 +74,7 @@ public class Immutable<name>ArrayListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>ArrayList list1 = Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>ArrayList list2 = Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
     @Test
@@ -88,23 +89,23 @@ public class Immutable<name>ArrayListTest extends AbstractImmutable<name>ListTes
     public void binarySearch()
     {
         Immutable<name>ArrayList list = Immutable<name>ArrayList.newListWith(<["2", "3", "5", "6", "9"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
-        Assert.assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
-        Assert.assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
-        Assert.assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
-        Assert.assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
-        Assert.assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
-        Assert.assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
-        Assert.assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
+        assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
+        assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
+        assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
+        assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
+        assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
+        assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
+        assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
+        assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAll(this.classUnderTest());
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
@@ -26,10 +26,15 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyList}.
@@ -56,9 +61,9 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>Collection emptyCollection = this.classUnderTest();
         Immutable<name>Collection newCollection = emptyCollection.newWithout(<(literal.(type))("9")>);
-        Assert.assertEquals(this.newMutableCollectionWith(), newCollection);
-        Assert.assertSame(emptyCollection, newCollection);
-        Assert.assertEquals(this.newMutableCollectionWith(), emptyCollection);
+        assertEquals(this.newMutableCollectionWith(), newCollection);
+        assertSame(emptyCollection, newCollection);
+        assertEquals(this.newMutableCollectionWith(), emptyCollection);
     }
 
     @Override
@@ -86,7 +91,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -98,7 +103,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         Verify.assertEmpty(iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         <name>Iterable <type>Iterable = iterable.select(<name>Predicates.greaterThan(<(literal.(type))("4")>));
         Verify.assertEmpty(<type>Iterable);
-        Assert.assertSame(iterable, <type>Iterable);
+        assertSame(iterable, <type>Iterable);
     }
 
     @Override
@@ -110,7 +115,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         Verify.assertEmpty(iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         <name>Iterable <type>Iterable = iterable.reject(<name>Predicates.greaterThan(<(literal.(type))("4")>));
         Verify.assertEmpty(<type>Iterable);
-        Assert.assertSame(iterable, <type>Iterable);
+        assertSame(iterable, <type>Iterable);
     }
 
     @Override
@@ -120,8 +125,8 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         Verify.assertEqualsAndHashCode(this.classUnderTest(), this.classUnderTest());
         Verify.assertEqualsAndHashCode(this.newMutableCollectionWith(), this.classUnderTest());
         Verify.assertPostSerializedIdentity(this.newWith());
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(<(literal.(type))("1")>));
+        assertNotEquals(this.classUnderTest(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertNotEquals(this.classUnderTest(), this.newWith(<(literal.(type))("1")>));
     }
 
     @Override
@@ -135,7 +140,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
     }
 
     @Override
@@ -149,7 +154,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
     }
 
     @Override
@@ -171,7 +176,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>EmptyList list1 = new Immutable<name>EmptyList();
         Immutable<name>EmptyList list2 = new Immutable<name>EmptyList();
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
     @Test
@@ -190,7 +195,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
 
         Immutable<name>EmptyList iterable = new Immutable<name>EmptyList();
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 
     @Override
@@ -200,14 +205,14 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         Immutable<name>List list1 = this.newWith();
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(<name>Lists.immutable.of(), this.classUnderTest().toReversed());
+        assertEquals(<name>Lists.immutable.of(), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -217,23 +222,23 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(0, sum[0], <(literal.(type))("0")>);
+        assertEquals(0, sum[0], <(literal.(type))("0")>);
     }
 
     @Test
     public void binarySearch()
     {
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("7")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("100")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("-1")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("7")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("100")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("-1")>));
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = new Immutable<name>EmptyList().toStack();
-        Assert.assertTrue(stack.isEmpty());
+        assertTrue(stack.isEmpty());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
@@ -21,8 +21,10 @@ import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import static org.junit.Assert.assertThrows;
 
@@ -43,7 +45,7 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
     public void testEquals()
     {
         super.testEquals();
-        Assert.assertNotEquals(this.newWith(<(literal.(type))("1")>), this.newWith());
+        assertNotEquals(this.newWith(<(literal.(type))("1")>), this.newWith());
     }
 
     @Test
@@ -51,7 +53,7 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
     {
         Immutable<name>SingletonList list1 = new Immutable<name>SingletonList(<(literal.(type))("3")>);
         Immutable<name>SingletonList list2 = new Immutable<name>SingletonList(<(literal.(type))("3")>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
     @Test
@@ -69,7 +71,7 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
 
         Immutable<name>SingletonList iterable = new Immutable<name>SingletonList(<(literal.(type))("1")>);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("1")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
     }
 
     @Override
@@ -79,14 +81,14 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
         Immutable<name>List list1 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("1")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("1")>), result);
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(<name>Lists.immutable.of(<(literal.(type))("1")>), this.classUnderTest().toReversed());
+        assertEquals(<name>Lists.immutable.of(<(literal.(type))("1")>), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -96,22 +98,22 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(1, sum[0], <(literal.(type))("0")>);
+        assertEquals(1, sum[0], <(literal.(type))("0")>);
     }
 
     @Test
     public void binarySearch()
     {
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
-        Assert.assertEquals(0, this.classUnderTest().binarySearch(<(literal.(type))("1")>));
-        Assert.assertEquals(-2, this.classUnderTest().binarySearch(<(literal.(type))("5")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
+        assertEquals(0, this.classUnderTest().binarySearch(<(literal.(type))("1")>));
+        assertEquals(-2, this.classUnderTest().binarySearch(<(literal.(type))("5")>));
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = this.classUnderTest().toStack();
-        Assert.assertEquals(<name>Stacks.mutable.with(<(literal.(type))("1")>), stack);
+        assertEquals(<name>Stacks.mutable.with(<(literal.(type))("1")>), stack);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -36,12 +36,20 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
 <if(primitive.specializedStream)>
 import java.util.stream.Collectors;
-import java.util.Arrays;<endif>
-
+import java.util.Arrays;
+<endif>
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>List}.
@@ -74,9 +82,9 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void get()
     {
         Mutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, list.get(0)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, list.get(1)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, list.get(2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, list.get(0)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("2")>, list.get(1)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, list.get(2)<(wideDelta.(type))>);
     }
 
     @Test
@@ -85,47 +93,47 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list = this.classUnderTest();
         BoxedMutable<name>List expected = new BoxedMutable<name>List(list);
         MutableList\<<wrapperName>\> actual = list.boxed();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void get_throws_index_greater_than_size()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(3));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(3));
     }
 
     @Test
     public void get_throws_index_negative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(-1));
     }
 
     @Test
     public void getFirst()
     {
         Mutable<name>List singleItemList = this.newWith(<(literal.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, singleItemList.getFirst()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, singleItemList.getFirst()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
     }
 
     @Test
     public void getFirst_emptyList_throws()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getFirst());
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getFirst());
     }
 
     @Test
     public void getLast()
     {
         Mutable<name>List singleItemList = this.newWith(<(literal.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, singleItemList.getLast()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.classUnderTest().getLast()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, singleItemList.getLast()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.classUnderTest().getLast()<(wideDelta.(type))>);
     }
 
     @Test
     public void getLast_emptyList_throws()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getLast());
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getLast());
     }
 
     @Test
@@ -133,7 +141,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
     @Test
@@ -141,25 +149,25 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>List list2 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
+        assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Test
     public void indexOf()
     {
         Mutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
+        assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
     }
 
     @Test
     public void lastIndexOf()
     {
         Mutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
+        assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
     }
 
     @Test
@@ -167,24 +175,24 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List emptyList = this.newWith();
         emptyList.addAtIndex(0, <(literal.(type))("1")>);
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyList);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyList);
         Mutable<name>List arrayList = this.classUnderTest();
         arrayList.addAtIndex(3, <(literal.(type))("4")>);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), arrayList);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), arrayList);
         arrayList.addAtIndex(2, <(literal.(type))("5")>);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "5", "3", "4"]:(literal.(type))(); separator=", ">), arrayList);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "5", "3", "4"]:(literal.(type))(); separator=", ">), arrayList);
     }
 
     @Test
     public void addAtIndex_throws_index_greater_than_size()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().addAtIndex(1, <(literal.(type))("0")>));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().addAtIndex(1, <(literal.(type))("0")>));
     }
 
     @Test
     public void addAtIndex_throws_index_negative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAtIndex(-1, <(literal.(type))("4")>));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAtIndex(-1, <(literal.(type))("4")>));
     }
 
     @Override
@@ -193,11 +201,11 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         super.addAllArray();
         Mutable<name>List list = this.classUnderTest();
-        Assert.assertFalse(list.addAllAtIndex(1));
-        Assert.assertTrue(list.addAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), list);
-        Assert.assertTrue(list.addAllAtIndex(4, <["5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "5", "6"]:(literal.(type))(); separator=", ">), list);
+        assertFalse(list.addAllAtIndex(1));
+        assertTrue(list.addAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), list);
+        assertTrue(list.addAllAtIndex(4, <["5", "6"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "5", "6"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Override
@@ -206,37 +214,37 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         super.addAllIterable();
         Mutable<name>List list = this.classUnderTest();
-        Assert.assertFalse(list.addAllAtIndex(1));
-        Assert.assertTrue(list.addAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertTrue(list.addAll(<name>ArrayStack.newStackWith(<["8", "7"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), list);
-        Assert.assertTrue(list.addAllAtIndex(4, <name>ArrayList.newListWith(<["5", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), list);
+        assertFalse(list.addAllAtIndex(1));
+        assertTrue(list.addAll(<name>ArrayList.newListWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
+        assertTrue(list.addAll(<name>ArrayStack.newStackWith(<["8", "7"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), list);
+        assertTrue(list.addAllAtIndex(4, <name>ArrayList.newListWith(<["5", "6"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Test
     public void addAll_throws_index_negative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void addAll_throws_index_greater_than_size()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void addAllIterable_throws_index_negative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+        assertThrows(IndexOutOfBoundsException.class, () ->
                 this.classUnderTest().addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void addAllIterable_throws_index_greater_than_size()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+        assertThrows(IndexOutOfBoundsException.class, () ->
                 this.classUnderTest().addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -245,19 +253,19 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list = this.classUnderTest();
         list.removeAtIndex(1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), list);
+        assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Test
     public void removeAtIndex_throws_index_greater_than_size()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().removeAtIndex(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().removeAtIndex(1));
     }
 
     @Test
     public void removeAtIndex_throws_index_negative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().removeAtIndex(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().removeAtIndex(-1));
     }
 
     @Test
@@ -265,7 +273,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list = this.classUnderTest();
         list.set(1, <(literal.(type))("4")>);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "4", "3"]:(literal.(type))(); separator=", ">), list);
+        assertEquals(this.newMutableCollectionWith(<["1", "4", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Test
@@ -273,15 +281,15 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list = this.classUnderTest();
         list.swap(1, 2);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
+        assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
         list.swap(1, 1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
+        assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Test
     public void subList()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
     }
 
     @Override
@@ -289,13 +297,13 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void <type>Iterator()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -303,45 +311,45 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void toArray()
     {
         super.toArray();
-        Assert.assertArrayEquals(new <type>[]{<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">).toArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">}, this.newWith(<["1", "2", "4", "3"]:(literal.(type))(); separator=", ">).toArray()<(delta.(type))>);
     }
 
     @Test
     public void reverseThis()
     {
-        Assert.assertEquals(new <name>ArrayList(), this.newWith().reverseThis());
+        assertEquals(new <name>ArrayList(), this.newWith().reverseThis());
         Mutable<name>List emptyList = this.newWith();
-        Assert.assertSame(emptyList, emptyList.reverseThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">), this.newWith(<["3"]:(literal.(type))(); separator=", ">).reverseThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">), this.newWith(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
+        assertSame(emptyList, emptyList.reverseThis());
+        assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">), this.newWith(<["3"]:(literal.(type))(); separator=", ">).reverseThis());
+        assertEquals(<name>ArrayList.newListWith(<["3", "1"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
+        assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">), this.newWith(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
         Mutable<name>List sameList = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(sameList, sameList.reverseThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7", "8"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "7", "9", "1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
+        assertSame(sameList, sameList.reverseThis());
+        assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7", "8"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "7", "9", "1", "3"]:(literal.(type))(); separator=", ">).reverseThis());
 
         Mutable<name>List list1 = <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
         list1.removeAtIndex(3);
-        Assert.assertEquals(list1, <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(list1.reverseThis(), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">));
+        assertEquals(list1, <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(list1.reverseThis(), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void sortThis()
     {
-        Assert.assertEquals(new <name>ArrayList(), this.newWith().sortThis());
+        assertEquals(new <name>ArrayList(), this.newWith().sortThis());
         Mutable<name>List emptyList = this.newWith();
-        Assert.assertSame(emptyList, emptyList.sortThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">), this.newWith(<["3"]:(literal.(type))(); separator=", ">).sortThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["3", "1"]:(literal.(type))(); separator=", ">).sortThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">), this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">).sortThis());
+        assertSame(emptyList, emptyList.sortThis());
+        assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">), this.newWith(<["3"]:(literal.(type))(); separator=", ">).sortThis());
+        assertEquals(<name>ArrayList.newListWith(<["1", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["3", "1"]:(literal.(type))(); separator=", ">).sortThis());
+        assertEquals(<name>ArrayList.newListWith(<["1", "3", "7", "9"]:(literal.(type))(); separator=", ">), this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">).sortThis());
         Mutable<name>List sameList = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(sameList, sameList.sortThis());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "3", "7", "8", "9"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "1", "7", "3", "9"]:(literal.(type))(); separator=", ">).sortThis());
+        assertSame(sameList, sameList.sortThis());
+        assertEquals(<name>ArrayList.newListWith(<["1", "3", "7", "8", "9"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "1", "7", "3", "9"]:(literal.(type))(); separator=", ">).sortThis());
         Mutable<name>List list = this.newWith();
         list.add(<(literal.(type))("2")>);
         list.add(<(literal.(type))("1")>);
         list.sortThis();
-        Assert.assertEquals(<(literal.(type))("1")>, list.get(0)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, list.get(0)<(wideDelta.(type))>);
     }
 
     @Test
@@ -351,7 +359,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
 
         index.sortThis((i1, i2) -> Double.compare(Math.sin(i1), Math.sin(i2)));
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["4", "0", "3", "1", "2"]:(literal.(type))(); separator=", ">), index);
+        assertEquals(<name>ArrayList.newListWith(<["4", "0", "3", "1", "2"]:(literal.(type))(); separator=", ">), index);
     }
 
     @Test
@@ -361,7 +369,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
 
         index.sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1)));
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "2", "4", "6", "8", "1", "3", "5", "7", "9"]:(literal.(type))(); separator=", ">), index);
+        assertEquals(<name>ArrayList.newListWith(<["0", "2", "4", "6", "8", "1", "3", "5", "7", "9"]:(literal.(type))(); separator=", ">), index);
     }
 
     @Test
@@ -372,7 +380,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
 
         index.sortThisBy(i -> list.get((int) i));
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), index);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), index);
     }
 
     @Test
@@ -383,16 +391,16 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
 
         index.sortThisBy(i -> list.get((int) i), Comparators.naturalOrder().reversed());
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), index);
+        assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), index);
     }
 
     @Test
     public void sortShuffledInputWithDupes()
     {
-        Assert.assertEquals(
+        assertEquals(
                 <name>ArrayList.newListWith(<["0", "1", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">),
                 this.newMutableCollectionWith(<["3", "2", "1", "0", "1", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
-        Assert.assertEquals(
+        assertEquals(
                 <name>ArrayList.newListWith(<["1", "2", "2", "2", "3", "4", "6", "7", "8", "10", "11", "12", "13", "14", "15", "15", "15", "17", "18", "19"]:(literal.(type))(); separator=", ">),
                 this.newMutableCollectionWith(<["17", "1", "15", "12", "10", "4", "2", "19", "2", "8", "18", "15", "15", "13", "3", "11", "7", "2", "14", "6"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
     }
@@ -400,15 +408,15 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     @Test
     public void sortShuffledInput()
     {
-        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "2", "1", "0", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+        assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "2", "1", "0", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
 
-        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "0", "1", "2", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+        assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "0", "1", "2", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
 
-        Assert.assertEquals(
+        assertEquals(
                 SORTED_LONGER_LIST,
                 this.newMutableCollectionWith(<["17", "1", "16", "12", "10", "4", "2", "19", "5", "8", "18", "15", "20", "13", "3", "11", "7", "9", "14", "6"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
 
-        Assert.assertEquals(
+        assertEquals(
                 SORTED_LONGER_LIST,
                 this.newMutableCollectionWith(<["12", "3", "17", "20", "5", "2", "4", "9", "16", "19", "10", "14", "6", "7", "15", "11", "13", "18", "8", "1"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
     }
@@ -416,9 +424,9 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     @Test
     public void sortSortedInput()
     {
-        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+        assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
 
-        Assert.assertEquals(
+        assertEquals(
                 SORTED_LONGER_LIST,
                 this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
     }
@@ -426,9 +434,9 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     @Test
     public void sortReversedSortedInput()
     {
-        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["5", "4", "3", "2", "1", "0"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+        assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["5", "4", "3", "2", "1", "0"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
 
-        Assert.assertEquals(
+        assertEquals(
                 SORTED_LONGER_LIST,
                 this.newMutableCollectionWith(<["20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
     }
@@ -443,42 +451,42 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         <name>List shuffleOne = list.shuffleThis().toImmutable();
         <name>List shuffleTwo = list.shuffleThis().toImmutable();
 
-        Assert.assertNotEquals(checkList, shuffleOne);
-        Assert.assertNotEquals(checkList, shuffleTwo);
-        Assert.assertNotEquals(shuffleOne, shuffleTwo);
+        assertNotEquals(checkList, shuffleOne);
+        assertNotEquals(checkList, shuffleTwo);
+        assertNotEquals(shuffleOne, shuffleTwo);
 
-        Assert.assertEquals(checkList, shuffleOne.toSortedList());
-        Assert.assertEquals(checkList, shuffleTwo.toSortedList());
+        assertEquals(checkList, shuffleOne.toSortedList());
+        assertEquals(checkList, shuffleTwo.toSortedList());
     }
 
     @Test
     public void binarySearch()
     {
         Mutable<name>List list = this.newWith(<["2", "3", "5", "6", "9"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
-        Assert.assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
-        Assert.assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
-        Assert.assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
-        Assert.assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
-        Assert.assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
-        Assert.assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
-        Assert.assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
+        assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
+        assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
+        assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
+        assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
+        assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
+        assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
+        assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
+        assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
     }
 
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(new <name>ArrayList(), this.newWith().toReversed());
+        assertEquals(new <name>ArrayList(), this.newWith().toReversed());
         Mutable<name>List emptyList = this.newWith();
-        Assert.assertNotSame(emptyList, emptyList.toReversed());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">), this.newWith(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">).toReversed());
+        assertNotSame(emptyList, emptyList.toReversed());
+        assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">), this.newWith(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">).toReversed());
         Mutable<name>List evenList = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
-        Assert.assertNotSame(evenList, evenList.toReversed());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7", "8"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "7", "9", "1", "3"]:(literal.(type))(); separator=", ">).toReversed());
+        assertNotSame(evenList, evenList.toReversed());
+        assertEquals(<name>ArrayList.newListWith(<["3", "1", "9", "7", "8"]:(literal.(type))(); separator=", ">), this.newWith(<["8", "7", "9", "1", "3"]:(literal.(type))(); separator=", ">).toReversed());
         Mutable<name>List oddList = this.newWith(<["3", "1", "9", "7", "8"]:(literal.(type))(); separator=", ">);
-        Assert.assertNotSame(oddList, oddList.toReversed());
+        assertNotSame(oddList, oddList.toReversed());
     }
 
     @Test
@@ -487,7 +495,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
     }
 
     /**
@@ -504,10 +512,10 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         MutableList\<<name><name>Pair> expected = Lists.mutable.with(
                 PrimitiveTuples.pair(<["3", "7"]:(literal.(type))(); separator=", ">),
                 PrimitiveTuples.pair(<["1", "9"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
 
         Mutable<name>List list3 = this.newWith(<["7", "9", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> list1.forEachInBoth(list3,
                         (one, three) -> result.add(PrimitiveTuples.pair(one, three))));
@@ -522,7 +530,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -534,7 +542,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -546,7 +554,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.rejectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.mutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.mutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -558,7 +566,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.rejectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.mutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.mutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -569,17 +577,17 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         MutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
 
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Sets.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Sets.mutable.empty()));
     }
@@ -592,10 +600,10 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         MutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
     }
@@ -607,7 +615,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         super.testEquals();
         Mutable<name>List list1 = this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
         Mutable<name>List list2 = this.newWith(<["4", "3", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertNotEquals(list1, list2);
+        assertNotEquals(list1, list2);
     }
 
     @Override
@@ -615,7 +623,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.classUnderTest().toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.classUnderTest().toString());
     }
 
     @Test
@@ -623,7 +631,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     {
         Mutable<name>List list1 = this.newWith(<["1", "2", "2", "3", "3", "3", "4", "4", "4", "4"]:(literal.(type))(); separator=", ">).distinct();
         Mutable<name>List list2 = this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(list1, list2);
+        assertEquals(list1, list2);
     }
 
     @Override
@@ -631,9 +639,9 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.classUnderTest().makeString());
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.classUnderTest().makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.classUnderTest().makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.classUnderTest().makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Override
@@ -643,13 +651,13 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         super.appendString();
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -657,14 +665,14 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toList());
     }
 
     @Test
     public void toImmutable()
     {
         Immutable<name>List immutable = this.classUnderTest().toImmutable();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), immutable);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), immutable);
     }
 
     @Override
@@ -675,7 +683,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
 
         <name>ArrayList arrayList = <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = arrayList.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 
     @Test
@@ -686,7 +694,7 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<wrapperName> result = list1.injectIntoWithIndex(
                 new Mutable<wrapperName>(<(literal.(type))("0")>),
                 (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
     }
 
     @Test
@@ -695,45 +703,45 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Mutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>List list2 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         MutableList\<<name><name>Pair> zipSame = list1.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSame);
         MutableList\<<name><name>Pair> zipSameLazy = list1.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSameLazy);
         MutableList\<<name><name>Pair> zipLess = list1.zip<name>(list2);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">)),
                 zipLess);
         MutableList\<<name><name>Pair> zipLessLazy = list1.zip<name>(list2.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">)),
                 zipLessLazy);
         MutableList\<<name><name>Pair> zipMore = list2.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">)),
                 zipMore);
         MutableList\<<name><name>Pair> zipMoreLazy = list2.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">)),
                 zipMoreLazy);
         MutableList\<<name><name>Pair> zipEmpty = list1.zip<name>(this.newWith());
-        Assert.assertTrue(zipEmpty.isEmpty());
+        assertTrue(zipEmpty.isEmpty());
     }
 
     @Test
@@ -744,62 +752,62 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         MutableList\<String> list3 = Lists.mutable.with("1", "2", "3");
         MutableList\<String> list4 = Lists.mutable.with("1", "2");
         MutableList\<<name>ObjectPair\<String\>> zipSame = list1.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSame);
         MutableList\<<name>ObjectPair\<String\>> zipSameLazy = list1.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSameLazy);
         MutableList\<<name>ObjectPair\<String\>> zipLess = list1.zip(list4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2")),
                 zipLess);
         MutableList\<<name>ObjectPair\<String\>> zipLessLazy = list1.zip(list4.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2")),
                 zipLessLazy);
         MutableList\<<name>ObjectPair\<String\>> zipMore = list2.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2")),
                 zipMore);
         MutableList\<<name>ObjectPair\<String\>> zipMoreLazy = list2.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2")),
                 zipMoreLazy);
         MutableList\<<name>ObjectPair\<String\>> zipEmpty = list1.zip(Lists.mutable.empty());
-        Assert.assertTrue(zipEmpty.isEmpty());
+        assertTrue(zipEmpty.isEmpty());
     }
 <if(primitive.specializedStream)>
 
     @Test
     public void stream()
     {
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void parallelStream()
     {
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 <endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
@@ -23,8 +23,10 @@ import java.util.stream.StreamSupport;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link BoxedMutable<name>List}.
@@ -61,27 +63,27 @@ public class BoxedMutable<name>ListTest
         BoxedMutable<name>List list = this.classUnderTest();
         list.add(<(literal.(type))("4")>);
         list.add(<(literal.(type))("7")>);
-        Assert.assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "2", "3", "4", "7"]:(literal.(type))(); separator=", ">)), list);
+        assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "2", "3", "4", "7"]:(literal.(type))(); separator=", ">)), list);
     }
 
     @Test
     public void remove()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, (<type>) this.classUnderTest().remove(1)<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, (<type>) this.classUnderTest().remove(1)<wideDelta.(type)>);
     }
 
     @Test
     public void removeIndexOutOfBounds()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().remove(10));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().remove(10));
     }
 
     @Test
     public void indexOf()
     {
         BoxedMutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(1, list.indexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1, list.indexOf(<(literal.(type))("5")>));
+        assertEquals(1, list.indexOf(<(literal.(type))("2")>));
+        assertEquals(-1, list.indexOf(<(literal.(type))("5")>));
     }
 
     @Test
@@ -89,20 +91,20 @@ public class BoxedMutable<name>ListTest
     {
         BoxedMutable<name>List list = this.classUnderTest();
         list.add(<(literal.(type))("1")>);
-        Assert.assertEquals(3, list.lastIndexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1, list.lastIndexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1, list.indexOf(<(literal.(type))("5")>));
+        assertEquals(3, list.lastIndexOf(<(literal.(type))("1")>));
+        assertEquals(1, list.lastIndexOf(<(literal.(type))("2")>));
+        assertEquals(-1, list.indexOf(<(literal.(type))("5")>));
     }
 
     @Test
     public void set()
     {
         BoxedMutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(<(literal.(type))("2")>, (<type>) list.set(1, <(literal.(type))("5")>)<wideDelta.(type)>);
-        Assert.assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "5", "3"]:(literal.(type))(); separator=", ">)), list);
+        assertEquals(<(literal.(type))("2")>, (<type>) list.set(1, <(literal.(type))("5")>)<wideDelta.(type)>);
+        assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "5", "3"]:(literal.(type))(); separator=", ">)), list);
 
-        Assert.assertEquals(<(literal.(type))("5")>, (<type>) list.set(1, <(literal.(type))("7")>)<wideDelta.(type)>);
-        Assert.assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "7", "3"]:(literal.(type))(); separator=", ">)), list);
+        assertEquals(<(literal.(type))("5")>, (<type>) list.set(1, <(literal.(type))("7")>)<wideDelta.(type)>);
+        assertEquals(new BoxedMutable<name>List(new <name>ArrayList(<["1", "7", "3"]:(literal.(type))(); separator=", ">)), list);
     }
 
     @Test
@@ -110,16 +112,16 @@ public class BoxedMutable<name>ListTest
     {
         <name>ArrayList originalList = new <name>ArrayList(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         BoxedMutable<name>List list = new BoxedMutable<name>List(originalList);
-        Assert.assertEquals(list, Lists.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(list, Lists.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
 
         originalList.add(<(literal.(type))("4")>);
-        Assert.assertEquals(list, Lists.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(list, Lists.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
 
         originalList.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(list, Lists.mutable.of(<["1", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(list, Lists.mutable.of(<["1", "3", "4"]:(literal.(type))(); separator=", ">));
 
         originalList.addAllAtIndex(1, <["7", "8", "9"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(list, Lists.mutable.of(<["1", "7", "8", "9", "3", "4"]:(literal.(type))(); separator=", ">));
+        assertEquals(list, Lists.mutable.of(<["1", "7", "8", "9", "3", "4"]:(literal.(type))(); separator=", ">));
 
         originalList.clear();
         Verify.assertEmpty(list);
@@ -128,21 +130,21 @@ public class BoxedMutable<name>ListTest
     @Test
     public void setIndexOutOfBounds()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().set(5, <(literal.(type))("5")>));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().set(5, <(literal.(type))("5")>));
     }
 
     @Test
     public void get()
     {
         BoxedMutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(<(literal.(type))("1")>, (<type>) list.get(0)<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, (<type>) list.get(1)<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("1")>, (<type>) list.get(0)<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, (<type>) list.get(1)<wideDelta.(type)>);
     }
 
     @Test
     public void getIndexOutOfBounds()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(5));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(5));
     }
 
     @Test
@@ -150,20 +152,20 @@ public class BoxedMutable<name>ListTest
     {
         BoxedMutable<name>List list = this.classUnderTest();
         list.addAll(1, Lists.mutable.of(<(literal.(type))("7")>, <(literal.(type))("9")>));
-        Assert.assertEquals(Lists.mutable.of(<["1", "7", "9", "2", "3"]:(literal.(type))(); separator=", ">), list);
+        assertEquals(Lists.mutable.of(<["1", "7", "9", "2", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
     @Test
     public void addAllIndexOutOfBounds()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+        assertThrows(IndexOutOfBoundsException.class, () ->
                 this.classUnderTest().addAll(5, Lists.mutable.of(<(literal.(type))("7")>, <(literal.(type))("9")>)));
     }
 
     @Test
     public void subList()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(1, 3));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(1, 3));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
@@ -25,8 +25,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.internal.primitive.<name>IterableIterate;
 import org.eclipse.collections.impl.utility.internal.primitive.<name>IteratorIterate;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link <name>ArrayList}.
@@ -55,7 +60,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         Verify.assertEmpty(arrayList);
         Field items = <name>ArrayList.class.getDeclaredField("items");
         items.setAccessible(true);
-        Assert.assertEquals(7L, ((<type>[]) items.get(arrayList)).length);
+        assertEquals(7L, ((<type>[]) items.get(arrayList)).length);
     }
 
     @Test
@@ -63,7 +68,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     {
         <name>ArrayList newList = <name>ArrayList.newWithNValues(5, <(literal.(type))("42")>);
         Verify.assertSize(5, newList);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["42", "42", "42", "42", "42"]:(literal.(type))(); separator=", ">), newList);
+        assertEquals(<name>ArrayList.newListWith(<["42", "42", "42", "42", "42"]:(literal.(type))(); separator=", ">), newList);
 
         <name>ArrayList newList2 = <name>ArrayList.newWithNValues(0, <(literal.(type))("2")>);
         Verify.assertSize(0, newList2);
@@ -72,7 +77,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     @Test
     public void newWithNValues_throws_negative_size()
     {
-        Assert.assertThrows(NegativeArraySizeException.class, () -> <name>ArrayList.newWithNValues(-5, <(literal.(type))("42")>));
+        assertThrows(NegativeArraySizeException.class, () -> <name>ArrayList.newWithNValues(-5, <(literal.(type))("42")>));
     }
 
     @Test
@@ -81,7 +86,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         <type>[] array = {<(literal.(type))("0")>, <(literal.(type))("1")>};
         <name>ArrayList list = <name>ArrayList.wrapCopy(array);
         array[0] = <(literal.(type))("1")>;
-        Assert.assertTrue(list.get(0) \< <(literal.(type))("1")>);
+        assertTrue(list.get(0) \< <(literal.(type))("1")>);
     }
 
     @Test
@@ -91,7 +96,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         listWithCapacity.addAtIndex(3, <(literal.(type))("5")>);
         Field items = <name>ArrayList.class.getDeclaredField("items");
         items.setAccessible(true);
-        Assert.assertEquals(7L, ((<type>[]) items.get(listWithCapacity)).length);
+        assertEquals(7L, ((<type>[]) items.get(listWithCapacity)).length);
     }
 
     @Test
@@ -100,10 +105,10 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         Field items = <name>ArrayList.class.getDeclaredField("items");
         items.setAccessible(true);
         <name>ArrayList arrayList = new <name>ArrayList().with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(10L, ((<type>[]) items.get(arrayList)).length);
-        Assert.assertArrayEquals(new <type>[]{<["1", "2", "3", "0", "0", "0", "0", "0", "0", "0"]:(literal.(type))(); separator=", ">}, (<type>[]) items.get(arrayList)<(delta.(type))>);
+        assertEquals(10L, ((<type>[]) items.get(arrayList)).length);
+        assertArrayEquals(new <type>[]{<["1", "2", "3", "0", "0", "0", "0", "0", "0", "0"]:(literal.(type))(); separator=", ">}, (<type>[]) items.get(arrayList)<(delta.(type))>);
         arrayList.trimToSize();
-        Assert.assertArrayEquals(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}, (<type>[]) items.get(arrayList)<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["1", "2", "3"]:(literal.(type))(); separator=", ">}, (<type>[]) items.get(arrayList)<(delta.(type))>);
     }
 
     @Override
@@ -122,7 +127,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     {
         <name>ArrayList list1 = <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         <name>ArrayList list2 = <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
     @Override
@@ -131,7 +136,7 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     {
         <name>ArrayList list1 = <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         <name>ArrayList list2 = <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
+        assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Override
@@ -145,12 +150,12 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         <name>ArrayList arrayList1 = new <name>ArrayList().with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         <name>ArrayList arrayList2 = new <name>ArrayList().with(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
         <name>ArrayList arrayList3 = new <name>ArrayList().with(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertSame(emptyList, arrayList);
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), arrayList);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), arrayList0);
-        Assert.assertEquals(this.list, arrayList1);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), arrayList2);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), arrayList3);
+        assertSame(emptyList, arrayList);
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), arrayList);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), arrayList0);
+        assertEquals(this.list, arrayList1);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), arrayList2);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), arrayList3);
     }
 
     @Test
@@ -166,17 +171,17 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     {
         super.toImmutable();
         <name>ArrayList list = new <name>ArrayList(1);
-        Assert.assertEquals(list, list.toImmutable());
+        assertEquals(list, list.toImmutable());
         list.add(<(literal.(type))("5")>);
         list.removeAtIndex(0);
-        Assert.assertEquals(list, list.toImmutable());
+        assertEquals(list, list.toImmutable());
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAll(this.classUnderTest());
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/synchronizedPrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/synchronizedPrimitiveListTest.stg
@@ -20,8 +20,10 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>List}.
@@ -48,17 +50,17 @@ public class Synchronized<name>ListTest extends Abstract<name>ListTestCase
         super.asSynchronized();
         Synchronized<name>List list = this.classUnderTest();
         Mutable<name>List listWithLockObject = new Synchronized<name>List(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), new Object());
-        Assert.assertEquals(list, listWithLockObject);
-        Assert.assertSame(listWithLockObject, listWithLockObject.asSynchronized());
-        Assert.assertSame(list, list.asSynchronized());
-        Assert.assertEquals(list, list.asSynchronized());
+        assertEquals(list, listWithLockObject);
+        assertSame(listWithLockObject, listWithLockObject.asSynchronized());
+        assertSame(list, list.asSynchronized());
+        assertEquals(list, list.asSynchronized());
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAll(this.classUnderTest());
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -25,8 +25,13 @@ import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 <if(!primitive.booleanPrimitive)>import org.eclipse.collections.impl.block.factory.Comparators;<endif>
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>List}.
@@ -52,7 +57,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void addAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(0, <(literal.(type))("1")>));
     }
 
@@ -60,42 +65,42 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void addAtIndex_throws_index_greater_than_size()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(1, <(literal.(type))("0")>));
     }
 
     @Test
     public void unmodifiableBoxed()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void addAtIndex_throws_index_negative()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAtIndex(-1, <(literal.(type))("4")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.addAtIndex(-1, <(literal.(type))("4")>));
     }
 
     @Override
     @Test
     public void addAll_throws_index_negative()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void addAll_throws_index_greater_than_size()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void addAllIterable_throws_index_negative()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.list.addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -103,7 +108,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void addAllIterable_throws_index_greater_than_size()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.list.addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -111,14 +116,14 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void removeAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(1));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(1));
     }
 
     @Override
     @Test
     public void removeAtIndex_throws_index_greater_than_size()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).removeAtIndex(1));
     }
 
@@ -126,49 +131,49 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void removeAtIndex_throws_index_negative()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(-1));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(-1));
     }
 
     @Override
     @Test
     public void set()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.set(1, <(literal.(type))("4")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.set(1, <(literal.(type))("4")>));
     }
 
     @Override
     @Test
     public void swap()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.swap(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.swap(0, 1));
     }
 
     @Override
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(this.newMutableCollectionWith()));
     }
 
@@ -176,14 +181,14 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
@@ -191,14 +196,14 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeAll(this.newMutableCollectionWith()));
     }
 
@@ -206,14 +211,14 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().retainAll(this.newMutableCollectionWith()));
     }
 
@@ -221,14 +226,14 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>)));
     }
 
@@ -236,7 +241,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>));
     }
 
@@ -244,7 +249,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
     }
 
@@ -252,7 +257,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void reverseThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).reverseThis());
     }
 
@@ -260,7 +265,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
@@ -268,7 +273,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortWithPrimitiveComparator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis(<wrapperName>::compare));
     }
 
@@ -276,7 +281,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortWithOddEvenComparator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList())
                 .sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1))));
     }
@@ -285,7 +290,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortWithKeyExtractorNaturalComparator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString));
     }
 
@@ -293,7 +298,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortWithKeyExtractorUnnaturalComparator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList())
                 .sortThisBy(<wrapperName>::toString, Comparators.naturalOrder().reversed()));
     }
@@ -302,7 +307,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortShuffledInputWithDupes()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
@@ -310,7 +315,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortShuffledInput()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
@@ -318,7 +323,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortSortedInput()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
@@ -326,7 +331,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void sortReversedSortedInput()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
@@ -334,7 +339,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Test
     public void shuffleThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
             new Unmodifiable<name>List(new <name>ArrayList()).shuffleThis());
     }
 
@@ -343,24 +348,24 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     public void contains()
     {
         Unmodifiable<name>List collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
+            assertTrue(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("-1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("-1")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         Unmodifiable<name>List collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(collection1.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(collection1.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection1.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("3")>));
+        assertTrue(collection1.contains(<(literal.(type))("0")>));
+        assertTrue(collection1.contains(<(literal.(type))("1")>));
+        assertTrue(collection1.contains(<(literal.(type))("2")>));
+        assertFalse(collection1.contains(<(literal.(type))("3")>));
     }
 
     @Override
@@ -373,7 +378,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
         {
             iterator.next();
         }
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -381,8 +386,8 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.list, this.list.asUnmodifiable());
-        Assert.assertEquals(this.list, this.list.asUnmodifiable());
+        assertSame(this.list, this.list.asUnmodifiable());
+        assertEquals(this.list, this.list.asUnmodifiable());
     }
 
     @Override
@@ -391,9 +396,9 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     {
         Unmodifiable<name>List unmodifiable<name>List = this.classUnderTest();
         Mutable<name>Iterator iterator = unmodifiable<name>List.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -402,8 +407,8 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     {
         Unmodifiable<name>List unmodifiable<name>List = this.classUnderTest();
         Mutable<name>Iterator iterator = unmodifiable<name>List.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -417,7 +422,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAll(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
@@ -74,8 +74,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 /**
  * Abstract JUnit test for {@link Object<name>Map#keyValuesView()}.
@@ -115,16 +120,16 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void containsAllIterable()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
-        Assert.assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5)))));
+        assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5)))));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
-        Assert.assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5))));
+        assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5))));
     }
 
     @Test
@@ -149,8 +154,8 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
             result2.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result2);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
+        assertEquals(Bags.immutable.of(0, 0, 0), result2);
     }
 
     @Test
@@ -164,8 +169,8 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes);
     }
 
     @Test
@@ -190,7 +195,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void selectWith_target()
     {
         HashBag\<Object<name>Pair\<Integer>\> result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).selectWith(Predicates2.notEqual(), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), HashBag.\<Object<name>Pair\<Integer>\>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
     }
 
     @Test
@@ -215,7 +220,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void rejectWith_target()
     {
         HashBag\<Object<name>Pair\<Integer>\> result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).rejectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), HashBag.\<Object<name>Pair\<Integer>\>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)), result);
     }
 
     @Test
@@ -232,63 +237,63 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Integer> result1 =
                 this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collect((Object<name>Pair\<Integer> object) -> (int) object.getTwo());
 
-        Assert.assertEquals(FastList.newListWith(2, 3, 4), result1.toList());
+        assertEquals(FastList.newListWith(2, 3, 4), result1.toList());
     }
 
     @Test
     public void collectBoolean()
     {
         BooleanIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectBoolean(pair -> (pair.getTwo() % 2) == 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true, true), result.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true, true), result.toBag());
     }
 
     @Test
     public void collectByte()
     {
         ByteIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectByte(pair -> (byte) pair.getTwo());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 2, (byte) 3, (byte) 4), result.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 2, (byte) 3, (byte) 4), result.toBag());
     }
 
     @Test
     public void collectChar()
     {
         CharIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectChar(pair -> (char) pair.getTwo());
-        Assert.assertEquals(CharHashBag.newBagWith((char) 2, (char) 4, (char) 3), result.toBag());
+        assertEquals(CharHashBag.newBagWith((char) 2, (char) 4, (char) 3), result.toBag());
     }
 
     @Test
     public void collectDouble()
     {
         DoubleIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectDouble(pair -> (double) pair.getTwo());
-        Assert.assertEquals(DoubleHashBag.newBagWith(4.0, 3.0, 2.0), result.toBag());
+        assertEquals(DoubleHashBag.newBagWith(4.0, 3.0, 2.0), result.toBag());
     }
 
     @Test
     public void collectFloat()
     {
         FloatIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectFloat(pair -> (float) pair.getTwo());
-        Assert.assertEquals(FloatHashBag.newBagWith(3.0f, 4.0f, 2.0f), result.toBag());
+        assertEquals(FloatHashBag.newBagWith(3.0f, 4.0f, 2.0f), result.toBag());
     }
 
     @Test
     public void collectInt()
     {
         IntIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectInt(pair -> (int) pair.getTwo());
-        Assert.assertEquals(IntHashBag.newBagWith(2, 4, 3), result.toBag());
+        assertEquals(IntHashBag.newBagWith(2, 4, 3), result.toBag());
     }
 
     @Test
     public void collectLong()
     {
         LongIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectLong(pair -> (long) pair.getTwo());
-        Assert.assertEquals(LongHashBag.newBagWith(4L, 2L, 3L), result.toBag());
+        assertEquals(LongHashBag.newBagWith(4L, 2L, 3L), result.toBag());
     }
 
     @Test
     public void collectShort()
     {
         ShortIterable result = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectShort(pair -> (short) pair.getTwo());
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 2, (short) 4, (short) 3), result.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 2, (short) 4, (short) 3), result.toBag());
     }
 
     @Test
@@ -309,82 +314,82 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detect(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
-        Assert.assertNull(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detect(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertNull(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
     }
 
     @Test
     public void min_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).minBy(pair -> (int) pair.getTwo() & 1));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).minBy(pair -> (int) pair.getTwo() & 1));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).maxBy(pair -> (int) pair.getTwo() & 1));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).maxBy(pair -> (int) pair.getTwo() & 1));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
-        Assert.assertNull(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertNull(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0\<Object<name>Pair\<Integer>\> function = Functions0.value(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectIfNone(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)), function));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))), function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectIfNone(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)), function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))), function));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0\<Object<name>Pair\<Integer>\> function = Functions0.value(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>),
                 function));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("6")>), this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)),
                 function));
@@ -393,59 +398,59 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfy(Object<name>Pair.class::isInstance));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfy(Object<name>Pair.class::isInstance));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfyWith(Predicates2.instanceOf(), Object<name>Pair.class));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfyWith(Predicates2.instanceOf(), Object<name>Pair.class));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).allSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5)))));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfy(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5)))));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
-        Assert.assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5))));
+        assertTrue(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertFalse(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5))));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Boolean.class::isInstance));
-        Assert.assertEquals(3, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Object<name>Pair.class::isInstance));
-        Assert.assertEquals(1, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
+        assertEquals(0, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Boolean.class::isInstance));
+        assertEquals(3, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Object<name>Pair.class::isInstance));
+        assertEquals(1, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).count(Predicates.equal(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>))));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertEquals(3, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Predicates2.instanceOf(), Object<name>Pair.class));
-        Assert.assertEquals(1, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertEquals(0, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Predicates2.instanceOf(), Boolean.class));
+        assertEquals(3, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Predicates2.instanceOf(), Object<name>Pair.class));
+        assertEquals(1, this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).countWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
     }
 
     @Test
@@ -467,7 +472,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(5L, 7L, 9L),
                 this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectWith((Object<name>Pair\<Integer> argument1, Long argument2) -> (long) (argument1.getTwo() + argument1.getTwo() + argument2), 1L).toBag());
     }
@@ -475,7 +480,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(5L, 7L, 9L),
                 this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).collectWith((Object<name>Pair\<Integer> argument1, Long argument2) -> (long) (argument1.getTwo() + argument1.getTwo() + argument2), 1L, HashBag.\<Long>newBag()));
     }
@@ -484,20 +489,20 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void getFirst()
     {
         Object<name>Pair\<Integer> first = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).getFirst();
-        Assert.assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(first)
+        assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(first)
                 || PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>).equals(first)
                 || PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>).equals(first));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>).getFirst());
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>).getFirst());
     }
 
     @Test
     public void getLast()
     {
         Object<name>Pair\<Integer> last = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).getLast();
-        Assert.assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(last)
+        assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(last)
                 || PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>).equals(last)
                 || PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>).equals(last));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>).getLast());
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), this.newWith(1, <(literal.(type))("2")>).getLast());
     }
 
     @Test
@@ -505,7 +510,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(1, <(literal.(type))("2")>));
-        Assert.assertTrue(this.newWith(1, <(literal.(type))("2")>).notEmpty());
+        assertTrue(this.newWith(1, <(literal.(type))("2")>).notEmpty());
     }
 
     @Test
@@ -516,13 +521,13 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Iterator\<Object<name>Pair\<Integer>\> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
 
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -532,11 +537,11 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Iterator\<Object<name>Pair\<Integer>\> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -544,7 +549,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         Long result = objects.injectInto(Long.valueOf(1L), (Long argument1, Object<name>Pair\<Integer> argument2) -> (long) (argument1 + argument2.getTwo() + argument2.getTwo()));
-        Assert.assertEquals(Long.valueOf(19), result);
+        assertEquals(Long.valueOf(19), result);
     }
 
     @Test
@@ -552,7 +557,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         int result = objects.injectInto(1, (int intParameter, Object<name>Pair\<Integer> argument2) -> (int) (intParameter + argument2.getTwo() + argument2.getTwo()));
-        Assert.assertEquals(19, result);
+        assertEquals(19, result);
     }
 
     @Test
@@ -560,7 +565,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         long result = objects.injectInto(1L, (long parameter, Object<name>Pair\<Integer> argument2) -> (long) (parameter + argument2.getTwo() + argument2.getTwo()));
-        Assert.assertEquals(19, result);
+        assertEquals(19, result);
     }
 
     @Test
@@ -568,7 +573,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         double result = objects.injectInto(1.0, (double parameter, Object<name>Pair\<Integer> argument2) -> (double) (parameter + argument2.getTwo() + argument2.getTwo()));
-        Assert.assertEquals(19.0, result, 0.0);
+        assertEquals(19.0, result, 0.0);
     }
 
     @Test
@@ -576,7 +581,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         float result = objects.injectInto(1.0f, (float parameter, Object<name>Pair\<Integer> argument2) -> (float) (parameter + argument2.getTwo() + argument2.getTwo()));
-        Assert.assertEquals(19.0, result, 0.0);
+        assertEquals(19.0, result, 0.0);
     }
 
     @Test
@@ -584,7 +589,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         double actual = objects.sumOfFloat(pair -> (float) (pair.getTwo() + pair.getTwo()));
-        Assert.assertEquals(18.0, actual, 0.0);
+        assertEquals(18.0, actual, 0.0);
     }
 
     @Test
@@ -592,7 +597,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         double actual = objects.sumOfDouble(pair -> (double) (pair.getTwo() + pair.getTwo()));
-        Assert.assertEquals(18.0, actual, 0.0);
+        assertEquals(18.0, actual, 0.0);
     }
 
     @Test
@@ -600,7 +605,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         long actual = objects.sumOfInt(pair -> (int) (pair.getTwo() + pair.getTwo()));
-        Assert.assertEquals(18, actual);
+        assertEquals(18, actual);
     }
 
     @Test
@@ -608,7 +613,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         long actual = objects.sumOfLong(pair -> (long) (pair.getTwo() + pair.getTwo()));
-        Assert.assertEquals(18, actual);
+        assertEquals(18, actual);
     }
 
     @Test
@@ -651,7 +656,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(5, <(literal.(type))("3")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("4")>);
         MutableList\<Object<name>Pair\<Integer>\> list = pairs.toSortedList();
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>)), list);
     }
 
     @Test
@@ -659,7 +664,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(5, <(literal.(type))("3")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("4")>);
         MutableList\<Object<name>Pair\<Integer>\> list = pairs.toSortedList(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)), list);
     }
 
     @Test
@@ -667,7 +672,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(5, <(literal.(type))("3")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("4")>);
         MutableList\<Object<name>Pair\<Integer>\> list = pairs.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("4")>), PrimitiveTuples.pair(Integer.valueOf(5), <(literal.(type))("3")>)), list);
     }
 
     @Test
@@ -736,7 +741,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         MutableMap\<String, String> map =
                 pairs.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
     }
 
     @Test
@@ -745,7 +750,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith("1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith("1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
     }
 
     @Test
@@ -754,7 +759,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(Comparators.reverseNaturalOrder(), String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
     }
 
     @Test
@@ -763,14 +768,14 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> pairs = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMapBy(String::valueOf, String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "1:<(toStringLiteral.(type))("2")>", "1:<(toStringLiteral.(type))("2")>", "2:<(toStringLiteral.(type))("3")>", "2:<(toStringLiteral.(type))("3")>", "3:<(toStringLiteral.(type))("4")>", "3:<(toStringLiteral.(type))("4")>"), map);
     }
 
     @Test
     public void testToString()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>);
-        Assert.assertTrue("[1:<(toStringLiteral.(type))("2")>, 2:<(toStringLiteral.(type))("3")>]".equals(collection.toString())
+        assertTrue("[1:<(toStringLiteral.(type))("2")>, 2:<(toStringLiteral.(type))("3")>]".equals(collection.toString())
                 || "[2:<(toStringLiteral.(type))("3")>, 1:<(toStringLiteral.(type))("2")>]".equals(collection.toString()));
     }
 
@@ -778,21 +783,21 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void makeString()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -801,7 +806,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -810,7 +815,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -819,7 +824,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
@@ -829,10 +834,10 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Function\<Object<name>Pair\<Integer>, Boolean> function = pair -> PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(pair);
 
         Multimap\<Boolean, Object<name>Pair\<Integer>\> multimap = collection.groupBy(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)));
     }
 
     @Test
@@ -842,10 +847,10 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Function\<Object<name>Pair\<Integer>, MutableList\<Boolean>\> function = pair -> Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>).equals(pair));
 
         Multimap\<Boolean, Object<name>Pair\<Integer>\> multimap = collection.groupByEach(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>)));
     }
 
     @Test
@@ -854,7 +859,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>);
         RichIterable\<Pair\<Object<name>Pair\<Integer>, Integer>\> result = collection.zip(Interval.oneTo(5));
 
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 2)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 2)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 2)).equals(result.toBag()));
     }
 
@@ -863,7 +868,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>);
         RichIterable\<Pair\<Object<name>Pair\<Integer>, Integer>\> result = collection.zipWithIndex();
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 1)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 1)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>), 1)).equals(result.toBag()));
     }
 
@@ -871,7 +876,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void chunk()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)),
+        assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), <(literal.(type))("2")>)),
                 FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(2), <(literal.(type))("3")>)),
                 FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(3), <(literal.(type))("4")>))),
                 collection.chunk(1).toBag());
@@ -881,7 +886,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void chunk_zero_throws()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test
@@ -895,8 +900,8 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -916,9 +921,9 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         };
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
         MapIterable\<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(4, aggregation.get("3:<(toStringLiteral.(type))("4")>").intValue());
-        Assert.assertEquals(3, aggregation.get("2:<(toStringLiteral.(type))("3")>").intValue());
-        Assert.assertEquals(2, aggregation.get("1:<(toStringLiteral.(type))("2")>").intValue());
+        assertEquals(4, aggregation.get("3:<(toStringLiteral.(type))("4")>").intValue());
+        assertEquals(3, aggregation.get("2:<(toStringLiteral.(type))("3")>").intValue());
+        assertEquals(2, aggregation.get("1:<(toStringLiteral.(type))("2")>").intValue());
     }
 
     @Test
@@ -928,8 +933,8 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Function2\<Integer, Object<name>Pair\<Integer>, Integer> sumAggregator = (aggregate, pair) -> (int) (aggregate + pair.getTwo());
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>);
         MapIterable\<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("2:<(toStringLiteral.(type))("3")>").intValue());
-        Assert.assertEquals(2, aggregation.get("1:<(toStringLiteral.(type))("2")>").intValue());
+        assertEquals(3, aggregation.get("2:<(toStringLiteral.(type))("3")>").intValue());
+        assertEquals(2, aggregation.get("1:<(toStringLiteral.(type))("2")>").intValue());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeysViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeysViewTestCase.stg
@@ -27,8 +27,12 @@ import org.eclipse.collections.api.map.primitive.Object<name>Map;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Abstract JUnit test for {@link Object<name>Map#keysView()}.
@@ -46,17 +50,17 @@ public abstract class AbstractObject<name>MapKeysViewTestCase extends AbstractLa
         MutableSet\<String> actual = UnifiedSet.newSet();
 
         Iterator\<String> iterator = this.newWithKeysValues("zero", <(literal.(type))("0")>, "thirtyOne", <(literal.(type))("31")>, "thirtyTwo", <(literal.(type))("32")>).keysView().iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
@@ -40,8 +40,15 @@ import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * This file was automatically generated from template file abstractObjectPrimitiveMapTestCase.stg.
@@ -66,8 +73,8 @@ public abstract class AbstractObject<name>MapTestCase
     public void keySet()
     {
         Verify.assertEmpty(this.getEmptyMap().keySet());
-        Assert.assertEquals(UnifiedSet.newSetWith("0"), this.newWithKeysValues("0", <(literal.(type))("0")>).keySet());
-        Assert.assertEquals(UnifiedSet.newSetWith("0", "1", "2"),
+        assertEquals(UnifiedSet.newSetWith("0"), this.newWithKeysValues("0", <(literal.(type))("0")>).keySet());
+        assertEquals(UnifiedSet.newSetWith("0", "1", "2"),
                 this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>).keySet());
     }
 
@@ -78,49 +85,49 @@ public abstract class AbstractObject<name>MapTestCase
 
         Object<name>Map\<String> map = this.newWithKeysValues("0", <(literal.(type))("0")>);
         Verify.assertSize(1, map.values());
-        Assert.assertTrue(map.values().contains(<(literal.(type))("0")>));
+        assertTrue(map.values().contains(<(literal.(type))("0")>));
 
         Object<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>);
         Verify.assertSize(3, map1.values());
-        Assert.assertTrue(map1.values().contains(<(literal.(type))("0")>));
-        Assert.assertTrue(map1.values().contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map1.values().contains(<(literal.(type))("2")>));
+        assertTrue(map1.values().contains(<(literal.(type))("0")>));
+        assertTrue(map1.values().contains(<(literal.(type))("1")>));
+        assertTrue(map1.values().contains(<(literal.(type))("2")>));
     }
 
     @Test
     public void get()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.get("1")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.get("2")<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.get("1")<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.get("2")<delta.(type)>);
     }
 
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.getOrThrow("0")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getOrThrow("1")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.getOrThrow("2")<delta.(type)>);
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
+        assertEquals(<(literal.(type))("0")>, this.map.getOrThrow("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getOrThrow("1")<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.getOrThrow("2")<delta.(type)>);
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey("0"));
-        Assert.assertTrue(this.map.containsKey("1"));
-        Assert.assertTrue(this.map.containsKey("2"));
-        Assert.assertFalse(this.map.containsKey("3"));
-        Assert.assertFalse(this.map.containsKey(null));
+        assertTrue(this.map.containsKey("0"));
+        assertTrue(this.map.containsKey("1"));
+        assertTrue(this.map.containsKey("2"));
+        assertFalse(this.map.containsKey("3"));
+        assertFalse(this.map.containsKey(null));
     }
 
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("0")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("1")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("2")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("0")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("1")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("2")>));
     }
 
     @Test
@@ -140,42 +147,42 @@ public abstract class AbstractObject<name>MapTestCase
     public void isEmpty()
     {
         Verify.assertEmpty(this.getEmptyMap());
-        Assert.assertFalse(this.map.isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(null, <(literal.(type))("1")>).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(1, <(literal.(type))("1")>).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(0, <(literal.(type))("0")>).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(50, <(literal.(type))("50")>).isEmpty());
+        assertFalse(this.map.isEmpty());
+        assertFalse(this.newWithKeysValues(null, <(literal.(type))("1")>).isEmpty());
+        assertFalse(this.newWithKeysValues(1, <(literal.(type))("1")>).isEmpty());
+        assertFalse(this.newWithKeysValues(0, <(literal.(type))("0")>).isEmpty());
+        assertFalse(this.newWithKeysValues(50, <(literal.(type))("50")>).isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyMap().notEmpty());
-        Assert.assertTrue(this.map.notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(1, <(literal.(type))("1")>).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(null, <(literal.(type))("1")>).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(0, <(literal.(type))("0")>).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(50, <(literal.(type))("50")>).notEmpty());
+        assertFalse(this.getEmptyMap().notEmpty());
+        assertTrue(this.map.notEmpty());
+        assertTrue(this.newWithKeysValues(1, <(literal.(type))("1")>).notEmpty());
+        assertTrue(this.newWithKeysValues(null, <(literal.(type))("1")>).notEmpty());
+        assertTrue(this.newWithKeysValues(0, <(literal.(type))("0")>).notEmpty());
+        assertTrue(this.newWithKeysValues(50, <(literal.(type))("50")>).notEmpty());
     }
 
     @Test
     public void asLazy()
     {
         Verify.assertSize(this.map.toList().size(), this.map.asLazy().toList());
-        Assert.assertTrue(this.map.asLazy().toList().containsAll(this.map.toList()));
+        assertTrue(this.map.asLazy().toList().containsAll(this.map.toList()));
     }
 
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
     }
 
     @Test
@@ -189,40 +196,40 @@ public abstract class AbstractObject<name>MapTestCase
 
         Verify.assertEqualsAndHashCode(map1, map2);
         Verify.assertPostSerializedEqualsAndHashCode(map1);
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map1, map7);
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map1, map7);
 
-        Assert.assertEquals(map1, Object<name>Maps.mutable.ofAll(map1));
-        Assert.assertEquals(map1, Object<name>Maps.immutable.ofAll(map1));
+        assertEquals(map1, Object<name>Maps.mutable.ofAll(map1));
+        assertEquals(map1, Object<name>Maps.immutable.ofAll(map1));
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>).hashCode(),
                 this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(50, <(literal.(type))("0")>, null, <(literal.(type))("1")>).hashCode(),
                 this.newWithKeysValues(50, <(literal.(type))("0")>, null, <(literal.(type))("1")>).hashCode());
-        Assert.assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
+        assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.\<Integer>getEmptyMap().toString());
-        Assert.assertEquals("{0=<(toStringLiteral.(type))("0")>}", this.newWithKeysValues(0, <(literal.(type))("0")>).toString());
+        assertEquals("{}", this.\<Integer>getEmptyMap().toString());
+        assertEquals("{0=<(toStringLiteral.(type))("0")>}", this.newWithKeysValues(0, <(literal.(type))("0")>).toString());
 
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
-        Assert.assertTrue(
+        assertTrue(
                 map1.toString(),
                 "{0=<(toStringLiteral.(type))("0")>, 1=<(toStringLiteral.(type))("1")>}".equals(map1.toString())
                         || "{1=<(toStringLiteral.(type))("1")>, 0=<(toStringLiteral.(type))("0")>}".equals(map1.toString()));
 
         Object<name>Map\<Integer> map2 = this.newWithKeysValues(1, <(literal.(type))("1")>, null, <(literal.(type))("0")>);
-        Assert.assertTrue(
+        assertTrue(
                 map2.toString(),
                 "{1=<(toStringLiteral.(type))("1")>, null=<(toStringLiteral.(type))("0")>}".equals(map2.toString())
                         || "{null=<(toStringLiteral.(type))("0")>, 1=<(toStringLiteral.(type))("1")>}".equals(map2.toString()));
@@ -235,17 +242,17 @@ public abstract class AbstractObject<name>MapTestCase
         Mutable<name>Set actual = <name>HashSet.newSetWith();
 
         <name>Iterator iterator = this.map.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(NoSuchElementException.class, () ->
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, () ->
         {
             this.getEmptyMap().<type>Iterator().next();
         });
@@ -260,7 +267,7 @@ public abstract class AbstractObject<name>MapTestCase
         {
             sum01[0] += each;
         });
-        Assert.assertEquals(<(literal.(type))("3")>, sum01[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, sum01[0]<delta.(type)>);
 
         Object<name>Map\<Integer> map = this.newWithKeysValues(3, <(literal.(type))("4")>, 4, <(literal.(type))("5")>);
         <type>[] sum = new <type>[1];
@@ -268,7 +275,7 @@ public abstract class AbstractObject<name>MapTestCase
         {
             sum[0] += each;
         });
-        Assert.assertEquals(<(literal.(type))("9")>, sum[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, sum[0]<delta.(type)>);
 
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(3, <(literal.(type))("4")>, null, <(literal.(type))("5")>);
         <type>[] sum1 = new <type>[1];
@@ -276,7 +283,7 @@ public abstract class AbstractObject<name>MapTestCase
         {
             sum1[0] += each;
         });
-        Assert.assertEquals(<(literal.(type))("9")>, sum1[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, sum1[0]<delta.(type)>);
     }
 
     @Test
@@ -285,12 +292,12 @@ public abstract class AbstractObject<name>MapTestCase
         Object<name>Map\<Integer> map01 = this.newWithKeysValues(0, <(literal.(type))("1")>, 1, <(literal.(type))("2")>);
         <type>[] sum01 = new <type>[1];
         map01.forEachValue((<type> each) -> sum01[0] += each);
-        Assert.assertEquals(<(literal.(type))("3")>, sum01[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, sum01[0]<delta.(type)>);
 
         Object<name>Map\<Integer> map = this.newWithKeysValues(3, <(literal.(type))("4")>, null, <(literal.(type))("5")>);
         <type>[] sum = new <type>[1];
         map.forEachValue((<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(literal.(type))("9")>, sum[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, sum[0]<delta.(type)>);
     }
 
     @Test
@@ -299,13 +306,13 @@ public abstract class AbstractObject<name>MapTestCase
         Object<name>Map\<Integer> map01 = this.newWithKeysValues(0, <(literal.(type))("1")>, 1, <(literal.(type))("2")>);
         int[] sum01 = new int[1];
         map01.forEachKey((Integer each) -> sum01[0] += each);
-        Assert.assertEquals(1, sum01[0]);
+        assertEquals(1, sum01[0]);
 
         Object<name>Map\<Integer> map = this.newWithKeysValues(3, <(literal.(type))("4")>, null, <(literal.(type))("5")>);
         String[] sum = new String[1];
         sum[0] = "";
         map.forEachKey(each -> sum[0] += String.valueOf(each));
-        Assert.assertTrue("3null".equals(sum[0]) || "null3".equals(sum[0]));
+        assertTrue("3null".equals(sum[0]) || "null3".equals(sum[0]));
     }
 
     @Test
@@ -319,8 +326,8 @@ public abstract class AbstractObject<name>MapTestCase
             sumKey01[0] += eachKey;
             sumValue01[0] += eachValue;
         });
-        Assert.assertEquals(1, sumKey01[0]);
-        Assert.assertEquals(<(literal.(type))("3")>, sumValue01[0]<delta.(type)>);
+        assertEquals(1, sumKey01[0]);
+        assertEquals(<(literal.(type))("3")>, sumValue01[0]<delta.(type)>);
 
         Object<name>Map\<Integer> map = this.newWithKeysValues(3, <(literal.(type))("4")>, null, <(literal.(type))("5")>);
         String[] sumKey = new String[1];
@@ -331,8 +338,8 @@ public abstract class AbstractObject<name>MapTestCase
             sumKey[0] += String.valueOf(eachKey);
             sumValue[0] += eachValue;
         });
-        Assert.assertTrue("3null".equals(sumKey[0]) || "null3".equals(sumKey[0]));
-        Assert.assertEquals(<(literal.(type))("9")>, sumValue[0]<delta.(type)>);
+        assertTrue("3null".equals(sumKey[0]) || "null3".equals(sumKey[0]));
+        assertEquals(<(literal.(type))("9")>, sumValue[0]<delta.(type)>);
     }
 
     @Test
@@ -341,27 +348,27 @@ public abstract class AbstractObject<name>MapTestCase
         Object<name>Map\<String> map0 = this.newWithKeysValues("2", <(literal.(type))("3")>, "4", <(literal.(type))("5")>);
 
         String result0 = map0.injectIntoKeyValue(new String("1"), (result, eachKey, eachValue) -> result + eachKey + String.valueOf(eachValue));
-        Assert.assertTrue(result0, "12<(toStringLiteral.(type))("3")>4<(toStringLiteral.(type))("5")>".equals(result0) || "14<(toStringLiteral.(type))("5")>2<(toStringLiteral.(type))("3")>".equals(result0));
+        assertTrue(result0, "12<(toStringLiteral.(type))("3")>4<(toStringLiteral.(type))("5")>".equals(result0) || "14<(toStringLiteral.(type))("5")>2<(toStringLiteral.(type))("3")>".equals(result0));
 
         Object<name>Map copy = map0.injectIntoKeyValue(Object<name>Maps.mutable.empty(), MutableObject<name>Map::withKeyValue);
-        Assert.assertEquals(map0, copy);
+        assertEquals(map0, copy);
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", this.\<String>getEmptyMap().makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>", this.newWithKeysValues(0, <(literal.(type))("0")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWithKeysValues(1, <(literal.(type))("1")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("5")>", this.newWithKeysValues(null, <(literal.(type))("5")>).makeString());
+        assertEquals("", this.\<String>getEmptyMap().makeString());
+        assertEquals("<(toStringLiteral.(type))("0")>", this.newWithKeysValues(0, <(literal.(type))("0")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWithKeysValues(1, <(literal.(type))("1")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("5")>", this.newWithKeysValues(null, <(literal.(type))("5")>).makeString());
 
         Object<name>Map\<Integer> map2 = this.newWithKeysValues(1, <(literal.(type))("1")>, 32, <(literal.(type))("32")>);
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("32")>]".equals(map2.makeString("[", "/", "]"))
                         || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>]".equals(map2.makeString("[", "/", "]")));
 
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("/"),
                 "<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("32")>".equals(map2.makeString("/"))
                         || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>".equals(map2.makeString("/")));
@@ -372,38 +379,38 @@ public abstract class AbstractObject<name>MapTestCase
     {
         Appendable appendable = new StringBuilder();
         this.getEmptyMap().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         Appendable appendable0 = new StringBuilder();
         this.newWithKeysValues(0, <(literal.(type))("0")>).appendString(appendable0);
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>", appendable0.toString());
+        assertEquals("<(toStringLiteral.(type))("0")>", appendable0.toString());
 
         Appendable appendable1 = new StringBuilder();
         this.newWithKeysValues(1, <(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
 
         Appendable appendable2 = new StringBuilder();
         this.newWithKeysValues(null, <(literal.(type))("5")>).appendString(appendable2);
-        Assert.assertEquals("<(toStringLiteral.(type))("5")>", appendable2.toString());
+        assertEquals("<(toStringLiteral.(type))("5")>", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
         map1.appendString(appendable3);
-        Assert.assertTrue(
+        assertTrue(
                 appendable3.toString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("1")>".equals(appendable3.toString())
                         || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(appendable3.toString()));
 
         Appendable appendable4 = new StringBuilder();
         map1.appendString(appendable4, "/");
-        Assert.assertTrue(
+        assertTrue(
                 appendable4.toString(),
                 "<(toStringLiteral.(type))("0")>/<(toStringLiteral.(type))("1")>".equals(appendable4.toString())
                         || "<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>".equals(appendable4.toString()));
 
         Appendable appendable5 = new StringBuilder();
         map1.appendString(appendable5, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable5.toString(),
                 "[<(toStringLiteral.(type))("0")>/<(toStringLiteral.(type))("1")>]".equals(appendable5.toString())
                         || "[<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>]".equals(appendable5.toString()));
@@ -412,36 +419,36 @@ public abstract class AbstractObject<name>MapTestCase
     @Test
     public void select()
     {
-        Assert.assertEquals(this.map, this.map.select((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) == 0));
+        assertEquals(this.map, this.map.select((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) == 0));
 
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>),
+        assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>),
                 this.map.select((String object, <type> value) -> <(lessThan.(type))("Integer.parseInt(object) + value", {<(literal.(type))("4")>})>));
 
-        Assert.assertEquals(this.getEmptyMap(), this.map.select((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) != 0));
+        assertEquals(this.getEmptyMap(), this.map.select((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) != 0));
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>),
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>),
                 this.map.select(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>).toBag());
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>), this.map.select(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>).toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>), this.map.select(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>).toBag());
 
-        Assert.assertEquals(new <name>HashBag(), this.map.select(value -> value > <(literal.(type))("2")>).toBag());
+        assertEquals(new <name>HashBag(), this.map.select(value -> value > <(literal.(type))("2")>).toBag());
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.getEmptyMap(), this.map.reject((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) == 0));
+        assertEquals(this.getEmptyMap(), this.map.reject((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) == 0));
 
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>),
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>),
                 this.map.reject((String object, <type> value) -> <(lessThan.(type))("Integer.parseInt(object) + value", {<(literal.(type))("4")>})>));
 
-        Assert.assertEquals(this.map, this.map.reject((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) != 0));
+        assertEquals(this.map, this.map.reject((String object, <type> value) -> ((Integer.parseInt(object) + value) % 2) != 0));
 
-        Assert.assertEquals(new <name>HashBag(), this.map.reject(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>).toBag());
+        assertEquals(new <name>HashBag(), this.map.reject(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>).toBag());
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("2")>), this.map.reject(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>).toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("2")>), this.map.reject(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>).toBag());
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>),
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>),
                 this.map.reject(value -> value > <(literal.(type))("2")>).toBag());
     }
 
@@ -449,58 +456,58 @@ public abstract class AbstractObject<name>MapTestCase
     public void tap()
     {
         Mutable<name>List tapResult = <name>Lists.mutable.empty();
-        Assert.assertSame(this.map, this.map.tap(tapResult::add));
-        Assert.assertEquals(this.map.toList(), tapResult);
+        assertSame(this.map, this.map.tap(tapResult::add));
+        assertEquals(this.map.toList(), tapResult);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(3L, this.map.count(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
+        assertEquals(3L, this.map.count(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
 
-        Assert.assertEquals(2L, this.map.count(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
+        assertEquals(2L, this.map.count(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
 
-        Assert.assertEquals(0L, this.map.count(value -> value > <(literal.(type))("2")>));
+        assertEquals(0L, this.map.count(value -> value > <(literal.(type))("2")>));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.map.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
+        assertTrue(this.map.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
 
-        Assert.assertTrue(this.map.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
+        assertTrue(this.map.anySatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
 
-        Assert.assertFalse(this.map.anySatisfy(value -> value > <(literal.(type))("2")>));
+        assertFalse(this.map.anySatisfy(value -> value > <(literal.(type))("2")>));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.map.allSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
+        assertTrue(this.map.allSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>));
 
-        Assert.assertFalse(this.map.allSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
+        assertFalse(this.map.allSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
 
-        Assert.assertFalse(this.map.allSatisfy(value -> value > <(literal.(type))("2")>));
+        assertFalse(this.map.allSatisfy(value -> value > <(literal.(type))("2")>));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.map.noneSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("0")>})>));
+        assertTrue(this.map.noneSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("0")>})>));
 
-        Assert.assertFalse(this.map.noneSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
+        assertFalse(this.map.noneSatisfy(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>));
     }
 
     @Test
     public void detectIfNone()
     {
         <type> detect = this.map.detectIfNone(value -> <(lessThan.(type))("value", {<(literal.(type))("3")>})>, <(literal.(type))("5")>);
-        Assert.assertTrue(<(equals.(type))("detect", "0")> || <(equals.(type))("detect", "1")> || <(equals.(type))("detect", "2")>);
+        assertTrue(<(equals.(type))("detect", "0")> || <(equals.(type))("detect", "1")> || <(equals.(type))("detect", "2")>);
 
         <type> detect1 = this.map.detectIfNone(value -> <(lessThan.(type))("value", {<(literal.(type))("2")>})>, <(literal.(type))("5")>);
-        Assert.assertTrue(<(equals.(type))("detect1", "0")> || <(equals.(type))("detect1", "1")>);
+        assertTrue(<(equals.(type))("detect1", "0")> || <(equals.(type))("detect1", "1")>);
 
-        Assert.assertEquals(<(literal.(type))("5")>, this.map.detectIfNone(value -> value > <(literal.(type))("2")>, <(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.map.detectIfNone(value -> value > <(literal.(type))("2")>, <(literal.(type))("5")>)<delta.(type)>);
     }
 
     @Test
@@ -508,155 +515,155 @@ public abstract class AbstractObject<name>MapTestCase
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
-        Assert.assertTrue(map1.collect(toString).toString(), FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("0")>").equals(map1.collect(toString))
+        assertTrue(map1.collect(toString).toString(), FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("0")>").equals(map1.collect(toString))
                 || FastList.newListWith("<(toStringLiteral.(type))("0")>", "<(toStringLiteral.(type))("1")>").equals(map1.collect(toString)));
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.map.sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.map.sum()<wideDelta.(type)>);
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.max()<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.newWithKeysValues(null, <(literal.(type))("3")>, 0, <(literal.(type))("0")>, 2, <(literal.(type))("2")>).max()<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.max()<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.newWithKeysValues(null, <(literal.(type))("3")>, 0, <(literal.(type))("0")>, 2, <(literal.(type))("2")>).max()<delta.(type)>);
     }
 
     @Test
     public void max_throws_emptyList()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().max());
+        assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().max());
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.min()<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.newWithKeysValues(null, <(literal.(type))("0")>, 5, <(literal.(type))("5")>, 1, <(literal.(type))("1")>).min()<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.min()<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.newWithKeysValues(null, <(literal.(type))("0")>, 5, <(literal.(type))("5")>, 1, <(literal.(type))("1")>).min()<delta.(type)>);
     }
 
     @Test
     public void min_throws_emptyList()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().min());
+        assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().min());
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.newWithKeysValues(null, <(literal.(type))("3")>, 0, <(literal.(type))("0")>, 2, <(literal.(type))("2")>).maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, this.getEmptyMap().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.newWithKeysValues(null, <(literal.(type))("3")>, 0, <(literal.(type))("0")>, 2, <(literal.(type))("2")>).maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, this.getEmptyMap().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.newWithKeysValues(null, <(literal.(type))("0")>, 5, <(literal.(type))("5")>, 1, <(literal.(type))("1")>).minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.newWithKeysValues(null, <(literal.(type))("0")>, 5, <(literal.(type))("5")>, 1, <(literal.(type))("1")>).minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(1.0, this.map.average(), 0.0);
+        assertEquals(1.0, this.map.average(), 0.0);
     }
 
     @Test
     public void averageThrowsOnEmpty()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
+        assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(1.0, this.map.median(), 0.0);
-        Assert.assertEquals(1.5, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>).median(), 0.0);
+        assertEquals(1.0, this.map.median(), 0.0);
+        assertEquals(1.5, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>).median(), 0.0);
     }
 
     @Test
     public void medianThrowsOnEmpty()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
+        assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertTrue(Arrays.equals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>}, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toArray())
+        assertTrue(Arrays.equals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>}, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toArray())
                 || Arrays.equals(new <type>[]{<(literal.(type))("1")>, <(literal.(type))("0")>}, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toArray()));
-        Assert.assertArrayEquals(new <type>[]{}, this.getEmptyMap().toArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{}, this.getEmptyMap().toArray()<delta.(type)>);
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("2")>, <(literal.(type))("9")>}, this.newWithKeysValues("9", <(literal.(type))("9")>, "0", <(literal.(type))("0")>, "2", <(literal.(type))("2")>).toSortedArray()<delta.(type)>);
-        Assert.assertArrayEquals(new <type>[]{}, this.getEmptyMap().toSortedArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("2")>, <(literal.(type))("9")>}, this.newWithKeysValues("9", <(literal.(type))("9")>, "0", <(literal.(type))("0")>, "2", <(literal.(type))("2")>).toSortedArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{}, this.getEmptyMap().toSortedArray()<delta.(type)>);
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type))("2")>));
+        assertTrue(this.map.contains(<(literal.(type))("0")>));
+        assertTrue(this.map.contains(<(literal.(type))("1")>));
+        assertTrue(this.map.contains(<(literal.(type))("2")>));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.map.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
-        Assert.assertFalse(this.map.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertTrue(this.map.containsAll());
+        assertTrue(this.map.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
+        assertFalse(this.map.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertTrue(this.map.containsAll());
     }
 
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertTrue(this.map.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
-        Assert.assertFalse(this.map.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertTrue(this.map.containsAll(new <name>ArrayList()));
+        assertTrue(this.map.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
+        assertFalse(this.map.containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertTrue(this.map.containsAll(new <name>ArrayList()));
     }
 
     @Test
     public void toList()
     {
-        Assert.assertTrue(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>).equals(this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toList())
+        assertTrue(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>).equals(this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toList())
                 || <name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("0")>).equals(this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>).toList()));
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().toList());
+        assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("2")>, <(literal.(type))("9")>), this.newWithKeysValues("9", <(literal.(type))("9")>, "0", <(literal.(type))("0")>, "2", <(literal.(type))("2")>).toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("2")>, <(literal.(type))("9")>), this.newWithKeysValues("9", <(literal.(type))("9")>, "0", <(literal.(type))("0")>, "2", <(literal.(type))("2")>).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>), this.map.toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(), this.getEmptyMap().toSet());
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>), this.map.toSet());
+        assertEquals(<name>HashSet.newSetWith(), this.getEmptyMap().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>), this.map.toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(), this.getEmptyMap().toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>), this.map.toBag());
+        assertEquals(<name>HashBag.newBagWith(), this.getEmptyMap().toBag());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(ImmutableObject<name>Map.class, this.classUnderTest().toImmutable());
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
@@ -78,8 +78,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name>BooleanMap#keyValuesView()}.
@@ -119,16 +124,16 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void containsAllIterable()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true))));
-        Assert.assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("1")>, true))));
+        assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true))));
+        assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("1")>, true))));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
-        Assert.assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(1, 5L)));
+        assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(1, 5L)));
     }
 
     @Test
@@ -159,8 +164,8 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
             result2.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result2);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
+        assertEquals(Bags.immutable.of(0, 0, 0), result2);
     }
 
     @Test
@@ -174,8 +179,8 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("0")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("0")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes);
     }
 
     @Test
@@ -200,7 +205,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void selectWith_target()
     {
         HashBag\<<name>BooleanPair> result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).selectWith(Predicates2.notEqual(), PrimitiveTuples.pair(<(literal.(type))("2")>, true), HashBag.\<<name>BooleanPair>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
     }
 
     @Test
@@ -225,7 +230,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void rejectWith_target()
     {
         HashBag\<<name>BooleanPair> result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).rejectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true), HashBag.\<<name>BooleanPair>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), result);
     }
 
     @Test
@@ -241,10 +246,10 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<Integer> result1 =
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collect((<name>BooleanPair object) -> (int) object.getOne());
-        Assert.assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
+        assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
         RichIterable\<Boolean> result2 =
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collect(<name>BooleanPair::getTwo);
-        Assert.assertEquals(Bags.immutable.of(false, true, false), result2.toBag());
+        assertEquals(Bags.immutable.of(false, true, false), result2.toBag());
     }
 
     @Test
@@ -252,56 +257,56 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         BooleanIterable result =
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectBoolean((<name>BooleanPair each) -> (each.getOne() % 2) == 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
     }
 
     @Test
     public void collectByte()
     {
         ByteIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectByte((<name>BooleanPair anObject) -> (byte) anObject.getOne());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
     }
 
     @Test
     public void collectChar()
     {
         CharIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectChar((<name>BooleanPair anObject) -> (char) anObject.getOne());
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
     }
 
     @Test
     public void collectDouble()
     {
         DoubleIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectDouble((<name>BooleanPair anObject) -> (double) anObject.getOne());
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
+        assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
     }
 
     @Test
     public void collectFloat()
     {
         FloatIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectFloat((<name>BooleanPair anObject) -> (float) anObject.getOne());
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
     }
 
     @Test
     public void collectInt()
     {
         IntIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectInt((<name>BooleanPair anObject) -> (int) anObject.getOne());
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
     }
 
     @Test
     public void collectLong()
     {
         LongIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectLong((<name>BooleanPair anObject) -> (long) anObject.getOne());
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
+        assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
     }
 
     @Test
     public void collectShort()
     {
         ShortIterable result = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).collectShort((<name>BooleanPair anObject) -> (short) anObject.getOne());
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
     }
 
     @Test
@@ -322,84 +327,84 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detect(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
-        Assert.assertNull(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detect(PrimitiveTuples.pair(2, 4L)::equals));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detect(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
+        assertNull(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detect(PrimitiveTuples.pair(2, 4L)::equals));
     }
 
     @Test
     public void min_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, false), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true),
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true),
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).minBy((<name>BooleanPair object) -> (int) object.getOne() & 1));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false),
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false),
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("4")>, false).maxBy((<name>BooleanPair object) -> (int) object.getOne() & 1));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
-        Assert.assertNull(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, false)));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertNull(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, false)));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0\<<name>BooleanPair> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type))("5")>, true));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectIfNone(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals, function));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectIfNone(PrimitiveTuples.pair(<(literal.(type))("2")>, false)::equals, function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectIfNone(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals, function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectIfNone(PrimitiveTuples.pair(<(literal.(type))("2")>, false)::equals, function));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0\<<name>BooleanPair> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type))("5")>, true));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(<(literal.(type))("2")>, true),
                 function));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, true), this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(<(literal.(type))("2")>, false),
                 function));
@@ -408,59 +413,59 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfy(<name>BooleanPair.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfy(<name>BooleanPair.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfyWith(Predicates2.instanceOf(), <name>BooleanPair.class));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfyWith(Predicates2.instanceOf(), <name>BooleanPair.class));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfy(PrimitiveTuples.pair(2, 5L)::equals));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfy(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfy(PrimitiveTuples.pair(2, 5L)::equals));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfyWith(Object::equals, PrimitiveTuples.pair(2, 5L)));
+        assertTrue(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertFalse(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).anySatisfyWith(Object::equals, PrimitiveTuples.pair(2, 5L)));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(Boolean.class::isInstance));
-        Assert.assertEquals(3, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(<name>BooleanPair.class::isInstance));
-        Assert.assertEquals(1, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
+        assertEquals(0, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(Boolean.class::isInstance));
+        assertEquals(3, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(<name>BooleanPair.class::isInstance));
+        assertEquals(1, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).count(PrimitiveTuples.pair(<(literal.(type))("2")>, true)::equals));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertEquals(3, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Predicates2.instanceOf(), <name>BooleanPair.class));
-        Assert.assertEquals(1, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertEquals(0, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Predicates2.instanceOf(), Boolean.class));
+        assertEquals(3, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Predicates2.instanceOf(), <name>BooleanPair.class));
+        assertEquals(1, this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
     }
 
     @Test
@@ -482,7 +487,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("<(toStringLiteral.(type))("3")>:false-", "<(toStringLiteral.(type))("2")>:true-", "<(toStringLiteral.(type))("1")>:false-"),
 
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false)
@@ -493,7 +498,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("<(toStringLiteral.(type))("1")>:false-", "<(toStringLiteral.(type))("2")>:true-", "<(toStringLiteral.(type))("3")>:false-"),
                 this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false)
                         .collectWith((<name>BooleanPair argument1, String argument2) -> argument1 + argument2, "-", HashBag.\<String>newBag()));
@@ -503,20 +508,20 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void getFirst()
     {
         <name>BooleanPair first = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).getFirst();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(first)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type))("2")>, true).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type))("3")>, false).equals(first));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false).getFirst());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false).getFirst());
     }
 
     @Test
     public void getLast()
     {
         <name>BooleanPair last = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).getLast();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(last)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type))("2")>, true).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type))("3")>, false).equals(last));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false).getLast());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), this.newWith(<(literal.(type))("1")>, false).getLast());
     }
 
     @Test
@@ -524,7 +529,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(<(literal.(type))("1")>, false));
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, false).notEmpty());
+        assertTrue(this.newWith(<(literal.(type))("1")>, false).notEmpty());
     }
 
     @Test
@@ -535,11 +540,11 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Iterator\<<name>BooleanPair> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -549,11 +554,11 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Iterator\<<name>BooleanPair> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -561,7 +566,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Iterator\<<name>BooleanPair> iterator = objects.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+        assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -569,7 +574,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Long result = objects.injectInto(1L, (Long argument1, <name>BooleanPair argument2) -> (long) (argument1 + argument2.getOne() + (argument2.getTwo() ? 0 : 1)));
-        Assert.assertEquals(Long.valueOf(9), result);
+        assertEquals(Long.valueOf(9), result);
     }
 
     @Test
@@ -577,7 +582,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         int result = objects.injectInto(1, (int intParameter, <name>BooleanPair argument2) -> (int) (intParameter + argument2.getOne() + (argument2.getTwo() ? 0 : 1)));
-        Assert.assertEquals(9, result);
+        assertEquals(9, result);
     }
 
     @Test
@@ -585,7 +590,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         long result = objects.injectInto(1L, (long parameter, <name>BooleanPair argument2) -> (long) (parameter + argument2.getOne() + (argument2.getTwo() ? 0 : 1)));
-        Assert.assertEquals(9, result);
+        assertEquals(9, result);
     }
 
     @Test
@@ -593,7 +598,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         double result = objects.injectInto(1.0, (double parameter, <name>BooleanPair argument2) -> (double) (parameter + argument2.getOne() + (argument2.getTwo() ? 0 : 1)));
-        Assert.assertEquals(9.0, result, 0.0);
+        assertEquals(9.0, result, 0.0);
     }
 
     @Test
@@ -601,7 +606,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         float result = objects.injectInto(1.0f, (float parameter, <name>BooleanPair argument2) -> (float) (parameter + argument2.getOne() + (argument2.getTwo() ? 0 : 1)));
-        Assert.assertEquals(9.0, result, 0.0);
+        assertEquals(9.0, result, 0.0);
     }
 
     @Test
@@ -609,7 +614,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         double actual = objects.sumOfFloat((<name>BooleanPair each) -> (float) (each.getOne() + (each.getTwo() ? 0 : 1)));
-        Assert.assertEquals(8.0, actual, 0.0);
+        assertEquals(8.0, actual, 0.0);
     }
 
     @Test
@@ -617,7 +622,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         double actual = objects.sumOfDouble((<name>BooleanPair each) -> (double) (each.getOne() + (each.getTwo() ? 0 : 1)));
-        Assert.assertEquals(8.0, actual, 0.0);
+        assertEquals(8.0, actual, 0.0);
     }
 
     @Test
@@ -625,7 +630,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         long actual = objects.sumOfInt((<name>BooleanPair each) -> (int) (each.getOne() + (each.getTwo() ? 0 : 1)));
-        Assert.assertEquals(8, actual);
+        assertEquals(8, actual);
     }
 
     @Test
@@ -633,7 +638,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         long actual = objects.sumOfLong((<name>BooleanPair each) -> (long) (each.getOne() + (each.getTwo() ? 0 : 1)));
-        Assert.assertEquals(8, actual);
+        assertEquals(8, actual);
     }
 
     @Test
@@ -687,7 +692,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("2")>, true, <(literal.(type))("1")>, false, <(literal.(type))("3")>, false);
         MutableList\<<name>BooleanPair> list = pairs.toSortedList();
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), list);
     }
 
     @Test
@@ -695,7 +700,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("2")>, true, <(literal.(type))("1")>, false, <(literal.(type))("3")>, false);
         MutableList\<<name>BooleanPair> list = pairs.toSortedList(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("3")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("1")>, false)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("3")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("1")>, false)), list);
     }
 
     @Test
@@ -703,7 +708,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("2")>, true, <(literal.(type))("1")>, false, <(literal.(type))("3")>, false);
         MutableList\<<name>BooleanPair> list = pairs.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false)), list);
     }
 
     @Test
@@ -772,7 +777,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MutableMap\<String, String> map =
                 pairs.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
     }
 
     @Test
@@ -781,7 +786,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
+        assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
     }
 
     @Test
@@ -790,7 +795,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(Comparators.reverseNaturalOrder(), String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
     }
 
     @Test
@@ -799,7 +804,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMapBy(String::valueOf, String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), map);
     }
 
     @Test
@@ -807,14 +812,14 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> pairs = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MutableBiMap\<String, String> biMap = pairs.toBiMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), biMap);
+        assertEquals(HashBiMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("1")>:false", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("2")>:true", "<(toStringLiteral.(type))("3")>:false", "<(toStringLiteral.(type))("3")>:false"), biMap);
     }
 
     @Test
     public void testToString()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
-        Assert.assertTrue("[<(toStringLiteral.(type))("1")>:false, <(toStringLiteral.(type))("2")>:true]".equals(collection.toString())
+        assertTrue("[<(toStringLiteral.(type))("1")>:false, <(toStringLiteral.(type))("2")>:true]".equals(collection.toString())
                 || "[<(toStringLiteral.(type))("2")>:true, <(toStringLiteral.(type))("1")>:false]".equals(collection.toString()));
     }
 
@@ -822,21 +827,21 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void makeString()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -845,7 +850,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -854,7 +859,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -863,7 +868,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
@@ -873,10 +878,10 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Function\<<name>BooleanPair, Boolean> function = (<name>BooleanPair object) -> PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(object);
 
         Multimap\<Boolean, <name>BooleanPair> multimap = collection.groupBy(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, false)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, false)));
     }
 
     @Test
@@ -886,10 +891,10 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Function\<<name>BooleanPair, MutableList\<Boolean>\> function = (<name>BooleanPair object) -> Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, false).equals(object));
 
         Multimap\<Boolean, <name>BooleanPair> multimap = collection.groupByEach(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, false)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, true)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, false)));
     }
 
     @Test
@@ -898,7 +903,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
         RichIterable\<Pair\<<name>BooleanPair, Integer>\> result = collection.zip(Interval.oneTo(5));
 
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 2)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 2)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 2)).equals(result.toBag()));
     }
 
@@ -907,7 +912,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
         RichIterable\<Pair\<<name>BooleanPair, Integer>\> result = collection.zipWithIndex();
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 1)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 1)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, true), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, false), 1)).equals(result.toBag()));
     }
 
@@ -915,7 +920,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void chunk()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false)),
+        assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, false)),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("2")>, true)),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("3")>, false))),
                 collection.chunk(1).toBag());
@@ -925,7 +930,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void chunk_zero_throws()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test
@@ -939,8 +944,8 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -957,9 +962,9 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Procedure2\<AtomicInteger, <name>BooleanPair> sumAggregator = (AtomicInteger aggregate, <name>BooleanPair value) -> aggregate.addAndGet((int) value.getOne());
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         MapIterable\<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("<(toStringLiteral.(type))("3")>:false").intValue());
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:true").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:false").intValue());
+        assertEquals(3, aggregation.get("<(toStringLiteral.(type))("3")>:false").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:true").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:false").intValue());
     }
 
     @Test
@@ -969,8 +974,8 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Function2\<Integer, <name>BooleanPair, Integer> sumAggregator = (Integer aggregate, <name>BooleanPair value) -> (int) (aggregate + value.getOne());
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
         MapIterable\<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:true").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:false").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:true").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:false").intValue());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
@@ -45,8 +45,13 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This file was automatically generated from template file abstractPrimitiveBooleanMapTestCase.stg.
@@ -68,74 +73,74 @@ public abstract class Abstract<name>BooleanMapTestCase
     @Test
     public void get()
     {
-        Assert.assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().get(<(literal.(type))("32")>));
 
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("33")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("33")>));
     }
 
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
     }
 
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("1")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("33")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("1")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("33")>));
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
     }
 
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
-        Assert.assertTrue(this.classUnderTest().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(true));
+        assertTrue(this.classUnderTest().containsValue(false));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(true));
-        Assert.assertTrue(this.classUnderTest().contains(false));
+        assertTrue(this.classUnderTest().contains(true));
+        assertTrue(this.classUnderTest().contains(false));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(true, false));
-        Assert.assertTrue(this.classUnderTest().containsAll(true, true));
-        Assert.assertTrue(this.classUnderTest().containsAll(false, false));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertTrue(this.classUnderTest().containsAll(true, false));
+        assertTrue(this.classUnderTest().containsAll(true, true));
+        assertTrue(this.classUnderTest().containsAll(false, false));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
     }
 
     @Test
@@ -155,20 +160,20 @@ public abstract class Abstract<name>BooleanMapTestCase
     public void isEmpty()
     {
         Verify.assertEmpty(this.getEmptyMap());
-        Assert.assertFalse(this.classUnderTest().isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, true).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("0")>, false).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("50")>, true).isEmpty());
+        assertFalse(this.classUnderTest().isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, true).isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("0")>, false).isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("50")>, true).isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyMap().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, false).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("0")>, true).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("50")>, false).notEmpty());
+        assertFalse(this.getEmptyMap().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, false).notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("0")>, true).notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("50")>, false).notEmpty());
     }
 
     @Test
@@ -188,53 +193,53 @@ public abstract class Abstract<name>BooleanMapTestCase
         Verify.assertPostSerializedEqualsAndHashCode(map8);
         Verify.assertPostSerializedEqualsAndHashCode(map6);
         Verify.assertPostSerializedEqualsAndHashCode(this.getEmptyMap());
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map7, map6);
-        Assert.assertNotEquals(map7, map8);
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map7, map6);
+        assertNotEquals(map7, map8);
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("32")>, true).hashCode(),
                 this.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("0")>, true, <(literal.(type))("1")>, false).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(<(literal.(type))("50")>, true, <(literal.(type))("60")>, false, <(literal.(type))("70")>, false).hashCode(),
                 this.newWithKeysValues(<(literal.(type))("50")>, true, <(literal.(type))("60")>, false, <(literal.(type))("70")>, false).hashCode());
-        Assert.assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
+        assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.getEmptyMap().toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("0")>=true}", this.newWithKeysValues(<(literal.(type))("0")>, true).toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("1")>=false}", this.newWithKeysValues(<(literal.(type))("1")>, false).toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("5")>=false}", this.newWithKeysValues(<(literal.(type))("5")>, false).toString());
+        assertEquals("{}", this.getEmptyMap().toString());
+        assertEquals("{<(toStringLiteral.(type))("0")>=true}", this.newWithKeysValues(<(literal.(type))("0")>, true).toString());
+        assertEquals("{<(toStringLiteral.(type))("1")>=false}", this.newWithKeysValues(<(literal.(type))("1")>, false).toString());
+        assertEquals("{<(toStringLiteral.(type))("5")>=false}", this.newWithKeysValues(<(literal.(type))("5")>, false).toString());
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
-        Assert.assertTrue(
+        assertTrue(
                 map1.toString(),
                 "{<(toStringLiteral.(type))("0")>=true, <(toStringLiteral.(type))("1")>=false}".equals(map1.toString())
                         || "{<(toStringLiteral.(type))("1")>=false, <(toStringLiteral.(type))("0")>=true}".equals(map1.toString()));
 
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
-        Assert.assertTrue(
+        assertTrue(
                 map2.toString(),
                 "{<(toStringLiteral.(type))("1")>=false, <(toStringLiteral.(type))("32")>=true}".equals(map2.toString())
                         || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("1")>=false}".equals(map2.toString()));
 
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true);
-        Assert.assertTrue(
+        assertTrue(
                 map3.toString(),
                 "{<(toStringLiteral.(type))("0")>=true, <(toStringLiteral.(type))("32")>=true}".equals(map3.toString())
                         || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("0")>=true}".equals(map3.toString()));
 
         <name>BooleanMap map4 = this.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false);
-        Assert.assertTrue(
+        assertTrue(
                 map4.toString(),
                 "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("33")>=false}".equals(map4.toString())
                         || "{<(toStringLiteral.(type))("33")>=false, <(toStringLiteral.(type))("32")>=true}".equals(map4.toString()));
@@ -246,22 +251,22 @@ public abstract class Abstract<name>BooleanMapTestCase
         <name>BooleanMap map0 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("3")>, true);
         String[] sum0 = {""};
         map0.forEach((boolean each) -> sum0[0] += each);
-        Assert.assertTrue("truefalse".equals(sum0[0]) || "falsetrue".equals(sum0[0]));
+        assertTrue("truefalse".equals(sum0[0]) || "falsetrue".equals(sum0[0]));
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("3")>, true);
         String[] sum1 = {""};
         map1.forEach((boolean each) -> sum1[0] += each);
-        Assert.assertEquals("truetrue", sum1[0]);
+        assertEquals("truetrue", sum1[0]);
 
         <name>BooleanMap map01 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true);
         String[] sum01 = {""};
         map01.forEach((boolean each) -> sum01[0] += each);
-        Assert.assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
+        assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
 
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("3")>, false, <(literal.(type))("4")>, false);
         String[] sum = {""};
         map.forEach((boolean each) -> sum[0] += each);
-        Assert.assertEquals("falsefalse", sum[0]);
+        assertEquals("falsefalse", sum[0]);
     }
 
     @Test
@@ -270,22 +275,22 @@ public abstract class Abstract<name>BooleanMapTestCase
         <name>BooleanMap map0 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("3")>, true);
         String[] sum0 = {""};
         map0.forEachValue((boolean each) -> sum0[0] += each);
-        Assert.assertTrue("truefalse".equals(sum0[0]) || "falsetrue".equals(sum0[0]));
+        assertTrue("truefalse".equals(sum0[0]) || "falsetrue".equals(sum0[0]));
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("3")>, true);
         String[] sum1 = {""};
         map1.forEachValue((boolean each) -> sum1[0] += each);
-        Assert.assertEquals("truetrue", sum1[0]);
+        assertEquals("truetrue", sum1[0]);
 
         <name>BooleanMap map01 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true);
         String[] sum01 = {""};
         map01.forEachValue((boolean each) -> sum01[0] += each);
-        Assert.assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
+        assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
 
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("3")>, false, <(literal.(type))("4")>, false);
         String[] sum = {""};
         map.forEachValue((boolean each) -> sum[0] += each);
-        Assert.assertEquals("falsefalse", sum[0]);
+        assertEquals("falsefalse", sum[0]);
     }
 
     @Test
@@ -294,22 +299,22 @@ public abstract class Abstract<name>BooleanMapTestCase
         <name>BooleanMap map0 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("3")>, false);
         <type>[] sum0 = new <type>[1];
         map0.forEachKey((<type> each) -> sum0[0] += each);
-        Assert.assertEquals(<(literal.(type))("3")>, sum0[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, sum0[0]<delta.(type)>);
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("3")>, false);
         <type>[] sum1 = new <type>[1];
         map1.forEachKey((<type> each) -> sum1[0] += each);
-        Assert.assertEquals(<(literal.(type))("4")>, sum1[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("4")>, sum1[0]<delta.(type)>);
 
         <name>BooleanMap map01 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true);
         <type>[] sum01 = new <type>[1];
         map01.forEachKey((<type> each) -> sum01[0] += each);
-        Assert.assertEquals(<(literal.(type))("1")>, sum01[0]<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, sum01[0]<delta.(type)>);
 
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("3")>, false, <(literal.(type))("4")>, true);
         <type>[] sum = new <type>[1];
         map.forEachKey((<type> each) -> sum[0] += each);
-        Assert.assertEquals(7, sum[0]<delta.(type)>);
+        assertEquals(7, sum[0]<delta.(type)>);
     }
 
     @Test
@@ -323,8 +328,8 @@ public abstract class Abstract<name>BooleanMapTestCase
             sumKey0[0] += eachKey;
             sumValue0[0] += eachValue;
         });
-        Assert.assertEquals(<(literal.(type))("3")>, sumKey0[0]<delta.(type)>);
-        Assert.assertEquals("truetrue", sumValue0[0]);
+        assertEquals(<(literal.(type))("3")>, sumKey0[0]<delta.(type)>);
+        assertEquals("truetrue", sumValue0[0]);
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("3")>, false);
         <type>[] sumKey1 = new <type>[1];
@@ -334,8 +339,8 @@ public abstract class Abstract<name>BooleanMapTestCase
             sumKey1[0] += eachKey;
             sumValue1[0] += eachValue;
         });
-        Assert.assertEquals(<(literal.(type))("4")>, sumKey1[0]<delta.(type)>);
-        Assert.assertTrue("truefalse".equals(sumValue1[0]) || "falsetrue".equals(sumValue1[0]));
+        assertEquals(<(literal.(type))("4")>, sumKey1[0]<delta.(type)>);
+        assertTrue("truefalse".equals(sumValue1[0]) || "falsetrue".equals(sumValue1[0]));
 
         <name>BooleanMap map01 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, false);
         <type>[] sumKey01 = new <type>[1];
@@ -345,8 +350,8 @@ public abstract class Abstract<name>BooleanMapTestCase
             sumKey01[0] += eachKey;
             sumValue01[0] += eachValue;
         });
-        Assert.assertEquals(<(literal.(type))("1")>, sumKey01[0]<delta.(type)>);
-        Assert.assertEquals("falsefalse", sumValue01[0]);
+        assertEquals(<(literal.(type))("1")>, sumKey01[0]<delta.(type)>);
+        assertEquals("falsefalse", sumValue01[0]);
 
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("3")>, false, <(literal.(type))("4")>, true);
         <type>[] sumKey = new <type>[1];
@@ -356,38 +361,38 @@ public abstract class Abstract<name>BooleanMapTestCase
             sumKey[0] += eachKey;
             sumValue[0] += eachValue;
         });
-        Assert.assertEquals(7, sumKey[0]<delta.(type)>);
-        Assert.assertTrue("truefalse".equals(sumValue[0]) || "falsetrue".equals(sumValue[0]));
+        assertEquals(7, sumKey[0]<delta.(type)>);
+        assertTrue("truefalse".equals(sumValue[0]) || "falsetrue".equals(sumValue[0]));
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", this.getEmptyMap().makeString());
-        Assert.assertEquals("true", this.newWithKeysValues(<(literal.(type))("0")>, true).makeString());
-        Assert.assertEquals("false", this.newWithKeysValues(<(literal.(type))("1")>, false).makeString());
-        Assert.assertEquals("false", this.newWithKeysValues(<(literal.(type))("5")>, false).makeString());
+        assertEquals("", this.getEmptyMap().makeString());
+        assertEquals("true", this.newWithKeysValues(<(literal.(type))("0")>, true).makeString());
+        assertEquals("false", this.newWithKeysValues(<(literal.(type))("1")>, false).makeString());
+        assertEquals("false", this.newWithKeysValues(<(literal.(type))("5")>, false).makeString());
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
-        Assert.assertTrue(
+        assertTrue(
                 map1.makeString(),
                 "true, false".equals(map1.makeString())
                         || "false, true".equals(map1.makeString()));
 
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("[", "/", "]"),
                 "[false/true]".equals(map2.makeString("[", "/", "]"))
                         || "true/false]".equals(map2.makeString("[", "/", "]")));
 
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true);
-        Assert.assertTrue(
+        assertTrue(
                 map3.makeString("~"),
                 "true~true".equals(map3.makeString("~"))
                         || "true~true".equals(map3.makeString("~")));
 
         <name>BooleanMap map4 = this.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false);
-        Assert.assertTrue(
+        assertTrue(
                 map4.makeString("[", ", ", "]"),
                 "[true, false]".equals(map4.makeString("[", ", ", "]"))
                         || "[false, true]".equals(map4.makeString("[", ", ", "]")));
@@ -398,24 +403,24 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         Appendable appendable = new StringBuilder();
         this.getEmptyMap().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         Appendable appendable0 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("0")>, true).appendString(appendable0);
-        Assert.assertEquals("true", appendable0.toString());
+        assertEquals("true", appendable0.toString());
 
         Appendable appendable1 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("1")>, false).appendString(appendable1);
-        Assert.assertEquals("false", appendable1.toString());
+        assertEquals("false", appendable1.toString());
 
         Appendable appendable2 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("5")>, false).appendString(appendable2);
-        Assert.assertEquals("false", appendable2.toString());
+        assertEquals("false", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
         map1.appendString(appendable3);
-        Assert.assertTrue(
+        assertTrue(
                 appendable3.toString(),
                 "true, false".equals(appendable3.toString())
                         || "false, true".equals(appendable3.toString()));
@@ -423,7 +428,7 @@ public abstract class Abstract<name>BooleanMapTestCase
         Appendable appendable4 = new StringBuilder();
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         map2.appendString(appendable4, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable4.toString(),
                 "[false/true]".equals(appendable4.toString())
                         || "[true/false]".equals(appendable4.toString()));
@@ -431,14 +436,14 @@ public abstract class Abstract<name>BooleanMapTestCase
         Appendable appendable5 = new StringBuilder();
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         map3.appendString(appendable5, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable5.toString(),
                 "[false/true]".equals(appendable5.toString())
                         || "[true/false]".equals(appendable5.toString()));
 
         Appendable appendable6 = new StringBuilder();
         map1.appendString(appendable6, "/");
-        Assert.assertTrue(
+        assertTrue(
                 appendable6.toString(),
                 "true/false".equals(appendable6.toString())
                         || "false/true".equals(appendable6.toString()));
@@ -449,9 +454,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true);
         <name>BooleanMap actual1 = map.select((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("1")>})> || value);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("3")>, true, <(literal.(type))("0")>, true), actual1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("3")>, true, <(literal.(type))("0")>, true), actual1);
         <name>BooleanMap actual2 = map.select((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("0")>})> || !value);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("2")>, false, <(literal.(type))("1")>, false), actual2);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("2")>, false, <(literal.(type))("1")>, false), actual2);
     }
 
     @Test
@@ -459,9 +464,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true);
         <name>BooleanMap actual1 = map.reject((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("2")>})> || !value);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("3")>, true), actual1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("3")>, true), actual1);
         <name>BooleanMap actual2 = map.reject((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("3")>})> || value);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, false), actual2);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, false), actual2);
     }
 
     @Test
@@ -469,9 +474,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         BooleanIterable actual1 = map.select(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanBags.immutable.with(true, true), actual1);
+        assertEquals(BooleanBags.immutable.with(true, true), actual1);
         BooleanIterable actual2 = map.select(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanBags.immutable.with(false, false), actual2);
+        assertEquals(BooleanBags.immutable.with(false, false), actual2);
     }
 
     @Test
@@ -479,9 +484,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         BooleanIterable actual1 = map.reject(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanBags.immutable.with(false, false), actual1);
+        assertEquals(BooleanBags.immutable.with(false, false), actual1);
         BooleanIterable actual2 = map.reject(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanBags.immutable.with(true, true), actual2);
+        assertEquals(BooleanBags.immutable.with(true, true), actual2);
     }
 
     @Test
@@ -491,15 +496,15 @@ public abstract class Abstract<name>BooleanMapTestCase
 
         RichIterable\<Boolean> objects = map.collect((boolean booleanParameter) -> !booleanParameter);
 
-        Assert.assertEquals(HashBag.newBagWith(false, true, false), objects.toBag());
+        assertEquals(HashBag.newBagWith(false, true, false), objects.toBag());
     }
 
     @Test
     public void count()
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
-        Assert.assertEquals(2, map.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(1, map.count(BooleanPredicates.isFalse()));
+        assertEquals(2, map.count(BooleanPredicates.isTrue()));
+        assertEquals(1, map.count(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -508,62 +513,62 @@ public abstract class Abstract<name>BooleanMapTestCase
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false);
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         boolean resultNotFound = map.detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true);
-        Assert.assertTrue(resultNotFound);
+        assertTrue(resultNotFound);
         boolean resultNotFound2 = map.detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false);
-        Assert.assertFalse(resultNotFound2);
+        assertFalse(resultNotFound2);
 
-        Assert.assertTrue(map.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(map.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(map2.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertTrue(map.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(map.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(map2.detectIfNone(BooleanPredicates.isFalse(), true));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true).anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true).anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false).allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false).allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true).noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true).noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.newWithKeysValues(<(literal.(type))("0")>, true).toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(false), this.newWithKeysValues(<(literal.(type))("1")>, false).toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.newWithKeysValues(<(literal.(type))("2")>, true).toList());
+        assertEquals(BooleanArrayList.newListWith(true), this.newWithKeysValues(<(literal.(type))("0")>, true).toList());
+        assertEquals(BooleanArrayList.newListWith(false), this.newWithKeysValues(<(literal.(type))("1")>, false).toList());
+        assertEquals(BooleanArrayList.newListWith(true), this.newWithKeysValues(<(literal.(type))("2")>, true).toList());
     }
 
     @Test
     public void toSet()
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), map.toSet());
+        assertEquals(BooleanHashSet.newSetWith(true, false), map.toSet());
     }
 
     @Test
     public void toBag()
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false), map.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false), map.toBag());
     }
 
     @Test
@@ -573,17 +578,17 @@ public abstract class Abstract<name>BooleanMapTestCase
         MutableBooleanBag actual = BooleanHashBag.newBagWith();
 
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().booleanIterator().next());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().booleanIterator().next());
     }
 
     @Test
@@ -591,14 +596,14 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         LazyBooleanIterable lazy = map.asLazy();
-        Assert.assertTrue(lazy.toList().containsAll(true, true, false));
+        assertTrue(lazy.toList().containsAll(true, true, false));
     }
 
     @Test
     public void keysView()
     {
         Mutable<name>List keys = this.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false).keysView().toSortedList();
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>), keys);
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>), keys);
     }
 
     @Test
@@ -606,7 +611,7 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         MutableBag\<<name>BooleanPair> expected = Bags.mutable.of();
         this.classUnderTest().forEachKeyValue((<type> key, boolean value) -> expected.add(PrimitiveTuples.pair(key, value)));
-        Assert.assertEquals(expected, this.classUnderTest().keyValuesView().toBag());
+        assertEquals(expected, this.classUnderTest().keyValuesView().toBag());
     }
 
     @Test
@@ -614,14 +619,14 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
         boolean[] array = map.toArray();
-        Assert.assertTrue(Arrays.equals(new boolean[]{false, true}, array)
+        assertTrue(Arrays.equals(new boolean[]{false, true}, array)
                 || Arrays.equals(new boolean[]{true, false}, array));
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(Immutable<name>BooleanMap.class, this.classUnderTest().toImmutable());
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
@@ -76,8 +76,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name>ObjectMap#keyValuesView()}.
@@ -117,16 +122,16 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void containsAllIterable()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
-        Assert.assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5)))));
+        assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5)))));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
-        Assert.assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5))));
+        assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(5))));
     }
 
     @Test
@@ -157,8 +162,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
             result2.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result2);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
+        assertEquals(Bags.immutable.of(0, 0, 0), result2);
 
         MutableBag\<<name>ObjectPair\<Integer>\> result3 = Bags.mutable.of();
         MutableBag\<Integer> result4 = Bags.mutable.of();
@@ -169,8 +174,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
             result4.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("4")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result3);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result4);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("4")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result3);
+        assertEquals(Bags.immutable.of(0, 0, 0), result4);
     }
 
     @Test
@@ -184,8 +189,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("0")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("0")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes);
 
         MutableBag\<<name>ObjectPair\<Integer>\> elements2 = Bags.mutable.of();
         MutableBag\<Integer> indexes2 = Bags.mutable.of();
@@ -195,8 +200,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
             elements2.add(object);
             indexes2.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), elements2);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes2);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), elements2);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes2);
     }
 
     @Test
@@ -221,7 +226,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void selectWith_target()
     {
         HashBag\<<name>ObjectPair\<Integer>\> result = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).selectWith(Predicates2.notEqual(), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), HashBag.\<<name>ObjectPair\<Integer>\>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
     }
 
     @Test
@@ -246,7 +251,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void rejectWith_target()
     {
         HashBag\<<name>ObjectPair\<Integer>\> result = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).rejectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), HashBag.\<<name>ObjectPair\<Integer>\>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), result);
     }
 
     @Test
@@ -263,9 +268,9 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
 
         RichIterable\<Integer> result1 = pairs.collect((<name>ObjectPair\<Integer> object) -> (int) object.getOne());
-        Assert.assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
+        assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
         RichIterable\<Integer> result2 = pairs.collect(<name>ObjectPair::getTwo);
-        Assert.assertEquals(Bags.immutable.of(2, 3, 4), result2.toBag());
+        assertEquals(Bags.immutable.of(2, 3, 4), result2.toBag());
     }
 
     @Test
@@ -273,7 +278,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         BooleanIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectBoolean((<name>ObjectPair\<Integer> each) -> (each.getOne() % 2) == 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
     }
 
     @Test
@@ -281,7 +286,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         ByteIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectByte((<name>ObjectPair\<Integer> anObject) -> (byte) anObject.getOne());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
     }
 
     @Test
@@ -289,7 +294,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         CharIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectChar((<name>ObjectPair\<Integer> anObject) -> (char) anObject.getOne());
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
     }
 
     @Test
@@ -297,7 +302,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         DoubleIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectDouble((<name>ObjectPair\<Integer> anObject) -> (double) anObject.getOne());
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
+        assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
     }
 
     @Test
@@ -305,7 +310,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         FloatIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectFloat((<name>ObjectPair\<Integer> anObject) -> (float) anObject.getOne());
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
     }
 
     @Test
@@ -313,7 +318,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         IntIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectInt((<name>ObjectPair\<Integer> anObject) -> (int) anObject.getOne());
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
     }
 
     @Test
@@ -321,7 +326,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         LongIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectLong((<name>ObjectPair\<Integer> anObject) -> (long) anObject.getOne());
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
+        assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
     }
 
     @Test
@@ -329,7 +334,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         ShortIterable result =
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).collectShort((<name>ObjectPair\<Integer> anObject) -> (short) anObject.getOne());
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
     }
 
     @Test
@@ -350,50 +355,50 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
-        Assert.assertNull(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertNull(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
     }
 
     @Test
     public void min_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)),
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).minBy((<name>ObjectPair\<Integer> object) -> (int) object.getOne() & 1));
     }
@@ -401,7 +406,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)),
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("4")>, 5).maxBy((<name>ObjectPair\<Integer> object) -> (int) object.getOne() & 1));
     }
@@ -409,27 +414,27 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
-        Assert.assertNull(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertNull(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0\<<name>ObjectPair\<Integer>\> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))), function));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))), function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))), function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectIfNone(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4))), function));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0\<<name>ObjectPair\<Integer>\> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)),
                 function));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("5")>, Integer.valueOf(6)), this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)),
                 function));
@@ -438,59 +443,59 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfy(<name>ObjectPair.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfy(<name>ObjectPair.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfyWith(Predicates2.instanceOf(), <name>ObjectPair.class));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfyWith(Predicates2.instanceOf(), <name>ObjectPair.class));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5)))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfy(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5)))));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
-        Assert.assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5))));
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertFalse(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(5))));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(Boolean.class::isInstance));
-        Assert.assertEquals(3, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(<name>ObjectPair.class::isInstance));
-        Assert.assertEquals(1, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
+        assertEquals(0, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(Boolean.class::isInstance));
+        assertEquals(3, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(<name>ObjectPair.class::isInstance));
+        assertEquals(1, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).count(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)))));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertEquals(3, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Predicates2.instanceOf(), <name>ObjectPair.class));
-        Assert.assertEquals(1, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertEquals(0, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Predicates2.instanceOf(), Boolean.class));
+        assertEquals(3, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Predicates2.instanceOf(), <name>ObjectPair.class));
+        assertEquals(1, this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
     }
 
     @Test
@@ -512,7 +517,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(4L, 6L, 8L),
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4)
                       .collectWith((<name>ObjectPair\<Integer> argument1, Long argument2) -> (long) (argument1.getOne() + argument1.getTwo() + argument2), 1L).toBag());
@@ -521,7 +526,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(4L, 6L, 8L),
                 this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4)
                        .collectWith((<name>ObjectPair\<Integer> argument1, Long argument2) -> (long) (argument1.getOne() + argument1.getTwo() + argument2), 1L, HashBag.\<Long>newBag()));
@@ -531,20 +536,20 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void getFirst()
     {
         <name>ObjectPair\<Integer> first = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).getFirst();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(first)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)).equals(first));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2).getFirst());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2).getFirst());
     }
 
     @Test
     public void getLast()
     {
         <name>ObjectPair\<Integer> last = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).getLast();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(last)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)).equals(last));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2).getLast());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), this.newWith(<(literal.(type))("1")>, 2).getLast());
     }
 
     @Test
@@ -552,7 +557,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(<(literal.(type))("1")>, 2));
-        Assert.assertTrue(this.newWith(<(literal.(type))("1")>, 2).notEmpty());
+        assertTrue(this.newWith(<(literal.(type))("1")>, 2).notEmpty());
     }
 
     @Test
@@ -563,11 +568,11 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Iterator\<<name>ObjectPair\<Integer>\> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -578,11 +583,11 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Iterator\<<name>ObjectPair\<Integer>\> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -592,11 +597,11 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Iterator\<<name>ObjectPair\<Integer>\> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -604,7 +609,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Iterator\<<name>ObjectPair\<Integer>\> iterator = objects.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+        assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -612,7 +617,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Long result = objects.injectInto(1L, (Long argument1, <name>ObjectPair\<Integer> argument2) -> (long) (argument1 + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(Long.valueOf(16), result);
+        assertEquals(Long.valueOf(16), result);
     }
 
     @Test
@@ -620,7 +625,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         int result = objects.injectInto(1, (int intParameter, <name>ObjectPair\<Integer> argument2) -> (int) (intParameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16, result);
+        assertEquals(16, result);
     }
 
     @Test
@@ -628,7 +633,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         long result = objects.injectInto(1L, (long parameter, <name>ObjectPair\<Integer> argument2) -> (long) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16, result);
+        assertEquals(16, result);
     }
 
     @Test
@@ -636,7 +641,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         double result = objects.injectInto(1.0, (double parameter, <name>ObjectPair\<Integer> argument2) -> (double) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16.0, result, 0.0);
+        assertEquals(16.0, result, 0.0);
     }
 
     @Test
@@ -644,7 +649,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         float result = objects.injectInto(1.0f, (float parameter, <name>ObjectPair\<Integer> argument2) -> (float) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16.0, result, 0.0);
+        assertEquals(16.0, result, 0.0);
     }
 
     @Test
@@ -652,7 +657,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         double actual = objects.sumOfFloat((<name>ObjectPair\<Integer> each) -> (float) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15.0, actual, 0.0);
+        assertEquals(15.0, actual, 0.0);
     }
 
     @Test
@@ -660,7 +665,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         double actual = objects.sumOfDouble((<name>ObjectPair\<Integer> each) -> (double) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15.0, actual, 0.0);
+        assertEquals(15.0, actual, 0.0);
     }
 
     @Test
@@ -668,7 +673,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         long actual = objects.sumOfInt((<name>ObjectPair\<Integer> each) -> (int) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15, actual);
+        assertEquals(15, actual);
     }
 
     @Test
@@ -676,7 +681,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         long actual = objects.sumOfLong((<name>ObjectPair\<Integer> each) -> (long) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15, actual);
+        assertEquals(15, actual);
     }
 
     @Test
@@ -719,7 +724,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("2")>, 3, <(literal.(type))("1")>, 2, <(literal.(type))("3")>, 4);
         MutableList\<<name>ObjectPair\<Integer>\> list = pairs.toSortedList();
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), list);
     }
 
     @Test
@@ -727,7 +732,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("2")>, 3, <(literal.(type))("1")>, 2, <(literal.(type))("3")>, 4);
         MutableList\<<name>ObjectPair\<Integer>\> list = pairs.toSortedList(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))), list);
     }
 
     @Test
@@ -735,7 +740,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("2")>, 3, <(literal.(type))("1")>, 2, <(literal.(type))("3")>, 4);
         MutableList\<<name>ObjectPair\<Integer>\> list = pairs.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))), list);
     }
 
     @Test
@@ -804,7 +809,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MutableMap\<String, String> map =
                 pairs.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
     }
 
     @Test
@@ -813,7 +818,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
+        assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
     }
 
     @Test
@@ -822,7 +827,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(Comparators.reverseNaturalOrder(), String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
     }
 
     @Test
@@ -831,7 +836,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMapBy(String::valueOf, String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), map);
     }
 
     @Test
@@ -839,14 +844,14 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> pairs = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MutableBiMap\<String, String> biMap = pairs.toBiMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), biMap);
+        assertEquals(HashBiMap.newWithKeysValues("<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("1")>:2", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("2")>:3", "<(toStringLiteral.(type))("3")>:4", "<(toStringLiteral.(type))("3")>:4"), biMap);
     }
 
     @Test
     public void testToString()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3);
-        Assert.assertTrue("[<(toStringLiteral.(type))("1")>:2, <(toStringLiteral.(type))("2")>:3]".equals(collection.toString())
+        assertTrue("[<(toStringLiteral.(type))("1")>:2, <(toStringLiteral.(type))("2")>:3]".equals(collection.toString())
                 || "[<(toStringLiteral.(type))("2")>:3, <(toStringLiteral.(type))("1")>:2]".equals(collection.toString()));
     }
 
@@ -854,21 +859,21 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void makeString()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -877,7 +882,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -886,7 +891,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -895,7 +900,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
@@ -905,10 +910,10 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Function\<<name>ObjectPair\<Integer>, Boolean> function = (<name>ObjectPair\<Integer> object) -> PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(object);
 
         Multimap\<Boolean, <name>ObjectPair\<Integer>\> multimap = collection.groupBy(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))));
     }
 
     @Test
@@ -918,10 +923,10 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Function\<<name>ObjectPair\<Integer>, MutableList\<Boolean>\> function = (<name>ObjectPair\<Integer> object) -> Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)).equals(object));
 
         Multimap\<Boolean, <name>ObjectPair\<Integer>\> multimap = collection.groupByEach(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4))));
     }
 
     @Test
@@ -930,7 +935,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3);
         RichIterable\<Pair\<<name>ObjectPair\<Integer>, Integer>\> result = collection.zip(Interval.oneTo(5));
 
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 2)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 2)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 2)).equals(result.toBag()));
     }
 
@@ -939,7 +944,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3);
         RichIterable\<Pair\<<name>ObjectPair\<Integer>, Integer>\> result = collection.zipWithIndex();
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 1)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 1)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3)), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2)), 1)).equals(result.toBag()));
     }
 
@@ -947,7 +952,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void chunk()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))),
+        assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("1")>, Integer.valueOf(2))),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(3))),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type))("3")>, Integer.valueOf(4)))),
                 collection.chunk(1).toBag());
@@ -957,7 +962,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void chunk_zero_throws()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test
@@ -971,8 +976,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -989,9 +994,9 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Procedure2\<AtomicInteger, <name>ObjectPair\<Integer>\> sumAggregator = (AtomicInteger aggregate, <name>ObjectPair\<Integer> value) -> aggregate.addAndGet((int) value.getOne());
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         MapIterable\<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("<(toStringLiteral.(type))("3")>:4").intValue());
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:3").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:2").intValue());
+        assertEquals(3, aggregation.get("<(toStringLiteral.(type))("3")>:4").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:3").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:2").intValue());
     }
 
     @Test
@@ -1001,8 +1006,8 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Function2\<Integer, <name>ObjectPair\<Integer>, Integer> sumAggregator = (Integer aggregate, <name>ObjectPair\<Integer> value) -> (int) (aggregate + value.getOne());
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3);
         MapIterable\<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:3").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:2").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type))("2")>:3").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type))("1")>:2").intValue());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
@@ -87,8 +87,15 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * This file was automatically generated from template file abstractPrimitiveObjectMapTestCase.stg.
@@ -109,8 +116,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     public void keySet()
     {
         Verify.assertEmpty(this.getEmptyMap().keySet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>), this.newWithKeysValues(<(literal.(type))("0")>, "zero").keySet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("9")>),
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>), this.newWithKeysValues(<(literal.(type))("0")>, "zero").keySet());
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("9")>),
                 this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine").keySet());
     }
 
@@ -136,34 +143,34 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
                 map1.select((<type> value, String object) -> (value % 2) != 0));
 
         <name>ObjectPredicate\<String> keyGreaterThanOrEqualToSeven = (<type> value, String object) -> value \<= 7;
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), map1.select(keyGreaterThanOrEqualToSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), map1.select(keyGreaterThanOrEqualToSeven));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), map2.select(keyGreaterThanOrEqualToSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), map2.select(keyGreaterThanOrEqualToSeven));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map3.select(keyGreaterThanOrEqualToSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map3.select(keyGreaterThanOrEqualToSeven));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("5")>, "five"), map4.select(keyGreaterThanOrEqualToSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("5")>, "five"), map4.select(keyGreaterThanOrEqualToSeven));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
                 map1.select((<type> value, String object) -> object.endsWith("ne")));
 
         RichIterable\<String> actual1 = map1.select(StringPredicates.endsWith("ne"));
-        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
+        assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
 
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine")));
+        assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine")));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o")));
+        assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o")));
 
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine"), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine"), HashBag.\<String>newBag()));
 
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.select(StringPredicates.endsWith("ne"), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.select(StringPredicates.endsWith("ne"), HashBag.\<String>newBag()));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o"), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o"), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -171,11 +178,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne"));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne"));
 
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine"));
+        assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine"));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o"));
+        assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o"));
     }
 
     @Test
@@ -183,11 +190,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne", HashBag.\<String>newBag()));
 
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine", HashBag.\<String>newBag()));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o", HashBag.\<String>newBag()));
     }
 
     @Test
@@ -195,8 +202,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<Number> numbers = this.\<Number>newWithKeysValues(<(literal.(type))("0")>, 0, <(literal.(type))("1")>, 1.0, <(literal.(type))("5")>, 5.0);
 
-        Assert.assertEquals(HashBag.newBagWith(0), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(HashBag.newBagWith(1.0, 5.0), numbers.selectInstancesOf(Double.class));
+        assertEquals(HashBag.newBagWith(0), numbers.selectInstancesOf(Integer.class));
+        assertEquals(HashBag.newBagWith(1.0, 5.0), numbers.selectInstancesOf(Double.class));
     }
 
     @Test
@@ -204,8 +211,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase()));
-        Assert.assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase()));
+        assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -213,7 +220,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "true", <(literal.(type))("1")>, "false", <(literal.(type))("2")>, "nah");
 
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), map1.collectBoolean(StringFunctions.toPrimitiveBoolean()));
+        assertEquals(BooleanHashBag.newBagWith(true, false, false), map1.collectBoolean(StringFunctions.toPrimitiveBoolean()));
     }
 
     @Test
@@ -221,8 +228,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "true", <(literal.(type))("1")>, "false", <(literal.(type))("2")>, "nah");
         BooleanHashBag target = new BooleanHashBag();
-        Assert.assertSame(target, map1.collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), target);
+        assertSame(target, map1.collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
+        assertEquals(BooleanHashBag.newBagWith(true, false, false), target);
     }
 
     @Test
@@ -230,7 +237,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), map1.collectByte(Byte::parseByte));
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), map1.collectByte(Byte::parseByte));
     }
 
     @Test
@@ -238,8 +245,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         ByteHashBag target = new ByteHashBag();
-        Assert.assertSame(target, map1.collectByte(Byte::parseByte, target));
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), target);
+        assertSame(target, map1.collectByte(Byte::parseByte, target));
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), target);
     }
 
     @Test
@@ -247,7 +254,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), map1.collectChar(StringFunctions.toPrimitiveChar()));
+        assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), map1.collectChar(StringFunctions.toPrimitiveChar()));
     }
 
     @Test
@@ -255,8 +262,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         CharHashBag target = new CharHashBag();
-        Assert.assertSame(target, map1.collectChar(StringFunctions.toPrimitiveChar(), target));
-        Assert.assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), target);
+        assertSame(target, map1.collectChar(StringFunctions.toPrimitiveChar(), target));
+        assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), target);
     }
 
     @Test
@@ -264,7 +271,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), map1.collectDouble(Double::parseDouble));
+        assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), map1.collectDouble(Double::parseDouble));
     }
 
     @Test
@@ -272,8 +279,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         DoubleHashBag target = new DoubleHashBag();
-        Assert.assertSame(target, map1.collectDouble(Double::parseDouble, target));
-        Assert.assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), target);
+        assertSame(target, map1.collectDouble(Double::parseDouble, target));
+        assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), target);
     }
 
     @Test
@@ -281,7 +288,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), map1.collectFloat(Float::parseFloat));
+        assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), map1.collectFloat(Float::parseFloat));
     }
 
     @Test
@@ -289,8 +296,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         FloatHashBag target = new FloatHashBag();
-        Assert.assertSame(target, map1.collectFloat(Float::parseFloat, target));
-        Assert.assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), target);
+        assertSame(target, map1.collectFloat(Float::parseFloat, target));
+        assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), target);
     }
 
     @Test
@@ -298,7 +305,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(IntHashBag.newBagWith(0, 1, 9), map1.collectInt(Integer::parseInt));
+        assertEquals(IntHashBag.newBagWith(0, 1, 9), map1.collectInt(Integer::parseInt));
     }
 
     @Test
@@ -306,8 +313,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         IntHashBag target = new IntHashBag();
-        Assert.assertSame(target, map1.collectInt(Integer::parseInt, target));
-        Assert.assertEquals(IntHashBag.newBagWith(0, 1, 9), target);
+        assertSame(target, map1.collectInt(Integer::parseInt, target));
+        assertEquals(IntHashBag.newBagWith(0, 1, 9), target);
     }
 
     @Test
@@ -315,7 +322,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), map1.collectLong(Long::parseLong));
+        assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), map1.collectLong(Long::parseLong));
     }
 
     @Test
@@ -323,8 +330,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         LongHashBag target = new LongHashBag();
-        Assert.assertSame(target, map1.collectLong(Long::parseLong, target));
-        Assert.assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), target);
+        assertSame(target, map1.collectLong(Long::parseLong, target));
+        assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), target);
     }
 
     @Test
@@ -332,7 +339,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), map1.collectShort(Short::parseShort));
+        assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), map1.collectShort(Short::parseShort));
     }
 
     @Test
@@ -340,8 +347,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
         ShortHashBag target = new ShortHashBag();
-        Assert.assertSame(target, map1.collectShort(Short::parseShort, target));
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), target);
+        assertSame(target, map1.collectShort(Short::parseShort, target));
+        assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), target);
     }
 
     @Test
@@ -349,7 +356,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
+        assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
                 map1.collectWith((String argument1, String argument2) -> argument1.toUpperCase() + argument2, "!"));
     }
 
@@ -358,7 +365,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
+        assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
                 map1.collectWith((String argument1, String argument2) -> argument1.toUpperCase() + argument2, "!", HashBag.\<String>newBag()));
     }
 
@@ -367,9 +374,9 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("ONE", "NINE"), map1.collectIf(StringPredicates.endsWith("ne"), StringFunctions.toUpperCase()));
-        Assert.assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase()));
-        Assert.assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("ONE", "NINE"), map1.collectIf(StringPredicates.endsWith("ne"), StringFunctions.toUpperCase()));
+        assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase()));
+        assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -390,50 +397,50 @@ public abstract class Abstract<name>ObjectMapTestCase
             return list;
         };
 
-        Assert.assertEquals(UnifiedSet.newSetWith('z', 'e', 'r', 'o', 'n', 'i'), map1.flatCollect(toChars).toSet());
-        Assert.assertEquals(UnifiedSet.newSetWith('o', 'n', 'e', 'i'), map2.flatCollect(toChars).toSet());
-        Assert.assertEquals(UnifiedSet.newSetWith('f', 'i', 'v', 'e', 'n'), map3.flatCollect(toChars).toSet());
-        Assert.assertEquals(UnifiedSet.newSetWith('f', 'i', 'v', 'e', 'n'), map3.flatCollect(toChars, UnifiedSet.\<Character>newSet()));
+        assertEquals(UnifiedSet.newSetWith('z', 'e', 'r', 'o', 'n', 'i'), map1.flatCollect(toChars).toSet());
+        assertEquals(UnifiedSet.newSetWith('o', 'n', 'e', 'i'), map2.flatCollect(toChars).toSet());
+        assertEquals(UnifiedSet.newSetWith('f', 'i', 'v', 'e', 'n'), map3.flatCollect(toChars).toSet());
+        assertEquals(UnifiedSet.newSetWith('f', 'i', 'v', 'e', 'n'), map3.flatCollect(toChars, UnifiedSet.\<Character>newSet()));
     }
 
     @Test
     public void detect()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
-        Assert.assertTrue("one".equals(map1.detect(StringPredicates.endsWith("ne"))) || "nine".equals(map1.detect(StringPredicates.endsWith("ne"))));
-        Assert.assertEquals("zero", map1.detect(StringPredicates.endsWith("o")));
-        Assert.assertEquals("nine", map1.detect(Predicates.equal("nine")));
-        Assert.assertNull(map1.detect(Predicates.equal("ten")));
+        assertTrue("one".equals(map1.detect(StringPredicates.endsWith("ne"))) || "nine".equals(map1.detect(StringPredicates.endsWith("ne"))));
+        assertEquals("zero", map1.detect(StringPredicates.endsWith("o")));
+        assertEquals("nine", map1.detect(Predicates.equal("nine")));
+        assertNull(map1.detect(Predicates.equal("ten")));
     }
 
     @Test
     public void detectWith()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
-        Assert.assertTrue("one".equals(map1.detectWith(StringPredicates2.endsWith(), "ne")) || "nine".equals(map1.detectWith(StringPredicates2.endsWith(), "ne")));
-        Assert.assertEquals("zero", map1.detectWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertEquals("nine", map1.detectWith(Object::equals, "nine"));
-        Assert.assertNull(map1.detectWith(Object::equals, "ten"));
+        assertTrue("one".equals(map1.detectWith(StringPredicates2.endsWith(), "ne")) || "nine".equals(map1.detectWith(StringPredicates2.endsWith(), "ne")));
+        assertEquals("zero", map1.detectWith(StringPredicates2.endsWith(), "o"));
+        assertEquals("nine", map1.detectWith(Object::equals, "nine"));
+        assertNull(map1.detectWith(Object::equals, "ten"));
     }
 
     @Test
     public void detectOptional()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
-        Assert.assertTrue(Optional.of("one").equals(map1.detectOptional(StringPredicates.endsWith("ne"))) || Optional.of("nine").equals(map1.detectOptional(StringPredicates.endsWith("ne"))));
-        Assert.assertEquals(Optional.of("zero"), map1.detectOptional(StringPredicates.endsWith("o")));
-        Assert.assertEquals(Optional.of("nine"), map1.detectOptional(Predicates.equal("nine")));
-        Assert.assertEquals(Optional.empty(), map1.detectOptional(Predicates.equal("ten")));
+        assertTrue(Optional.of("one").equals(map1.detectOptional(StringPredicates.endsWith("ne"))) || Optional.of("nine").equals(map1.detectOptional(StringPredicates.endsWith("ne"))));
+        assertEquals(Optional.of("zero"), map1.detectOptional(StringPredicates.endsWith("o")));
+        assertEquals(Optional.of("nine"), map1.detectOptional(Predicates.equal("nine")));
+        assertEquals(Optional.empty(), map1.detectOptional(Predicates.equal("ten")));
     }
 
     @Test
     public void detectWithOptional()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
-        Assert.assertTrue(Optional.of("one").equals(map1.detectWithOptional(StringPredicates2.endsWith(), "ne")) || Optional.of("nine").equals(map1.detectWithOptional(StringPredicates2.endsWith(), "ne")));
-        Assert.assertEquals(Optional.of("zero"), map1.detectWithOptional(StringPredicates2.endsWith(), "o"));
-        Assert.assertEquals(Optional.of("nine"), map1.detectWithOptional(Object::equals, "nine"));
-        Assert.assertEquals(Optional.empty(), map1.detectWithOptional(Object::equals, "ten"));
+        assertTrue(Optional.of("one").equals(map1.detectWithOptional(StringPredicates2.endsWith(), "ne")) || Optional.of("nine").equals(map1.detectWithOptional(StringPredicates2.endsWith(), "ne")));
+        assertEquals(Optional.of("zero"), map1.detectWithOptional(StringPredicates2.endsWith(), "o"));
+        assertEquals(Optional.of("nine"), map1.detectWithOptional(Object::equals, "nine"));
+        assertEquals(Optional.empty(), map1.detectWithOptional(Object::equals, "ten"));
     }
 
     @Test
@@ -442,11 +449,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
         Function0\<String> ifNone = () -> "ifNone";
-        Assert.assertTrue("one".equals(map1.detectIfNone(StringPredicates.endsWith("ne"), ifNone))
+        assertTrue("one".equals(map1.detectIfNone(StringPredicates.endsWith("ne"), ifNone))
                 || "nine".equals(map1.detectIfNone(StringPredicates.endsWith("ne"), ifNone)));
-        Assert.assertEquals("zero", map1.detectIfNone(StringPredicates.endsWith("o"), ifNone));
-        Assert.assertEquals("nine", map1.detectIfNone(Predicates.equal("nine"), ifNone));
-        Assert.assertEquals("ifNone", map1.detectIfNone(Predicates.equal("ten"), ifNone));
+        assertEquals("zero", map1.detectIfNone(StringPredicates.endsWith("o"), ifNone));
+        assertEquals("nine", map1.detectIfNone(Predicates.equal("nine"), ifNone));
+        assertEquals("ifNone", map1.detectIfNone(Predicates.equal("ten"), ifNone));
     }
 
     @Test
@@ -455,11 +462,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
         Function0\<String> ifNone = () -> "ifNone";
-        Assert.assertTrue("one".equals(map1.detectWithIfNone(StringPredicates2.endsWith(), "ne", ifNone))
+        assertTrue("one".equals(map1.detectWithIfNone(StringPredicates2.endsWith(), "ne", ifNone))
                 || "nine".equals(map1.detectWithIfNone(StringPredicates2.endsWith(), "ne", ifNone)));
-        Assert.assertEquals("zero", map1.detectWithIfNone(StringPredicates2.endsWith(), "o", ifNone));
-        Assert.assertEquals("nine", map1.detectWithIfNone(Object::equals, "nine", ifNone));
-        Assert.assertEquals("ifNone", map1.detectWithIfNone(Object::equals, "ten", ifNone));
+        assertEquals("zero", map1.detectWithIfNone(StringPredicates2.endsWith(), "o", ifNone));
+        assertEquals("nine", map1.detectWithIfNone(Object::equals, "nine", ifNone));
+        assertEquals("ifNone", map1.detectWithIfNone(Object::equals, "ten", ifNone));
     }
 
     @Test
@@ -478,10 +485,10 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(2, map1.countWith(StringPredicates2.endsWith(), "ne"));
-        Assert.assertEquals(1, map1.countWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertEquals(1, map1.countWith(Object::equals, "nine"));
-        Assert.assertNotEquals(1, map1.countWith(Object::equals, "ten"));
+        assertEquals(2, map1.countWith(StringPredicates2.endsWith(), "ne"));
+        assertEquals(1, map1.countWith(StringPredicates2.endsWith(), "o"));
+        assertEquals(1, map1.countWith(Object::equals, "nine"));
+        assertNotEquals(1, map1.countWith(Object::equals, "ten"));
     }
 
     @Test
@@ -491,17 +498,17 @@ public abstract class Abstract<name>ObjectMapTestCase
         Verify.assertAnySatisfy(map1, StringPredicates.endsWith("ne"));
         Verify.assertAnySatisfy(map1, StringPredicates.endsWith("o"));
         Verify.assertAnySatisfy(map1, Predicates.equal("nine"));
-        Assert.assertFalse(map1.anySatisfy(Predicates.equal("ten")));
+        assertFalse(map1.anySatisfy(Predicates.equal("ten")));
     }
 
     @Test
     public void anySatisfyWith()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
-        Assert.assertTrue(map1.anySatisfyWith(StringPredicates2.endsWith(), "ne"));
-        Assert.assertTrue(map1.anySatisfyWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertTrue(map1.anySatisfyWith(Object::equals, "nine"));
-        Assert.assertFalse(map1.anySatisfyWith(Object::equals, "ten"));
+        assertTrue(map1.anySatisfyWith(StringPredicates2.endsWith(), "ne"));
+        assertTrue(map1.anySatisfyWith(StringPredicates2.endsWith(), "o"));
+        assertTrue(map1.anySatisfyWith(Object::equals, "nine"));
+        assertFalse(map1.anySatisfyWith(Object::equals, "ten"));
     }
 
     @Test
@@ -509,11 +516,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.allSatisfy(StringPredicates.contains("e")));
-        Assert.assertFalse(map1.allSatisfy(StringPredicates.endsWith("o")));
-        Assert.assertFalse(map1.allSatisfy(StringPredicates.contains("o")));
-        Assert.assertFalse(map1.allSatisfy(Predicates.equal("nine")));
-        Assert.assertFalse(map1.allSatisfy(Predicates.equal("ten")));
+        assertTrue(map1.allSatisfy(StringPredicates.contains("e")));
+        assertFalse(map1.allSatisfy(StringPredicates.endsWith("o")));
+        assertFalse(map1.allSatisfy(StringPredicates.contains("o")));
+        assertFalse(map1.allSatisfy(Predicates.equal("nine")));
+        assertFalse(map1.allSatisfy(Predicates.equal("ten")));
     }
 
     @Test
@@ -521,11 +528,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.allSatisfyWith(StringPredicates2.contains(), "e"));
-        Assert.assertFalse(map1.allSatisfyWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertFalse(map1.allSatisfyWith(StringPredicates2.contains(), "o"));
-        Assert.assertFalse(map1.allSatisfyWith(Object::equals, "nine"));
-        Assert.assertFalse(map1.allSatisfyWith(Object::equals, "ten"));
+        assertTrue(map1.allSatisfyWith(StringPredicates2.contains(), "e"));
+        assertFalse(map1.allSatisfyWith(StringPredicates2.endsWith(), "o"));
+        assertFalse(map1.allSatisfyWith(StringPredicates2.contains(), "o"));
+        assertFalse(map1.allSatisfyWith(Object::equals, "nine"));
+        assertFalse(map1.allSatisfyWith(Object::equals, "ten"));
     }
 
     @Test
@@ -533,12 +540,12 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.noneSatisfy(StringPredicates.notContains("e")));
-        Assert.assertFalse(map1.noneSatisfy(StringPredicates.endsWith("o")));
-        Assert.assertFalse(map1.noneSatisfy(StringPredicates.startsWith("o")));
-        Assert.assertFalse(map1.noneSatisfy(StringPredicates.contains("o")));
-        Assert.assertFalse(map1.noneSatisfy(Predicates.equal("nine")));
-        Assert.assertTrue(map1.noneSatisfy(Predicates.equal("ten")));
+        assertTrue(map1.noneSatisfy(StringPredicates.notContains("e")));
+        assertFalse(map1.noneSatisfy(StringPredicates.endsWith("o")));
+        assertFalse(map1.noneSatisfy(StringPredicates.startsWith("o")));
+        assertFalse(map1.noneSatisfy(StringPredicates.contains("o")));
+        assertFalse(map1.noneSatisfy(Predicates.equal("nine")));
+        assertTrue(map1.noneSatisfy(Predicates.equal("ten")));
     }
 
     @Test
@@ -546,12 +553,12 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.noneSatisfyWith(StringPredicates2.notContains(), "e"));
-        Assert.assertFalse(map1.noneSatisfyWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertFalse(map1.noneSatisfyWith(StringPredicates2.startsWith(), "o"));
-        Assert.assertFalse(map1.noneSatisfyWith(StringPredicates2.contains(), "o"));
-        Assert.assertFalse(map1.noneSatisfyWith(Object::equals, "nine"));
-        Assert.assertTrue(map1.noneSatisfyWith(Object::equals, "ten"));
+        assertTrue(map1.noneSatisfyWith(StringPredicates2.notContains(), "e"));
+        assertFalse(map1.noneSatisfyWith(StringPredicates2.endsWith(), "o"));
+        assertFalse(map1.noneSatisfyWith(StringPredicates2.startsWith(), "o"));
+        assertFalse(map1.noneSatisfyWith(StringPredicates2.contains(), "o"));
+        assertFalse(map1.noneSatisfyWith(Object::equals, "nine"));
+        assertTrue(map1.noneSatisfyWith(Object::equals, "ten"));
     }
 
     @Test
@@ -563,11 +570,11 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Function2\<String, String, String> concat = (String argument1, String argument2) -> argument1 + '-' + argument2;
 
-        Assert.assertTrue("Start-zero-nine".equals(map1.injectInto("Start", concat))
+        assertTrue("Start-zero-nine".equals(map1.injectInto("Start", concat))
                 || "Start-nine-zero".equals(map1.injectInto("Start", concat)));
-        Assert.assertTrue("Start-one-nine".equals(map2.injectInto("Start", concat))
+        assertTrue("Start-one-nine".equals(map2.injectInto("Start", concat))
                 || "Start-nine-one".equals(map2.injectInto("Start", concat)));
-        Assert.assertTrue("Start-five-nine".equals(map3.injectInto("Start", concat))
+        assertTrue("Start-five-nine".equals(map3.injectInto("Start", concat))
                 || "Start-nine-five".equals(map3.injectInto("Start", concat)));
     }
 
@@ -579,9 +586,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "abc", <(literal.(type))("9")>, "abcd");
 
         IntObjectToIntFunction\<String> function = (int intParameter, String objectParameter) -> intParameter + objectParameter.length();
-        Assert.assertEquals(6, map1.injectInto(1, function));
-        Assert.assertEquals(7, map2.injectInto(1, function));
-        Assert.assertEquals(8, map3.injectInto(1, function));
+        assertEquals(6, map1.injectInto(1, function));
+        assertEquals(7, map2.injectInto(1, function));
+        assertEquals(8, map3.injectInto(1, function));
     }
 
     @Test
@@ -592,9 +599,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "abc", <(literal.(type))("9")>, "abcd");
 
         LongObjectToLongFunction\<String> function = (long longParameter, String objectParameter) -> longParameter + objectParameter.length();
-        Assert.assertEquals(6L, map1.injectInto(1L, function));
-        Assert.assertEquals(7L, map2.injectInto(1L, function));
-        Assert.assertEquals(8L, map3.injectInto(1L, function));
+        assertEquals(6L, map1.injectInto(1L, function));
+        assertEquals(7L, map2.injectInto(1L, function));
+        assertEquals(8L, map3.injectInto(1L, function));
     }
 
     @Test
@@ -605,9 +612,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "abc", <(literal.(type))("9")>, "abcd");
 
         FloatObjectToFloatFunction\<String> function = (float floatParameter, String objectParameter) -> floatParameter + objectParameter.length();
-        Assert.assertEquals(6.0f, map1.injectInto(1.0f, function), 0.0);
-        Assert.assertEquals(7.0f, map2.injectInto(1.0f, function), 0.0);
-        Assert.assertEquals(8.0f, map3.injectInto(1.0f, function), 0.0);
+        assertEquals(6.0f, map1.injectInto(1.0f, function), 0.0);
+        assertEquals(7.0f, map2.injectInto(1.0f, function), 0.0);
+        assertEquals(8.0f, map3.injectInto(1.0f, function), 0.0);
     }
 
     @Test
@@ -618,9 +625,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "abc", <(literal.(type))("9")>, "abcd");
 
         DoubleObjectToDoubleFunction\<String> function = (double doubleParameter, String objectParameter) -> doubleParameter + objectParameter.length();
-        Assert.assertEquals(6.0, map1.injectInto(1.0, function), 0.0);
-        Assert.assertEquals(7.0, map2.injectInto(1.0, function), 0.0);
-        Assert.assertEquals(8.0, map3.injectInto(1.0, function), 0.0);
+        assertEquals(6.0, map1.injectInto(1.0, function), 0.0);
+        assertEquals(7.0, map2.injectInto(1.0, function), 0.0);
+        assertEquals(8.0, map3.injectInto(1.0, function), 0.0);
     }
 
     @Test
@@ -630,11 +637,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toList())
+        assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toList())
                 || FastList.newListWith("nine", "zero").equals(map1.toList()));
-        Assert.assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toList())
+        assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toList())
                 || FastList.newListWith("nine", "one").equals(map2.toList()));
-        Assert.assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toList())
+        assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toList())
                 || FastList.newListWith("nine", "five").equals(map3.toList()));
     }
 
@@ -645,25 +652,25 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(map1.toSortedList().toString(),
+        assertEquals(map1.toSortedList().toString(),
                 FastList.newListWith("nine", "zero"), map1.toSortedList());
-        Assert.assertEquals(map2.toSortedList().toString(),
+        assertEquals(map2.toSortedList().toString(),
                 FastList.newListWith("nine", "one"), map2.toSortedList());
-        Assert.assertEquals(map3.toSortedList().toString(), FastList.newListWith("five", "nine"), map3.toSortedList());
+        assertEquals(map3.toSortedList().toString(), FastList.newListWith("five", "nine"), map3.toSortedList());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        Assert.assertEquals(map1.toSortedList(comparator).toString(),
+        assertEquals(map1.toSortedList(comparator).toString(),
                 FastList.newListWith("zero", "nine"), map1.toSortedList(comparator));
-        Assert.assertEquals(map2.toSortedList(comparator).toString(),
+        assertEquals(map2.toSortedList(comparator).toString(),
                 FastList.newListWith("nine", "one"), map2.toSortedList(comparator));
-        Assert.assertEquals(map3.toSortedList(comparator).toString(), FastList.newListWith("nine", "five"), map3.toSortedList(comparator));
+        assertEquals(map3.toSortedList(comparator).toString(), FastList.newListWith("nine", "five"), map3.toSortedList(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        Assert.assertEquals(map1.toSortedListBy(substring).toString(),
+        assertEquals(map1.toSortedListBy(substring).toString(),
                 FastList.newListWith("zero", "nine"), map1.toSortedListBy(substring));
-        Assert.assertEquals(map2.toSortedListBy(substring).toString(),
+        assertEquals(map2.toSortedListBy(substring).toString(),
                 FastList.newListWith("nine", "one"), map2.toSortedListBy(substring));
-        Assert.assertEquals(map3.toSortedListBy(substring).toString(), FastList.newListWith("nine", "five"), map3.toSortedListBy(substring));
+        assertEquals(map3.toSortedListBy(substring).toString(), FastList.newListWith("nine", "five"), map3.toSortedListBy(substring));
     }
 
     @Test
@@ -673,9 +680,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toSet());
-        Assert.assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toSet());
-        Assert.assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toSet());
+        assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toSet());
+        assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toSet());
+        assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toSet());
     }
 
     @Test
@@ -685,21 +692,21 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toSortedSet());
-        Assert.assertEquals(map2.toSortedSet().toString(),
+        assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toSortedSet());
+        assertEquals(map2.toSortedSet().toString(),
                 TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet());
-        Assert.assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toSortedSet());
+        assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toSortedSet());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        Assert.assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSet(comparator));
-        Assert.assertEquals(map2.toSortedSet(comparator).toString(),
+        assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSet(comparator));
+        assertEquals(map2.toSortedSet(comparator).toString(),
                 TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet(comparator));
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSet(comparator));
+        assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSet(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        Assert.assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSetBy(substring));
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSetBy(substring));
-        Assert.assertEquals(map3.toSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSetBy(substring));
+        assertEquals(map3.toSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSetBy(substring));
     }
 
     @Test
@@ -709,9 +716,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("zero", "zero", "nine"), map1.toBag());
-        Assert.assertEquals(HashBag.newBagWith("one", "one", "nine"), map2.toBag());
-        Assert.assertEquals(HashBag.newBagWith("five", "five", "nine"), map3.toBag());
+        assertEquals(HashBag.newBagWith("zero", "zero", "nine"), map1.toBag());
+        assertEquals(HashBag.newBagWith("one", "one", "nine"), map2.toBag());
+        assertEquals(HashBag.newBagWith("five", "five", "nine"), map3.toBag());
     }
 
     @Test
@@ -723,9 +730,9 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Function\<String, Integer> keyFunction = StringFunctions.length();
         Function\<String, String> valueFunction = Functions.getPassThru();
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "a", 4, "abcd"), map1.toMap(keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(2, "ab", 4, "abcd"), map2.toMap(keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "abc", 4, "abcd"), map3.toMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "a", 4, "abcd"), map1.toMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(2, "ab", 4, "abcd"), map2.toMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(3, "abc", 4, "abcd"), map3.toMap(keyFunction, valueFunction));
     }
 
     @Test
@@ -745,9 +752,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         targetMap2.put(1L, "a");
         targetMap2.put(4L, "abcd");
 
-        Assert.assertEquals(targetMap1, map.toMap(keyStringFunction, valueFunction, new HashMap\<String, String>()));
-        Assert.assertEquals(targetMap2, map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
-        Assert.assertTrue(map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()) instanceof HashMap);
+        assertEquals(targetMap1, map.toMap(keyStringFunction, valueFunction, new HashMap\<String, String>()));
+        assertEquals(targetMap2, map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
+        assertTrue(map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()) instanceof HashMap);
     }
 
     @Test
@@ -759,11 +766,11 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Function\<String, Integer> keyFunction = StringFunctions.length();
         Function\<String, String> valueFunction = Functions.getPassThru();
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 1, "z"), map1.toSortedMap(keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(2, "ab", 4, "abcd"), map2.toSortedMap(keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMap(keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMap(Comparators.naturalOrder(), keyFunction, valueFunction));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMapBy(Functions.getPassThru(), keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 1, "z"), map1.toSortedMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(2, "ab", 4, "abcd"), map2.toSortedMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMap(keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMap(Comparators.naturalOrder(), keyFunction, valueFunction));
+        assertEquals(UnifiedMap.newWithKeysValues(4, "abcd", 3, "zyx"), map3.toSortedMapBy(Functions.getPassThru(), keyFunction, valueFunction));
     }
 
     @Test
@@ -773,11 +780,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toImmutableList())
+        assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toImmutableList())
                 || FastList.newListWith("nine", "zero").equals(map1.toList()));
-        Assert.assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toImmutableList())
+        assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toImmutableList())
                 || FastList.newListWith("nine", "one").equals(map2.toList()));
-        Assert.assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toImmutableList())
+        assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toImmutableList())
                 || FastList.newListWith("nine", "five").equals(map3.toList()));
     }
 
@@ -788,27 +795,27 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(map1.toSortedList().toString(),
+        assertEquals(map1.toSortedList().toString(),
                 FastList.newListWith("nine", "zero"), map1.toImmutableSortedList());
-        Assert.assertEquals(map2.toSortedList().toString(),
+        assertEquals(map2.toSortedList().toString(),
                 FastList.newListWith("nine", "one"), map2.toImmutableSortedList());
-        Assert.assertEquals(map3.toSortedList().toString(),
+        assertEquals(map3.toSortedList().toString(),
                 FastList.newListWith("five", "nine"), map3.toImmutableSortedList());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        Assert.assertEquals(map1.toSortedList(comparator).toString(),
+        assertEquals(map1.toSortedList(comparator).toString(),
                 FastList.newListWith("zero", "nine"), map1.toImmutableSortedList(comparator));
-        Assert.assertEquals(map2.toSortedList(comparator).toString(),
+        assertEquals(map2.toSortedList(comparator).toString(),
                 FastList.newListWith("nine", "one"), map2.toImmutableSortedList(comparator));
-        Assert.assertEquals(map3.toSortedList(comparator).toString(),
+        assertEquals(map3.toSortedList(comparator).toString(),
                 FastList.newListWith("nine", "five"), map3.toImmutableSortedList(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        Assert.assertEquals(map1.toSortedListBy(substring).toString(),
+        assertEquals(map1.toSortedListBy(substring).toString(),
                 FastList.newListWith("zero", "nine"), map1.toImmutableSortedListBy(substring));
-        Assert.assertEquals(map2.toSortedListBy(substring).toString(),
+        assertEquals(map2.toSortedListBy(substring).toString(),
                 FastList.newListWith("nine", "one"), map2.toImmutableSortedListBy(substring));
-        Assert.assertEquals(map3.toSortedListBy(substring).toString(),
+        assertEquals(map3.toSortedListBy(substring).toString(),
                 FastList.newListWith("nine", "five"), map3.toImmutableSortedListBy(substring));
     }
 
@@ -819,9 +826,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toImmutableSet());
-        Assert.assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toImmutableSet());
-        Assert.assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toImmutableSet());
+        assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toImmutableSet());
+        assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toImmutableSet());
+        assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toImmutableSet());
     }
 
     @Test
@@ -831,21 +838,21 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toImmutableSortedSet());
-        Assert.assertEquals(map2.toImmutableSortedSet().toString(),
+        assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toImmutableSortedSet());
+        assertEquals(map2.toImmutableSortedSet().toString(),
                 TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet());
-        Assert.assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toImmutableSortedSet());
+        assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toImmutableSortedSet());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        Assert.assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSet(comparator));
-        Assert.assertEquals(map2.toImmutableSortedSet(comparator).toString(),
+        assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSet(comparator));
+        assertEquals(map2.toImmutableSortedSet(comparator).toString(),
                 TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet(comparator));
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSet(comparator));
+        assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSet(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        Assert.assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSetBy(substring));
-        Assert.assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSetBy(substring));
-        Assert.assertEquals(map3.toImmutableSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSetBy(substring));
+        assertEquals(map3.toImmutableSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSetBy(substring));
     }
 
     @Test
@@ -855,9 +862,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("zero", "zero", "nine"), map1.toImmutableBag());
-        Assert.assertEquals(HashBag.newBagWith("one", "one", "nine"), map2.toImmutableBag());
-        Assert.assertEquals(HashBag.newBagWith("five", "five", "nine"), map3.toImmutableBag());
+        assertEquals(HashBag.newBagWith("zero", "zero", "nine"), map1.toImmutableBag());
+        assertEquals(HashBag.newBagWith("one", "one", "nine"), map2.toImmutableBag());
+        assertEquals(HashBag.newBagWith("five", "five", "nine"), map3.toImmutableBag());
     }
 
     @Test
@@ -885,18 +892,18 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "ab", <(literal.(type))("9")>, "abcd");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
-        Assert.assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray())
+        assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray())
                 || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()));
-        Assert.assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray())
+        assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray())
                 || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()));
-        Assert.assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray())
+        assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray())
                 || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()));
 
-        Assert.assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray(new String[2]))
+        assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray(new String[2]))
                 || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()));
-        Assert.assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray(new String[4]))
+        assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray(new String[4]))
                 || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()));
-        Assert.assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray(new String[2]))
+        assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray(new String[2]))
                 || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()));
     }
 
@@ -907,16 +914,16 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "ab", <(literal.(type))("9")>, "abcd");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
-        Assert.assertEquals("abcd", map1.min());
-        Assert.assertEquals("ab", map2.min());
-        Assert.assertEquals("abcd", map3.min());
-        Assert.assertEquals("abcd", map3.min(Comparators.naturalOrder()));
+        assertEquals("abcd", map1.min());
+        assertEquals("ab", map2.min());
+        assertEquals("abcd", map3.min());
+        assertEquals("abcd", map3.min(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_throws_empty()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().min());
+        assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().min());
     }
 
     @Test
@@ -927,11 +934,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<Class\<?>\> map3 = this.newWithKeysValues(<(literal.(type))("5")>, <name>ObjectHashMap.class, <(literal.(type))("9")>, <name>ObjectHashMapTest.class);
 
         Function\<Class\<?>, Integer> classNameLength = (Class\<?> aClass) -> aClass.getName().length();
-        Assert.assertEquals(<name>ObjectHashMapTest.class, map1.maxBy(classNameLength));
-        Assert.assertEquals(<name>ObjectHashMapTest.class, map2.maxBy(classNameLength));
-        Assert.assertEquals(<name>ObjectHashMapTest.class, map3.maxBy(classNameLength));
+        assertEquals(<name>ObjectHashMapTest.class, map1.maxBy(classNameLength));
+        assertEquals(<name>ObjectHashMapTest.class, map2.maxBy(classNameLength));
+        assertEquals(<name>ObjectHashMapTest.class, map3.maxBy(classNameLength));
 
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.\<Class\<?>\>newMap().maxBy(classNameLength));
+        assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.\<Class\<?>\>newMap().maxBy(classNameLength));
     }
 
     @Test
@@ -941,16 +948,16 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "ab", <(literal.(type))("9")>, "abcd");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
-        Assert.assertEquals("z", map1.max());
-        Assert.assertEquals("abcd", map2.max());
-        Assert.assertEquals("zyx", map3.max());
-        Assert.assertEquals("zyx", map3.max(Comparators.naturalOrder()));
+        assertEquals("z", map1.max());
+        assertEquals("abcd", map2.max());
+        assertEquals("zyx", map3.max());
+        assertEquals("zyx", map3.max(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_throws_empty()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().max());
+        assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().max());
     }
 
     @Test
@@ -961,11 +968,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<Class\<?>\> map3 = this.newWithKeysValues(<(literal.(type))("5")>, <name>ObjectHashMap.class, <(literal.(type))("9")>, <name>ObjectHashMapTest.class);
 
         Function\<Class\<?>, Integer> classNameLength = (Class\<?> object) -> object.getName().length();
-        Assert.assertEquals(<name>ObjectHashMap.class, map1.minBy(classNameLength));
-        Assert.assertEquals(<name>ObjectHashMap.class, map2.minBy(classNameLength));
-        Assert.assertEquals(<name>ObjectHashMap.class, map3.minBy(classNameLength));
+        assertEquals(<name>ObjectHashMap.class, map1.minBy(classNameLength));
+        assertEquals(<name>ObjectHashMap.class, map2.minBy(classNameLength));
+        assertEquals(<name>ObjectHashMap.class, map3.minBy(classNameLength));
 
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.\<Class\<?>\>newMap().minBy(classNameLength));
+        assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.\<Class\<?>\>newMap().minBy(classNameLength));
     }
 
     @Test
@@ -976,9 +983,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
         IntFunction\<String> function = StringFunctions.length();
-        Assert.assertEquals(5L, map1.sumOfInt(function));
-        Assert.assertEquals(6L, map2.sumOfInt(function));
-        Assert.assertEquals(7L, map3.sumOfInt(function));
+        assertEquals(5L, map1.sumOfInt(function));
+        assertEquals(6L, map2.sumOfInt(function));
+        assertEquals(7L, map3.sumOfInt(function));
     }
 
     @Test
@@ -989,9 +996,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
         LongFunction\<String> function = String::length;
-        Assert.assertEquals(5L, map1.sumOfLong(function));
-        Assert.assertEquals(6L, map2.sumOfLong(function));
-        Assert.assertEquals(7L, map3.sumOfLong(function));
+        assertEquals(5L, map1.sumOfLong(function));
+        assertEquals(6L, map2.sumOfLong(function));
+        assertEquals(7L, map3.sumOfLong(function));
     }
 
     @Test
@@ -1002,9 +1009,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
         DoubleFunction\<String> function = String::length;
-        Assert.assertEquals(5.0, map1.sumOfDouble(function), 0.0);
-        Assert.assertEquals(6.0, map2.sumOfDouble(function), 0.0);
-        Assert.assertEquals(7.0, map3.sumOfDouble(function), 0.0);
+        assertEquals(5.0, map1.sumOfDouble(function), 0.0);
+        assertEquals(6.0, map2.sumOfDouble(function), 0.0);
+        assertEquals(7.0, map3.sumOfDouble(function), 0.0);
     }
 
     @Test
@@ -1015,9 +1022,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
         FloatFunction\<String> function = String::length;
-        Assert.assertEquals(5.0, map1.sumOfFloat(function), 0.0);
-        Assert.assertEquals(6.0, map2.sumOfFloat(function), 0.0);
-        Assert.assertEquals(7.0, map3.sumOfFloat(function), 0.0);
+        assertEquals(5.0, map1.sumOfFloat(function), 0.0);
+        assertEquals(6.0, map2.sumOfFloat(function), 0.0);
+        assertEquals(7.0, map3.sumOfFloat(function), 0.0);
     }
 
     @Test
@@ -1025,8 +1032,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         RichIterable\<String> values = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>, "3");
         ObjectLongMap\<Integer> result = values.sumByInt(s -> Integer.parseInt(s) % 2, Integer::parseInt);
-        Assert.assertEquals(4, result.get(1));
-        Assert.assertEquals(2, result.get(0));
+        assertEquals(4, result.get(1));
+        assertEquals(2, result.get(0));
     }
 
     @Test
@@ -1034,8 +1041,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         RichIterable\<String> values = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>, "3");
         ObjectDoubleMap\<Integer> result = values.sumByFloat(s -> Integer.parseInt(s) % 2, Float::parseFloat);
-        Assert.assertEquals(4.0f, result.get(1), 0.0);
-        Assert.assertEquals(2.0f, result.get(0), 0.0);
+        assertEquals(4.0f, result.get(1), 0.0);
+        assertEquals(2.0f, result.get(0), 0.0);
     }
 
     @Test
@@ -1043,8 +1050,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         RichIterable\<String> values = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>, "3");
         ObjectLongMap\<Integer> result = values.sumByLong(s -> Integer.parseInt(s) % 2, Long::parseLong);
-        Assert.assertEquals(4, result.get(1));
-        Assert.assertEquals(2, result.get(0));
+        assertEquals(4, result.get(1));
+        assertEquals(2, result.get(0));
     }
 
     @Test
@@ -1052,15 +1059,15 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         RichIterable\<String> values = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>, "3");
         ObjectDoubleMap\<Integer> result = values.sumByDouble(s -> Integer.parseInt(s) % 2, Double::parseDouble);
-        Assert.assertEquals(4.0d, result.get(1), 0.0);
-        Assert.assertEquals(2.0d, result.get(0), 0.0);
+        assertEquals(4.0d, result.get(1), 0.0);
+        assertEquals(2.0d, result.get(0), 0.0);
     }
 
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().keysView().toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWithKeysValues(<(literal.(type))("1")>, "one").keysView().toList());
+        assertEquals(<name>ArrayList.newListWith(), this.getEmptyMap().keysView().toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWithKeysValues(<(literal.(type))("1")>, "one").keysView().toList());
     }
 
     @Test
@@ -1071,26 +1078,26 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
                 map1.reject((<type> value, String object) -> (value % 2) == 0));
 
         <name>ObjectPredicate\<String> keyLessThanSeven = (<type> value, String object) -> value > 7;
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), map1.reject(keyLessThanSeven));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), map2.reject(keyLessThanSeven));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map3.reject(keyLessThanSeven));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("5")>, "five"), map4.reject(keyLessThanSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), map1.reject(keyLessThanSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), map2.reject(keyLessThanSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map3.reject(keyLessThanSeven));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("5")>, "five"), map4.reject(keyLessThanSeven));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine"),
                 map1.reject((<type> value, String object) -> !object.endsWith("ne")));
 
         RichIterable\<String> actual1 = map1.reject(StringPredicates.endsWith("ne").not());
-        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not()));
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not()));
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not(), HashBag.\<String>newBag()));
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.reject(StringPredicates.endsWith("ne").not(), HashBag.\<String>newBag()));
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not(), HashBag.\<String>newBag()));
+        assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
+        assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not()));
+        assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not()));
+        assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not(), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.reject(StringPredicates.endsWith("ne").not(), HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -1098,9 +1105,9 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne"));
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine"));
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o"));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne"));
+        assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine"));
+        assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o"));
     }
 
     @Test
@@ -1108,9 +1115,9 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne", HashBag.\<String>newBag()));
-        Assert.assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine", HashBag.\<String>newBag()));
-        Assert.assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine", HashBag.\<String>newBag()));
+        assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o", HashBag.\<String>newBag()));
     }
 
     @Test
@@ -1120,8 +1127,8 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Predicate\<String> endsWithNe = StringPredicates.endsWith("ne");
         PartitionIterable\<String> partition = map1.partition(endsWithNe);
-        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(partition.getSelected()));
-        Assert.assertEquals(HashBag.newBagWith("zero"), partition.getRejected());
+        assertTrue(HashBag.newBagWith("one", "nine").equals(partition.getSelected()));
+        assertEquals(HashBag.newBagWith("zero"), partition.getRejected());
     }
 
     @Test
@@ -1131,24 +1138,24 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Predicate2\<String, String> endsWith = StringPredicates2.endsWith();
         PartitionIterable\<String> partition = map1.partitionWith(endsWith, "ne");
-        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(partition.getSelected()));
-        Assert.assertEquals(HashBag.newBagWith("zero"), partition.getRejected());
+        assertTrue(HashBag.newBagWith("one", "nine").equals(partition.getSelected()));
+        assertEquals(HashBag.newBagWith("zero"), partition.getRejected());
     }
 
     @Test
     public void get()
     {
-        Assert.assertEquals("zero", this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertEquals("thirtyOne", this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertEquals("thirtyTwo", this.classUnderTest().get(<(literal.(type))("32")>));
+        assertEquals("zero", this.classUnderTest().get(<(literal.(type))("0")>));
+        assertEquals("thirtyOne", this.classUnderTest().get(<(literal.(type))("31")>));
+        assertEquals("thirtyTwo", this.classUnderTest().get(<(literal.(type))("32")>));
 
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
 
         <name>ObjectMap\<Object> emptyMap = this.getEmptyMap();
-        Assert.assertNull(emptyMap.get(<(literal.(type))("0")>));
-        Assert.assertNull(emptyMap.get(<(literal.(type))("1")>));
-        Assert.assertNull(emptyMap.get(<(literal.(type))("33")>));
+        assertNull(emptyMap.get(<(literal.(type))("0")>));
+        assertNull(emptyMap.get(<(literal.(type))("1")>));
+        assertNull(emptyMap.get(<(literal.(type))("33")>));
     }
 
     @Test
@@ -1156,37 +1163,37 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         Function0\<String> ifAbsent = () -> "ifAbsent";
 
-        Assert.assertEquals("zero", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
-        Assert.assertEquals("thirtyOne", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
-        Assert.assertEquals("thirtyTwo", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
+        assertEquals("zero", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("thirtyOne", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
+        assertEquals("thirtyTwo", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
 
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
 
         <name>ObjectMap\<Object> emptyMap = this.getEmptyMap();
-        Assert.assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("1")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("33")>, ifAbsent));
+        assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("1")>, ifAbsent));
+        assertEquals("ifAbsent", emptyMap.getIfAbsent(<(literal.(type))("33")>, ifAbsent));
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
     }
 
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(null));
-        Assert.assertTrue(this.classUnderTest().containsValue("zero"));
-        Assert.assertTrue(this.classUnderTest().containsValue("thirtyOne"));
-        Assert.assertTrue(this.classUnderTest().containsValue("thirtyTwo"));
+        assertFalse(this.classUnderTest().containsValue(null));
+        assertTrue(this.classUnderTest().containsValue("zero"));
+        assertTrue(this.classUnderTest().containsValue("thirtyOne"));
+        assertTrue(this.classUnderTest().containsValue("thirtyTwo"));
     }
 
     @Test
@@ -1203,10 +1210,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         map3.forEachValue((String each) -> concat[2] += each);
         map4.forEachValue((String each) -> concat[3] += each);
 
-        Assert.assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
-        Assert.assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
-        Assert.assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
-        Assert.assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
+        assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
+        assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
+        assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
+        assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
     }
 
     @Test
@@ -1223,10 +1230,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         map3.forEachKey((<type> each) -> sum[2] += each);
         map4.forEachKey((<type> each) -> sum[3] += each);
 
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, sum[1]<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("7")>, sum[2]<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, sum[3]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, sum[1]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("7")>, sum[2]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, sum[3]<(wideDelta.(type))>);
     }
 
     @Test
@@ -1259,10 +1266,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += parameter;
         });
 
-        Assert.assertTrue(concat[0], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("5")>five".equals(concat[0]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("1")>one".equals(concat[0]));
-        Assert.assertTrue(concat[1], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("0")>zero".equals(concat[1]) || "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("1")>one".equals(concat[1]));
-        Assert.assertTrue(concat[2], "<(toStringLiteral.(type))("2")>two<(toStringLiteral.(type))("5")>five".equals(concat[2]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("2")>two".equals(concat[2]));
-        Assert.assertTrue(concat[3], "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("5")>five".equals(concat[3]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("0")>zero".equals(concat[3]));
+        assertTrue(concat[0], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("5")>five".equals(concat[0]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("1")>one".equals(concat[0]));
+        assertTrue(concat[1], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("0")>zero".equals(concat[1]) || "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("1")>one".equals(concat[1]));
+        assertTrue(concat[2], "<(toStringLiteral.(type))("2")>two<(toStringLiteral.(type))("5")>five".equals(concat[2]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("2")>two".equals(concat[2]));
+        assertTrue(concat[3], "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("5")>five".equals(concat[3]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("0")>zero".equals(concat[3]));
     }
 
     @Test
@@ -1271,40 +1278,40 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map0 = this.newWithKeysValues(<(literal.(type))("2")>, "3", <(literal.(type))("4")>, "5");
 
         String result0 = map0.injectIntoKeyValue(new String("1"), (result, eachKey, eachValue) -> result + String.valueOf(eachKey) + eachValue);
-        Assert.assertTrue(result0, "1<(toStringLiteral.(type))("2")>3<(toStringLiteral.(type))("4")>5".equals(result0) || "1<(toStringLiteral.(type))("4")>5<(toStringLiteral.(type))("2")>3".equals(result0));
+        assertTrue(result0, "1<(toStringLiteral.(type))("2")>3<(toStringLiteral.(type))("4")>5".equals(result0) || "1<(toStringLiteral.(type))("4")>5<(toStringLiteral.(type))("2")>3".equals(result0));
 
         <name>ObjectMap copy = map0.injectIntoKeyValue(<name>ObjectMaps.mutable.empty(), Mutable<name>ObjectMap::withKeyValue);
-        Assert.assertEquals(map0, copy);
+        assertEquals(map0, copy);
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(0, this.getEmptyMap().size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(3, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("6")>, "six", <(literal.(type))("5")>, "five").size());
+        assertEquals(0, this.getEmptyMap().size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
+        assertEquals(3, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("6")>, "six", <(literal.(type))("5")>, "five").size());
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.getEmptyMap().isEmpty());
-        Assert.assertFalse(this.classUnderTest().isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, "one").isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("0")>, "zero").isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<(literal.(type))("50")>, "fifty").isEmpty());
+        assertTrue(this.getEmptyMap().isEmpty());
+        assertFalse(this.classUnderTest().isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("1")>, "one").isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("0")>, "zero").isEmpty());
+        assertFalse(this.newWithKeysValues(<(literal.(type))("50")>, "fifty").isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyMap().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, "one").notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("0")>, "zero").notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<(literal.(type))("50")>, "fifty").notEmpty());
+        assertFalse(this.getEmptyMap().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("1")>, "one").notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("0")>, "zero").notEmpty());
+        assertTrue(this.newWithKeysValues(<(literal.(type))("50")>, "fifty").notEmpty());
     }
 
     @Test
@@ -1315,11 +1322,11 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("2")>, "two", <(literal.(type))("5")>, "five");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five");
 
-        Assert.assertTrue(map1.getFirst(), "one".equals(map1.getFirst()) || "five".equals(map1.getFirst()));
-        Assert.assertTrue(map2.getFirst(), "one".equals(map2.getFirst()) || "zero".equals(map2.getFirst()));
-        Assert.assertTrue(map3.getFirst(), "two".equals(map3.getFirst()) || "five".equals(map3.getFirst()));
-        Assert.assertTrue(map4.getFirst(), "zero".equals(map4.getFirst()) || "five".equals(map4.getFirst()));
-        Assert.assertNull(<name>ObjectHashMap.newMap().getFirst());
+        assertTrue(map1.getFirst(), "one".equals(map1.getFirst()) || "five".equals(map1.getFirst()));
+        assertTrue(map2.getFirst(), "one".equals(map2.getFirst()) || "zero".equals(map2.getFirst()));
+        assertTrue(map3.getFirst(), "two".equals(map3.getFirst()) || "five".equals(map3.getFirst()));
+        assertTrue(map4.getFirst(), "zero".equals(map4.getFirst()) || "five".equals(map4.getFirst()));
+        assertNull(<name>ObjectHashMap.newMap().getFirst());
     }
 
     @Test
@@ -1330,101 +1337,101 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("2")>, "two", <(literal.(type))("5")>, "five");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five");
 
-        Assert.assertTrue(map1.getLast(), "one".equals(map1.getLast()) || "five".equals(map1.getLast()));
-        Assert.assertTrue(map2.getLast(), "one".equals(map2.getLast()) || "zero".equals(map2.getLast()));
-        Assert.assertTrue(map3.getLast(), "two".equals(map3.getLast()) || "five".equals(map3.getLast()));
-        Assert.assertTrue(map4.getLast(), "zero".equals(map4.getLast()) || "five".equals(map4.getLast()));
-        Assert.assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").getLast());
-        Assert.assertNull(<name>ObjectHashMap.newMap().getLast());
+        assertTrue(map1.getLast(), "one".equals(map1.getLast()) || "five".equals(map1.getLast()));
+        assertTrue(map2.getLast(), "one".equals(map2.getLast()) || "zero".equals(map2.getLast()));
+        assertTrue(map3.getLast(), "two".equals(map3.getLast()) || "five".equals(map3.getLast()));
+        assertTrue(map4.getLast(), "zero".equals(map4.getLast()) || "five".equals(map4.getLast()));
+        assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").getLast());
+        assertNull(<name>ObjectHashMap.newMap().getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").getOnly());
-        Assert.assertEquals("one", this.newWithKeysValues(<(literal.(type))("1")>, "one").getOnly());
-        Assert.assertEquals("two", this.newWithKeysValues(<(literal.(type))("2")>, "two").getOnly());
+        assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").getOnly());
+        assertEquals("one", this.newWithKeysValues(<(literal.(type))("1")>, "one").getOnly());
+        assertEquals("two", this.newWithKeysValues(<(literal.(type))("2")>, "two").getOnly());
     }
 
     @Test
     public void getOnly_empty_throws()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.getEmptyMap().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.getEmptyMap().getOnly());
     }
 
     @Test
     public void getOnly_not_only_one_throws()
     {
-        Assert.assertThrows(IllegalStateException.class, () ->
+        assertThrows(IllegalStateException.class, () ->
                 this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").getOnly());
     }
 
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(null));
-        Assert.assertTrue(this.classUnderTest().contains("zero"));
-        Assert.assertTrue(this.classUnderTest().contains("thirtyOne"));
-        Assert.assertTrue(this.classUnderTest().contains("thirtyTwo"));
+        assertFalse(this.classUnderTest().contains(null));
+        assertTrue(this.classUnderTest().contains("zero"));
+        assertTrue(this.classUnderTest().contains("thirtyOne"));
+        assertTrue(this.classUnderTest().contains("thirtyTwo"));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
     }
 
     @Test
     public void containsAnyIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("none")));
+        assertTrue(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("none")));
     }
 
     @Test
     public void containsAny()
     {
-        Assert.assertTrue(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith("none")));
+        assertTrue(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith("none")));
     }
 
     @Test
     public void containsNoneIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("none")));
+        assertFalse(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("none")));
     }
 
     @Test
     public void containsNone()
     {
-        Assert.assertFalse(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith("none")));
+        assertFalse(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith("none")));
     }
 
     @Test
     public void containsAllArguments()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
-        Assert.assertTrue(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
+        assertTrue(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
+        assertTrue(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
     }
 
     @Test
@@ -1449,58 +1456,58 @@ public abstract class Abstract<name>ObjectMapTestCase
         Verify.assertPostSerializedEqualsAndHashCode(map10);
         Verify.assertPostSerializedEqualsAndHashCode(<name>ObjectHashMap.newMap());
         Verify.assertEqualsAndHashCode(map1, map2);
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map1, map6);
-        Assert.assertNotEquals(map1, map7);
-        Assert.assertNotEquals(map8, map5);
-        Assert.assertNotEquals(map9, map8);
-        Assert.assertNotEquals(this.newWithKeysValues(<(literal.(type))("0")>, null), this.newWithKeysValues(<(literal.(type))("6")>, ""));
-        Assert.assertNotEquals(this.newWithKeysValues(<(literal.(type))("5")>, null), this.newWithKeysValues(<(literal.(type))("6")>, ""));
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map1, map6);
+        assertNotEquals(map1, map7);
+        assertNotEquals(map8, map5);
+        assertNotEquals(map9, map8);
+        assertNotEquals(this.newWithKeysValues(<(literal.(type))("0")>, null), this.newWithKeysValues(<(literal.(type))("6")>, ""));
+        assertNotEquals(this.newWithKeysValues(<(literal.(type))("5")>, null), this.newWithKeysValues(<(literal.(type))("6")>, ""));
 
-        Assert.assertEquals(map1, <name>ObjectMaps.mutable.ofAll(map1));
-        Assert.assertEquals(map1, <name>ObjectMaps.immutable.ofAll(map1));
+        assertEquals(map1, <name>ObjectMaps.mutable.ofAll(map1));
+        assertEquals(map1, <name>ObjectMaps.immutable.ofAll(map1));
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo").hashCode(), this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one").hashCode());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("1")>, null).hashCode(), this.newWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("1")>, null).hashCode());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("50")>, "zero", <(literal.(type))("60")>, "one", <(literal.(type))("70")>, "thirtyThree").hashCode(), this.newWithKeysValues(<(literal.(type))("50")>, "zero", <(literal.(type))("60")>, "one", <(literal.(type))("70")>, "thirtyThree").hashCode());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("50")>, null, <(literal.(type))("60")>, null).hashCode(), this.newWithKeysValues(<(literal.(type))("50")>, null, <(literal.(type))("60")>, null).hashCode());
-        Assert.assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
+        assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo").hashCode(), this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one").hashCode());
+        assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("1")>, null).hashCode(), this.newWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("1")>, null).hashCode());
+        assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("50")>, "zero", <(literal.(type))("60")>, "one", <(literal.(type))("70")>, "thirtyThree").hashCode(), this.newWithKeysValues(<(literal.(type))("50")>, "zero", <(literal.(type))("60")>, "one", <(literal.(type))("70")>, "thirtyThree").hashCode());
+        assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type))("50")>, null, <(literal.(type))("60")>, null).hashCode(), this.newWithKeysValues(<(literal.(type))("50")>, null, <(literal.(type))("60")>, null).hashCode());
+        assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.getEmptyMap().toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("0")>=zero}", this.newWithKeysValues(<(literal.(type))("0")>, "zero").toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("1")>=one}", this.newWithKeysValues(<(literal.(type))("1")>, "one").toString());
-        Assert.assertEquals("{<(toStringLiteral.(type))("5")>=five}", this.newWithKeysValues(<(literal.(type))("5")>, "five").toString());
+        assertEquals("{}", this.getEmptyMap().toString());
+        assertEquals("{<(toStringLiteral.(type))("0")>=zero}", this.newWithKeysValues(<(literal.(type))("0")>, "zero").toString());
+        assertEquals("{<(toStringLiteral.(type))("1")>=one}", this.newWithKeysValues(<(literal.(type))("1")>, "one").toString());
+        assertEquals("{<(toStringLiteral.(type))("5")>=five}", this.newWithKeysValues(<(literal.(type))("5")>, "five").toString());
 
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
-        Assert.assertTrue(
+        assertTrue(
                 map1.toString(),
                 "{<(toStringLiteral.(type))("0")>=zero, <(toStringLiteral.(type))("1")>=one}".equals(map1.toString())
                         || "{<(toStringLiteral.(type))("1")>=one, <(toStringLiteral.(type))("0")>=zero}".equals(map1.toString()));
 
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertTrue(
+        assertTrue(
                 map2.toString(),
                 "{<(toStringLiteral.(type))("1")>=one, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map2.toString())
                         || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("1")>=one}".equals(map2.toString()));
 
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertTrue(
+        assertTrue(
                 map3.toString(),
                 "{<(toStringLiteral.(type))("0")>=zero, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map3.toString())
                         || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("0")>=zero}".equals(map3.toString()));
 
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("33")>, "thirtyThree");
-        Assert.assertTrue(
+        assertTrue(
                 map4.toString(),
                 "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("33")>=thirtyThree}".equals(map4.toString())
                         || "{<(toStringLiteral.(type))("33")>=thirtyThree, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map4.toString()));
@@ -1515,11 +1522,11 @@ public abstract class Abstract<name>ObjectMapTestCase
                 .zip(FastList.newListWith(1));
         RichIterable\<Pair\<String, Integer>\> zip3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five")
                 .zip(FastList.newListWith(1), FastList.\<Pair\<String, Integer>\>newList());
-        Assert.assertTrue(HashBag.newBagWith(Tuples.pair("zero", 0), Tuples.pair("five", 5)).equals(zip1)
+        assertTrue(HashBag.newBagWith(Tuples.pair("zero", 0), Tuples.pair("five", 5)).equals(zip1)
                 || HashBag.newBagWith(Tuples.pair("five", 0), Tuples.pair("zero", 5)).equals(zip1));
-        Assert.assertTrue(HashBag.newBagWith(Tuples.pair("one", 1)).equals(zip2)
+        assertTrue(HashBag.newBagWith(Tuples.pair("one", 1)).equals(zip2)
                 || HashBag.newBagWith(Tuples.pair("five", 1)).equals(zip2));
-        Assert.assertTrue(FastList.newListWith(Tuples.pair("one", 1)).equals(zip3)
+        assertTrue(FastList.newListWith(Tuples.pair("one", 1)).equals(zip3)
                 || FastList.newListWith(Tuples.pair("five", 1)).equals(zip3));
     }
 
@@ -1532,11 +1539,11 @@ public abstract class Abstract<name>ObjectMapTestCase
                 .zipWithIndex();
         RichIterable\<Pair\<String, Integer>\> zip3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five")
                 .zipWithIndex(FastList.\<Pair\<String, Integer>\>newList());
-        Assert.assertTrue(UnifiedSet.newSetWith(Tuples.pair("zero", 0), Tuples.pair("five", 1)).equals(zip1)
+        assertTrue(UnifiedSet.newSetWith(Tuples.pair("zero", 0), Tuples.pair("five", 1)).equals(zip1)
                 || UnifiedSet.newSetWith(Tuples.pair("five", 0), Tuples.pair("zero", 1)).equals(zip1));
-        Assert.assertTrue(UnifiedSet.newSetWith(Tuples.pair("one", 0), Tuples.pair("five", 1)).equals(zip2)
+        assertTrue(UnifiedSet.newSetWith(Tuples.pair("one", 0), Tuples.pair("five", 1)).equals(zip2)
                 || UnifiedSet.newSetWith(Tuples.pair("five", 0), Tuples.pair("one", 1)).equals(zip2));
-        Assert.assertTrue(FastList.newListWith(Tuples.pair("one", 0), Tuples.pair("five", 1)).equals(zip3)
+        assertTrue(FastList.newListWith(Tuples.pair("one", 0), Tuples.pair("five", 1)).equals(zip3)
                 || FastList.newListWith(Tuples.pair("five", 0), Tuples.pair("one", 1)).equals(zip3));
     }
 
@@ -1547,23 +1554,23 @@ public abstract class Abstract<name>ObjectMapTestCase
                 .chunk(1);
         RichIterable\<RichIterable\<String>\> chunk2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five")
                 .chunk(1);
-        Assert.assertTrue(FastList.newListWith(FastList.newListWith("zero"), FastList.newListWith("five")).equals(chunk1)
+        assertTrue(FastList.newListWith(FastList.newListWith("zero"), FastList.newListWith("five")).equals(chunk1)
                 || FastList.newListWith(FastList.newListWith("five"), FastList.newListWith("zero")).equals(chunk1));
-        Assert.assertTrue(FastList.newListWith(FastList.newListWith("one"), FastList.newListWith("five")).equals(chunk2)
+        assertTrue(FastList.newListWith(FastList.newListWith("one"), FastList.newListWith("five")).equals(chunk2)
                 || FastList.newListWith(FastList.newListWith("five"), FastList.newListWith("one")).equals(chunk2));
     }
 
     @Test
     public void chunk_throws_negative_size()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
+        assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
                 .chunk(-1));
     }
 
     @Test
     public void chunk_throws_zero_size()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
+        assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
                 .chunk(0));
     }
 
@@ -1574,9 +1581,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         Procedure2\<AtomicInteger, Integer> sumAggregator = AtomicInteger::addAndGet;
         <name>ObjectMap\<Integer> collection = this.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
         MapIterable\<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Test
@@ -1586,9 +1593,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         Function2\<Integer, Integer, Integer> sumAggregator = (Integer aggregate, Integer value) -> aggregate + value;
         <name>ObjectMap\<Integer> collection = this.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
         MapIterable\<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Test
@@ -1611,19 +1618,19 @@ public abstract class Abstract<name>ObjectMapTestCase
         Multimap\<Character, String> actual5 = map3.groupBy(firstChar, FastListMultimap.\<Character, String>newMultimap());
 
         Verify.assertSize(expected1.size(), actual1);
-        expected1.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual1.containsKeyAndValue(argument1, argument2)));
+        expected1.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual1.containsKeyAndValue(argument1, argument2)));
 
         Verify.assertSize(expected2.size(), actual2);
-        expected2.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual2.containsKeyAndValue(argument1, argument2)));
+        expected2.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual2.containsKeyAndValue(argument1, argument2)));
 
         Verify.assertSize(expected2.size(), actual3);
-        expected2.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual3.containsKeyAndValue(argument1, argument2)));
+        expected2.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual3.containsKeyAndValue(argument1, argument2)));
 
         Verify.assertSize(expected4.size(), actual4);
-        expected4.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual4.containsKeyAndValue(argument1, argument2)));
+        expected4.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual4.containsKeyAndValue(argument1, argument2)));
 
         Verify.assertSize(expected4.size(), actual5);
-        expected4.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual5.containsKeyAndValue(argument1, argument2)));
+        expected4.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual5.containsKeyAndValue(argument1, argument2)));
     }
 
     @Test
@@ -1651,13 +1658,13 @@ public abstract class Abstract<name>ObjectMapTestCase
         Multimap\<Character, String> actual2 = map2.groupByEach(toChars);
         Multimap\<Character, String> actual3 = map2.groupByEach(toChars, FastListMultimap.\<Character, String>newMultimap());
 
-        expected.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual.containsKeyAndValue(argument1, argument2)));
+        expected.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual.containsKeyAndValue(argument1, argument2)));
 
-        expected.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual1.containsKeyAndValue(argument1, argument2)));
+        expected.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual1.containsKeyAndValue(argument1, argument2)));
 
-        expected2.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual2.containsKeyAndValue(argument1, argument2)));
+        expected2.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual2.containsKeyAndValue(argument1, argument2)));
 
-        expected2.forEachKeyValue((Character argument1, String argument2) -> Assert.assertTrue(actual3.containsKeyAndValue(argument1, argument2)));
+        expected2.forEachKeyValue((Character argument1, String argument2) -> assertTrue(actual3.containsKeyAndValue(argument1, argument2)));
     }
 
     @Test
@@ -1667,8 +1674,8 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("2")>, "two");
 
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 'o', "one", 't', "two"), map1.groupByUniqueKey(firstChar));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues('t', "two"), map2.groupByUniqueKey(firstChar));
+        assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 'o', "one", 't', "two"), map1.groupByUniqueKey(firstChar));
+        assertEquals(UnifiedMap.newWithKeysValues('t', "two"), map2.groupByUniqueKey(firstChar));
     }
 
     @Test
@@ -1676,7 +1683,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Function\<String, Character> firstChar = (String object) -> 'a';
-        Assert.assertThrows(IllegalStateException.class, () -> map1.groupByUniqueKey(firstChar));
+        assertThrows(IllegalStateException.class, () -> map1.groupByUniqueKey(firstChar));
     }
 
     @Test
@@ -1685,8 +1692,8 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("0")>, "zero");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 'o', "one", 't', "two"), map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 't', "two"), map2.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
+        assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 'o', "one", 't', "two"), map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
+        assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 't', "two"), map2.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
     }
 
     @Test
@@ -1694,7 +1701,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        Assert.assertThrows(IllegalStateException.class, () ->
+        assertThrows(IllegalStateException.class, () ->
                 map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero")));
     }
 
@@ -1703,7 +1710,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        Assert.assertThrows(IllegalStateException.class, () ->
+        assertThrows(IllegalStateException.class, () ->
                 map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero")));
     }
 
@@ -1712,38 +1719,38 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("2")>, "two");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        Assert.assertThrows(IllegalStateException.class, () ->
+        assertThrows(IllegalStateException.class, () ->
                 map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", this.getEmptyMap().makeString());
-        Assert.assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").makeString());
-        Assert.assertEquals("one", this.newWithKeysValues(<(literal.(type))("1")>, "one").makeString());
-        Assert.assertEquals("five", this.newWithKeysValues(<(literal.(type))("5")>, "five").makeString());
+        assertEquals("", this.getEmptyMap().makeString());
+        assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").makeString());
+        assertEquals("one", this.newWithKeysValues(<(literal.(type))("1")>, "one").makeString());
+        assertEquals("five", this.newWithKeysValues(<(literal.(type))("5")>, "five").makeString());
 
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
-        Assert.assertTrue(
+        assertTrue(
                 map1.makeString(),
                 "zero, one".equals(map1.makeString())
                         || "one, zero".equals(map1.makeString()));
 
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("[", "/", "]"),
                 "[one/thirtyTwo]".equals(map2.makeString("[", "/", "]"))
                         || "[thirtyTwo/one]".equals(map2.makeString("[", "/", "]")));
 
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertTrue(
+        assertTrue(
                 map3.makeString("~"),
                 "zero~thirtyTwo".equals(map3.makeString("~"))
                         || "thirtyTwo~zero".equals(map3.makeString("~")));
 
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("33")>, "thirtyThree");
-        Assert.assertTrue(
+        assertTrue(
                 map4.makeString("[", ", ", "]"),
                 "[thirtyTwo, thirtyThree]".equals(map4.makeString("[", ", ", "]"))
                         || "[thirtyThree, thirtyTwo]".equals(map4.makeString("[", ", ", "]")));
@@ -1754,24 +1761,24 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         Appendable appendable = new StringBuilder();
         this.getEmptyMap().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         Appendable appendable0 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("0")>, "zero").appendString(appendable0);
-        Assert.assertEquals("zero", appendable0.toString());
+        assertEquals("zero", appendable0.toString());
 
         Appendable appendable1 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("1")>, "one").appendString(appendable1);
-        Assert.assertEquals("one", appendable1.toString());
+        assertEquals("one", appendable1.toString());
 
         Appendable appendable2 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type))("5")>, "five").appendString(appendable2);
-        Assert.assertEquals("five", appendable2.toString());
+        assertEquals("five", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         map1.appendString(appendable3);
-        Assert.assertTrue(
+        assertTrue(
                 appendable3.toString(),
                 "zero, one".equals(appendable3.toString())
                         || "one, zero".equals(appendable3.toString()));
@@ -1779,7 +1786,7 @@ public abstract class Abstract<name>ObjectMapTestCase
         Appendable appendable4 = new StringBuilder();
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         map2.appendString(appendable4, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable4.toString(),
                 "[one/thirtyTwo]".equals(appendable4.toString())
                         || "[thirtyTwo/one]".equals(appendable4.toString()));
@@ -1787,14 +1794,14 @@ public abstract class Abstract<name>ObjectMapTestCase
         Appendable appendable5 = new StringBuilder();
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         map3.appendString(appendable5, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable5.toString(),
                 "[one/thirtyTwo]".equals(appendable5.toString())
                         || "[thirtyTwo/one]".equals(appendable5.toString()));
 
         Appendable appendable6 = new StringBuilder();
         map3.appendString(appendable6, "/");
-        Assert.assertTrue(
+        assertTrue(
                 appendable6.toString(),
                 "one/thirtyTwo".equals(appendable6.toString())
                         || "thirtyTwo/one".equals(appendable6.toString()));
@@ -1814,15 +1821,15 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("2")>, "two", <(literal.(type))("5")>, "five");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five");
 
-        Assert.assertSame(map1, map1.tap(concat[0]::append));
-        Assert.assertSame(map2, map2.tap(concat[1]::append));
-        Assert.assertSame(map3, map3.tap(concat[2]::append));
-        Assert.assertSame(map4, map4.tap(concat[3]::append));
+        assertSame(map1, map1.tap(concat[0]::append));
+        assertSame(map2, map2.tap(concat[1]::append));
+        assertSame(map3, map3.tap(concat[2]::append));
+        assertSame(map4, map4.tap(concat[3]::append));
 
-        Assert.assertTrue(concat[0].toString(), "onefive".equals(concat[0].toString()) || "fiveone".equals(concat[0].toString()));
-        Assert.assertTrue(concat[1].toString(), "onezero".equals(concat[1].toString()) || "zeroone".equals(concat[1].toString()));
-        Assert.assertTrue(concat[2].toString(), "twofive".equals(concat[2].toString()) || "fivetwo".equals(concat[2].toString()));
-        Assert.assertTrue(concat[3].toString(), "zerofive".equals(concat[3].toString()) || "fivezero".equals(concat[3].toString()));
+        assertTrue(concat[0].toString(), "onefive".equals(concat[0].toString()) || "fiveone".equals(concat[0].toString()));
+        assertTrue(concat[1].toString(), "onezero".equals(concat[1].toString()) || "zeroone".equals(concat[1].toString()));
+        assertTrue(concat[2].toString(), "twofive".equals(concat[2].toString()) || "fivetwo".equals(concat[2].toString()));
+        assertTrue(concat[3].toString(), "zerofive".equals(concat[3].toString()) || "fivezero".equals(concat[3].toString()));
     }
 
     @Test
@@ -1839,10 +1846,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         map3.forEach(Procedures.cast(each -> concat[2] += each));
         map4.forEach(Procedures.cast(each -> concat[3] += each));
 
-        Assert.assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
-        Assert.assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
-        Assert.assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
-        Assert.assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
+        assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
+        assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
+        assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
+        assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
     }
 
     @Test
@@ -1875,10 +1882,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += parameter;
         });
 
-        Assert.assertTrue(concat[0], "one0five1".equals(concat[0]) || "five0one1".equals(concat[0]));
-        Assert.assertTrue(concat[1], "one0zero1".equals(concat[1]) || "zero0one1".equals(concat[1]));
-        Assert.assertTrue(concat[2], "two0five1".equals(concat[2]) || "five0two1".equals(concat[2]));
-        Assert.assertTrue(concat[3], "zero0five1".equals(concat[3]) || "five0zero1".equals(concat[3]));
+        assertTrue(concat[0], "one0five1".equals(concat[0]) || "five0one1".equals(concat[0]));
+        assertTrue(concat[1], "one0zero1".equals(concat[1]) || "zero0one1".equals(concat[1]));
+        assertTrue(concat[2], "two0five1".equals(concat[2]) || "five0two1".equals(concat[2]));
+        assertTrue(concat[3], "zero0five1".equals(concat[3]) || "five0zero1".equals(concat[3]));
     }
 
     @Test
@@ -1911,10 +1918,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += argument2;
         }, "-");
 
-        Assert.assertTrue(concat[0], "one-five-".equals(concat[0]) || "five-one-".equals(concat[0]));
-        Assert.assertTrue(concat[1], "one-zero-".equals(concat[1]) || "zero-one-".equals(concat[1]));
-        Assert.assertTrue(concat[2], "two-five-".equals(concat[2]) || "five-two-".equals(concat[2]));
-        Assert.assertTrue(concat[3], "zero-five-".equals(concat[3]) || "five-zero-".equals(concat[3]));
+        assertTrue(concat[0], "one-five-".equals(concat[0]) || "five-one-".equals(concat[0]));
+        assertTrue(concat[1], "one-zero-".equals(concat[1]) || "zero-one-".equals(concat[1]));
+        assertTrue(concat[2], "two-five-".equals(concat[2]) || "five-two-".equals(concat[2]));
+        assertTrue(concat[3], "zero-five-".equals(concat[3]) || "five-zero-".equals(concat[3]));
     }
 
     @Test
@@ -1924,22 +1931,22 @@ public abstract class Abstract<name>ObjectMapTestCase
         MutableSet\<String> actual = UnifiedSet.newSet();
 
         Iterator\<String> iterator = this.classUnderTest().iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(Immutable<name>ObjectMap.class, this.classUnderTest().toImmutable());
     }
 
@@ -1965,16 +1972,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     public void stream()
     {
         <name>ObjectMap\<String> map = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("9")>, "9");
-        Assert.assertEquals("129", CharAdapter.adapt(map.stream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
-        Assert.assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
+        assertEquals("129", CharAdapter.adapt(map.stream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
+        assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
     }
 
     @Test
     public void parallelStream()
     {
         <name>ObjectMap\<String> map = this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("9")>, "9");
-        Assert.assertEquals("129", CharAdapter.adapt(map.parallelStream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
-        Assert.assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
+        assertEquals("129", CharAdapter.adapt(map.parallelStream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
+        assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
@@ -78,8 +78,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name1><name2>Map#keyValuesView()}.
@@ -119,16 +124,16 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void containsAllIterable()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>))));
-        Assert.assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("5")>))));
+        assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>))));
+        assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("5")>))));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
-        Assert.assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("5")>)));
+        assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("5")>)));
     }
 
     @Test
@@ -159,8 +164,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
             result2.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("0")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result2);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("0")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
+        assertEquals(Bags.immutable.of(0, 0, 0), result2);
 
         MutableBag\<<name1><name2>Pair> result3 = Bags.mutable.of();
         MutableBag\<Integer> result4 = Bags.mutable.of();
@@ -171,8 +176,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
             result4.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>), PrimitiveTuples.pair(<(literal.(type1))("6")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result3);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result4);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>), PrimitiveTuples.pair(<(literal.(type1))("6")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result3);
+        assertEquals(Bags.immutable.of(0, 0, 0), result4);
     }
 
     @Test
@@ -186,8 +191,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("6")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("6")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes);
 
         MutableBag\<<name1><name2>Pair> elements2 = Bags.mutable.of();
         MutableBag\<Integer> indexes2 = Bags.mutable.of();
@@ -197,8 +202,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
             elements2.add(object);
             indexes2.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), elements2);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes2);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), elements2);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes2);
     }
 
     @Test
@@ -223,7 +228,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void selectWith_target()
     {
         HashBag\<<name1><name2>Pair> result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).selectWith(Predicates2.notEqual(), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), HashBag.\<<name1><name2>Pair>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
     }
 
     @Test
@@ -248,7 +253,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void rejectWith_target()
     {
         HashBag\<<name1><name2>Pair> result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).rejectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), HashBag.\<<name1><name2>Pair>newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), result);
     }
 
     @Test
@@ -264,66 +269,66 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<Integer> result1 =
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collect((<name1><name2>Pair object) -> (int) object.getOne());
-        Assert.assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
+        assertEquals(Bags.immutable.of(1, 2, 3), result1.toBag());
         RichIterable\<Long> result2 =
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collect((<name1><name2>Pair object) -> (long) object.getTwo());
-        Assert.assertEquals(Bags.immutable.of(2L, 3L, 4L), result2.toBag());
+        assertEquals(Bags.immutable.of(2L, 3L, 4L), result2.toBag());
     }
 
     @Test
     public void collectBoolean()
     {
         BooleanIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectBoolean((<name1><name2>Pair each) -> (each.getOne() % 2) == 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, false), result.toBag());
     }
 
     @Test
     public void collectByte()
     {
         ByteIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectByte((<name1><name2>Pair anObject) -> (byte) anObject.getOne());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
     }
 
     @Test
     public void collectChar()
     {
         CharIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectChar((<name1><name2>Pair anObject) -> (char) anObject.getOne());
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3), result.toBag());
     }
 
     @Test
     public void collectDouble()
     {
         DoubleIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectDouble((<name1><name2>Pair anObject) -> (double) anObject.getOne());
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
+        assertEquals(DoubleHashBag.newBagWith(1.0, 2.0, 3.0), result.toBag());
     }
 
     @Test
     public void collectFloat()
     {
         FloatIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectFloat((<name1><name2>Pair anObject) -> (float) anObject.getOne());
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
     }
 
     @Test
     public void collectInt()
     {
         IntIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectInt((<name1><name2>Pair anObject) -> (int) anObject.getOne());
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
     }
 
     @Test
     public void collectLong()
     {
         LongIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectLong((<name1><name2>Pair anObject) -> (long) anObject.getOne());
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
+        assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
     }
 
     @Test
     public void collectShort()
     {
         ShortIterable result = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectShort((<name1><name2>Pair anObject) -> (short) anObject.getOne());
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
     }
 
     @Test
@@ -344,84 +349,84 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detect(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
-        Assert.assertNull(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detect(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("4")>)::equals));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detect(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
+        assertNull(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detect(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("4")>)::equals));
     }
 
     @Test
     public void min_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).min(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).max(Comparators.naturalOrder()));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).max(Comparators.naturalOrder()));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).minBy((<name1><name2>Pair object) -> (int) object.getOne() & 1));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).minBy((<name1><name2>Pair object) -> (int) object.getOne() & 1));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>).maxBy((<name1><name2>Pair object) -> (int) object.getOne() & 1));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>).maxBy((<name1><name2>Pair object) -> (int) object.getOne() & 1));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
-        Assert.assertNull(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(2, 4L)));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertNull(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWith(Object::equals, PrimitiveTuples.pair(2, 4L)));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0\<<name1><name2>Pair> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type1))("5")>, <(literal.(type2))("6")>));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectIfNone(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals, function));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("5")>, <(literal.(type2))("6")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectIfNone(PrimitiveTuples.pair(2, 4L)::equals, function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectIfNone(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals, function));
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("5")>, <(literal.(type2))("6")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectIfNone(PrimitiveTuples.pair(2, 4L)::equals, function));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0\<<name1><name2>Pair> function = Functions0.value(PrimitiveTuples.pair(<(literal.(type1))("5")>, <(literal.(type2))("6")>));
-        Assert.assertEquals(
+        assertEquals(
                 PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>),
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWithIfNone(
                         Object::equals,
                         PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>),
                         function));
-        Assert.assertEquals(
+        assertEquals(
                 PrimitiveTuples.pair(<(literal.(type1))("5")>, <(literal.(type2))("6")>),
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detectWithIfNone(
                         Object::equals,
@@ -432,59 +437,59 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfy(<name1><name2>Pair.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfy(<name1><name2>Pair.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfyWith(Predicates2.instanceOf(), <name1><name2>Pair.class));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfyWith(Predicates2.instanceOf(), <name1><name2>Pair.class));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).allSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>)::equals));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfy(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>)::equals));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
-        Assert.assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>)));
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertFalse(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).anySatisfyWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("5")>)));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(Boolean.class::isInstance));
-        Assert.assertEquals(3, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(<name1><name2>Pair.class::isInstance));
-        Assert.assertEquals(1, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
+        assertEquals(0, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(Boolean.class::isInstance));
+        assertEquals(3, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(<name1><name2>Pair.class::isInstance));
+        assertEquals(1, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).count(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)::equals));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertEquals(3, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Predicates2.instanceOf(), <name1><name2>Pair.class));
-        Assert.assertEquals(1, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertEquals(0, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Predicates2.instanceOf(), Boolean.class));
+        assertEquals(3, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Predicates2.instanceOf(), <name1><name2>Pair.class));
+        assertEquals(1, this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).countWith(Object::equals, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
     }
 
     @Test
@@ -506,7 +511,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(4L, 6L, 8L),
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectWith((<name1><name2>Pair argument1, Long argument2) -> (long) (argument1.getOne() + argument1.getTwo() + argument2), 1L).toBag());
     }
@@ -514,7 +519,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(4L, 6L, 8L),
                 this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).collectWith((<name1><name2>Pair argument1, Long argument2) -> (long) (argument1.getOne() + argument1.getTwo() + argument2), 1L, HashBag.\<Long>newBag()));
     }
@@ -523,20 +528,20 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void getFirst()
     {
         <name1><name2>Pair first = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).getFirst();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(first)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>).equals(first)
                 || PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>).equals(first));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getFirst());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getFirst());
     }
 
     @Test
     public void getLast()
     {
         <name1><name2>Pair last = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).getLast();
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(last)
+        assertTrue(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>).equals(last)
                 || PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>).equals(last));
-        Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getLast());
+        assertEquals(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getLast());
     }
 
     @Test
@@ -544,7 +549,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
-        Assert.assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).notEmpty());
+        assertTrue(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>).notEmpty());
     }
 
     @Test
@@ -555,11 +560,11 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Iterator\<<name1><name2>Pair> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -570,11 +575,11 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Iterator\<<name1><name2>Pair> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test
@@ -584,11 +589,11 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Iterator\<<name1><name2>Pair> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -596,7 +601,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Iterator\<<name1><name2>Pair> iterator = objects.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+        assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -604,7 +609,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Long result = objects.injectInto(1L, (Long argument1, <name1><name2>Pair argument2) -> (long) (argument1 + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(Long.valueOf(16), result);
+        assertEquals(Long.valueOf(16), result);
     }
 
     @Test
@@ -612,7 +617,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         int result = objects.injectInto(1, (int intParameter, <name1><name2>Pair argument2) -> (int) (intParameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16, result);
+        assertEquals(16, result);
     }
 
     @Test
@@ -620,7 +625,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         long result = objects.injectInto(1L, (long parameter, <name1><name2>Pair argument2) -> (long) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16, result);
+        assertEquals(16, result);
     }
 
     @Test
@@ -628,7 +633,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         double result = objects.injectInto(1.0, (double parameter, <name1><name2>Pair argument2) -> (double) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16.0, result, 0.0);
+        assertEquals(16.0, result, 0.0);
     }
 
     @Test
@@ -636,7 +641,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         float result = objects.injectInto(1.0f, (float parameter, <name1><name2>Pair argument2) -> (float) (parameter + argument2.getOne() + argument2.getTwo()));
-        Assert.assertEquals(16.0, result, 0.0);
+        assertEquals(16.0, result, 0.0);
     }
 
     @Test
@@ -644,7 +649,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         double actual = objects.sumOfFloat((<name1><name2>Pair each) -> (float) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15.0, actual, 0.0);
+        assertEquals(15.0, actual, 0.0);
     }
 
     @Test
@@ -652,7 +657,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         double actual = objects.sumOfDouble((<name1><name2>Pair each) -> (double) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15.0, actual, 0.0);
+        assertEquals(15.0, actual, 0.0);
     }
 
     @Test
@@ -660,7 +665,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         long actual = objects.sumOfInt((<name1><name2>Pair each) -> (int) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15, actual);
+        assertEquals(15, actual);
     }
 
     @Test
@@ -668,7 +673,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         long actual = objects.sumOfLong((<name1><name2>Pair each) -> (long) (each.getOne() + each.getTwo()));
-        Assert.assertEquals(15, actual);
+        assertEquals(15, actual);
     }
 
     @Test
@@ -711,7 +716,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableList\<<name1><name2>Pair> list = pairs.toSortedList();
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), list);
     }
 
     @Test
@@ -719,7 +724,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableList\<<name1><name2>Pair> list = pairs.toSortedList(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)), list);
     }
 
     @Test
@@ -727,7 +732,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableList\<<name1><name2>Pair> list = pairs.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)), list);
     }
 
     @Test
@@ -796,7 +801,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableMap\<String, String> map =
                 pairs.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
     }
 
     @Test
@@ -805,7 +810,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
     }
 
     @Test
@@ -814,7 +819,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMap(Comparators.reverseNaturalOrder(), String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
     }
 
     @Test
@@ -823,14 +828,14 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> pairs = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MutableSortedMap\<String, String> map =
                 pairs.toSortedMapBy(String::valueOf, String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>", "<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>"), map);
     }
 
     @Test
     public void testToString()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>);
-        Assert.assertTrue("[<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>, <(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>]".equals(collection.toString())
+        assertTrue("[<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>, <(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>]".equals(collection.toString())
                 || "[<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>, <(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>]".equals(collection.toString()));
     }
 
@@ -838,21 +843,21 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void makeString()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -861,7 +866,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -870,7 +875,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -879,7 +884,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
@@ -889,10 +894,10 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Function\<<name1><name2>Pair, Boolean> function = (<name1><name2>Pair object) -> PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(object);
 
         Multimap\<Boolean, <name1><name2>Pair> multimap = collection.groupBy(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)));
     }
 
     @Test
@@ -902,10 +907,10 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Function\<<name1><name2>Pair, MutableList\<Boolean>\> function = (<name1><name2>Pair object) -> Lists.mutable.of(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).equals(object));
 
         Multimap\<Boolean, <name1><name2>Pair> multimap = collection.groupByEach(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>)));
     }
 
     @Test
@@ -914,7 +919,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>);
         RichIterable\<Pair\<<name1><name2>Pair, Integer>\> result = collection.zip(Interval.oneTo(5));
 
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 2)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 2)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 1), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 2)).equals(result.toBag()));
     }
 
@@ -923,7 +928,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>);
         RichIterable\<Pair\<<name1><name2>Pair, Integer>\> result = collection.zipWithIndex();
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 1)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 1)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>), 0), Tuples.pair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), 1)).equals(result.toBag()));
     }
 
@@ -931,7 +936,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void chunk()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)),
+        assertEquals(Bags.immutable.of(FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("3")>)),
                 FastList.newListWith(PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("4")>))),
                 collection.chunk(1).toBag());
@@ -941,7 +946,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void chunk_zero_throws()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test
@@ -955,8 +960,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -973,9 +978,9 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Procedure2\<AtomicInteger, <name1><name2>Pair> sumAggregator = (AtomicInteger aggregate, <name1><name2>Pair value) -> aggregate.addAndGet((int) value.getOne());
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         MapIterable\<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>").intValue());
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>").intValue());
+        assertEquals(3, aggregation.get("<(toStringLiteral.(type1))("3")>:<(toStringLiteral.(type2))("4")>").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>").intValue());
     }
 
     @Test
@@ -985,8 +990,8 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Function2\<Integer, <name1><name2>Pair, Integer> sumAggregator = (Integer aggregate, <name1><name2>Pair value) -> (int) (aggregate + value.getOne());
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>);
         MapIterable\<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(2, aggregation.get("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>").intValue());
-        Assert.assertEquals(1, aggregation.get("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>").intValue());
+        assertEquals(2, aggregation.get("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("3")>").intValue());
+        assertEquals(1, aggregation.get("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>").intValue());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -49,8 +49,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name2>HashSet;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;<endif>
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This file was automatically generated from template file abstractPrimitivePrimitiveMapTestCase.stg.
@@ -75,8 +80,8 @@ public abstract class Abstract<name1><name2>MapTestCase
     public void keySet()
     {
         Verify.assertEmpty(this.getEmptyMap().keySet());
-        Assert.assertEquals(<name1>HashSet.newSetWith(<(literal.(type1))("0")>), this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).keySet());
-        Assert.assertEquals(<name1>HashSet.newSetWith(<["0", "31", "32"]:(literal.(type1))(); separator=", ">),
+        assertEquals(<name1>HashSet.newSetWith(<(literal.(type1))("0")>), this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).keySet());
+        assertEquals(<name1>HashSet.newSetWith(<["0", "31", "32"]:(literal.(type1))(); separator=", ">),
                 this.newWithKeysValues(<["0", "31", "32"]:keyValue(); separator=", ">).keySet());
     }
 
@@ -87,119 +92,119 @@ public abstract class Abstract<name1><name2>MapTestCase
 
         <name1><name2>Map map = this.newWithKeysValues(<["0"]:keyValue(); separator=", ">);
         Verify.assertSize(1, map.values());
-        Assert.assertTrue(map.values().contains(<(literal.(type2))("0")>));
+        assertTrue(map.values().contains(<(literal.(type2))("0")>));
 
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "31", "32"]:keyValue(); separator=", ">);
         Verify.assertSize(3, map1.values());
-        Assert.assertTrue(map1.values().contains(<(literal.(type2))("0")>));
-        Assert.assertTrue(map1.values().contains(<(literal.(type2))("31")>));
-        Assert.assertTrue(map1.values().contains(<(literal.(type2))("32")>));
+        assertTrue(map1.values().contains(<(literal.(type2))("0")>));
+        assertTrue(map1.values().contains(<(literal.(type2))("31")>));
+        assertTrue(map1.values().contains(<(literal.(type2))("32")>));
     }
 
     @Test
     public void get()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
 
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("1")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("33")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("1")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("33")>)<wideDelta.(type2)>);
     }
 
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
     }
 
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.getOrThrow(<(literal.(type1))("31")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.getOrThrow(<(literal.(type1))("32")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.getOrThrow(<(literal.(type1))("31")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.getOrThrow(<(literal.(type1))("32")>)<wideDelta.(type2)>);
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("1")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("33")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("1")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("33")>));
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("31")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("32")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("1")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("5")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("35")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("31")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("1")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("5")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("35")>));
     }
 
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("31")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("32")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("31")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("32")>));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("0")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("31")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("32")>));
+        assertTrue(this.map.contains(<(literal.(type2))("0")>));
+        assertTrue(this.map.contains(<(literal.(type2))("31")>));
+        assertTrue(this.map.contains(<(literal.(type2))("32")>));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
-        Assert.assertFalse(this.map.containsAll(<["0", "31", "35"]:(literal.(type2))(); separator=", ">));
-        Assert.assertTrue(this.map.containsAll());
+        assertTrue(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
+        assertFalse(this.map.containsAll(<["0", "31", "35"]:(literal.(type2))(); separator=", ">));
+        assertTrue(this.map.containsAll());
     }
 
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertTrue(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertTrue(this.map.containsAll(new <name2>ArrayList()));
+        assertTrue(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
+        assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
+        assertTrue(this.map.containsAll(new <name2>ArrayList()));
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(0, this.getEmptyMap().size());
-        Assert.assertEquals(1, this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).size());
-        Assert.assertEquals(1, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).size());
+        assertEquals(0, this.getEmptyMap().size());
+        assertEquals(1, this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).size());
+        assertEquals(1, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).size());
 
-        Assert.assertEquals(2, this.newWithKeysValues(<["1", "5"]:keyValue(); separator=", ">).size());
-        Assert.assertEquals(2, this.newWithKeysValues(<["0", "5"]:keyValue(); separator=", ">).size());
-        Assert.assertEquals(3, this.newWithKeysValues(<["1", "0", "5"]:keyValue(); separator=", ">).size());
-        Assert.assertEquals(2, this.newWithKeysValues(<["6", "5"]:keyValue(); separator=", ">).size());
+        assertEquals(2, this.newWithKeysValues(<["1", "5"]:keyValue(); separator=", ">).size());
+        assertEquals(2, this.newWithKeysValues(<["0", "5"]:keyValue(); separator=", ">).size());
+        assertEquals(3, this.newWithKeysValues(<["1", "0", "5"]:keyValue(); separator=", ">).size());
+        assertEquals(2, this.newWithKeysValues(<["6", "5"]:keyValue(); separator=", ">).size());
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.getEmptyMap().isEmpty());
-        Assert.assertFalse(this.map.isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(<["50"]:keyValue(); separator=", ">).isEmpty());
+        assertTrue(this.getEmptyMap().isEmpty());
+        assertFalse(this.map.isEmpty());
+        assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).isEmpty());
+        assertFalse(this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).isEmpty());
+        assertFalse(this.newWithKeysValues(<["50"]:keyValue(); separator=", ">).isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyMap().notEmpty());
-        Assert.assertTrue(this.map.notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(<["50"]:keyValue(); separator=", ">).notEmpty());
+        assertFalse(this.getEmptyMap().notEmpty());
+        assertTrue(this.map.notEmpty());
+        assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).notEmpty());
+        assertTrue(this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).notEmpty());
+        assertTrue(this.newWithKeysValues(<["50"]:keyValue(); separator=", ">).notEmpty());
     }
 
     @Test
@@ -220,61 +225,61 @@ public abstract class Abstract<name1><name2>MapTestCase
         Verify.assertPostSerializedEqualsAndHashCode(map6);
         Verify.assertPostSerializedEqualsAndHashCode(map8);
         Verify.assertPostSerializedEqualsAndHashCode(this.getEmptyMap());
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(this.getEmptyMap(), map3);
-        Assert.assertNotEquals(map9, this.getEmptyMap());
-        Assert.assertNotEquals(this.getEmptyMap(), map9);
-        Assert.assertNotEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), map9);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map7, map6);
-        Assert.assertNotEquals(map7, map8);
+        assertNotEquals(map1, map3);
+        assertNotEquals(this.getEmptyMap(), map3);
+        assertNotEquals(map9, this.getEmptyMap());
+        assertNotEquals(this.getEmptyMap(), map9);
+        assertNotEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), map9);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map7, map6);
+        assertNotEquals(map7, map8);
 
-        Assert.assertEquals(map1, <name1><name2>Maps.mutable.ofAll(map1));
-        Assert.assertEquals(map1, <name1><name2>Maps.immutable.ofAll(map1));
+        assertEquals(map1, <name1><name2>Maps.mutable.ofAll(map1));
+        assertEquals(map1, <name1><name2>Maps.immutable.ofAll(map1));
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(<["0", "1", "32"]:keyValue(); separator=", ">).hashCode(),
                 this.newWithKeysValues(<["32", "0", "1"]:keyValue(); separator=", ">).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(<(literal.(type1))("50")>, <(literal.(type2))("0")>, <(literal.(type1))("60")>, <(literal.(type2))("1")>, <(literal.(type1))("70")>, <(literal.(type2))("33")>).hashCode(),
                 this.newWithKeysValues(<(literal.(type1))("50")>, <(literal.(type2))("0")>, <(literal.(type1))("60")>, <(literal.(type2))("1")>, <(literal.(type1))("70")>, <(literal.(type2))("33")>).hashCode());
-        Assert.assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode(), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode());
+        assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
+        assertEquals(UnifiedMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode(), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.getEmptyMap().toString());
-        Assert.assertEquals("{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}", this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).toString());
-        Assert.assertEquals("{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}", this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toString());
-        Assert.assertEquals("{<(toStringLiteral.(type1))("5")>=<(toStringLiteral.(type2))("5")>}", this.newWithKeysValues(<["5"]:keyValue(); separator=", ">).toString());
+        assertEquals("{}", this.getEmptyMap().toString());
+        assertEquals("{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}", this.newWithKeysValues(<["0"]:keyValue(); separator=", ">).toString());
+        assertEquals("{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}", this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toString());
+        assertEquals("{<(toStringLiteral.(type1))("5")>=<(toStringLiteral.(type2))("5")>}", this.newWithKeysValues(<["5"]:keyValue(); separator=", ">).toString());
 
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 map1.toString(),
                 "{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}".equals(map1.toString())
                         || "{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map1.toString()));
 
         <name1><name2>Map map2 = this.newWithKeysValues(<["1", "32"]:keyValue(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 map2.toString(),
                 "{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map2.toString())
                         || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}".equals(map2.toString()));
 
         <name1><name2>Map map3 = this.newWithKeysValues(<["0", "32"]:keyValue(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 map3.toString(),
                 "{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map3.toString())
                         || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map3.toString()));
 
         <name1><name2>Map map4 = this.newWithKeysValues(<["32", "33"]:keyValue(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 map4.toString(),
                 "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("33")>=<(toStringLiteral.(type2))("33")>}".equals(map4.toString())
                         || "{<(toStringLiteral.(type1))("33")>=<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map4.toString()));
@@ -286,32 +291,32 @@ public abstract class Abstract<name1><name2>MapTestCase
         <name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type2>[] sum0 = new <type2>[1];
         map0.forEach(each -> sum0[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, sum0[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("5")>, sum0[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type2>[] sum1 = new <type2>[1];
         map1.forEach(each -> sum1[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("6")>, sum1[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("6")>, sum1[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map01 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type2>[] sum01 = new <type2>[1];
         map01.forEach(each -> sum01[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, sum01[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("3")>, sum01[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <type2>[] sum = new <type2>[1];
         map.forEach(each -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("9")>, sum[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("9")>, sum[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map2 = this.getEmptyMap();
         <type2>[] sum2 = new <type2>[1];
         map2.forEach(each -> sum2[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, sum2[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, sum2[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type2>[] sum3 = new <type2>[1];
         map3.forEach(each -> sum3[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, sum3[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("2")>, sum3[0]<wideDelta.(type2)>);
     }
 
     @Test
@@ -320,32 +325,32 @@ public abstract class Abstract<name1><name2>MapTestCase
         <name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type2>[] sum0 = new <type2>[1];
         map0.forEachValue(each -> sum0[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, sum0[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("5")>, sum0[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type2>[] sum1 = new <type2>[1];
         map1.forEachValue(each -> sum1[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("6")>, sum1[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("6")>, sum1[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map01 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type2>[] sum01 = new <type2>[1];
         map01.forEachValue(each -> sum01[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, sum01[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("3")>, sum01[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <type2>[] sum = new <type2>[1];
         map.forEachValue(each -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("9")>, sum[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("9")>, sum[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map2 = this.getEmptyMap();
         <type2>[] sum2 = new <type2>[1];
         map2.forEachValue(each -> sum2[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, sum2[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, sum2[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type2>[] sum3 = new <type2>[1];
         map3.forEachValue(each -> sum3[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, sum3[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("2")>, sum3[0]<wideDelta.(type2)>);
     }
 
     @Test
@@ -354,32 +359,32 @@ public abstract class Abstract<name1><name2>MapTestCase
         <name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type1>[] sum0 = new <type1>[1];
         map0.forEachKey(each -> sum0[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, sum0[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, sum0[0]<wideDelta.(type1)>);
 
         <name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type1>[] sum1 = new <type1>[1];
         map1.forEachKey(each -> sum1[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("4")>, sum1[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("4")>, sum1[0]<wideDelta.(type1)>);
 
         <name1><name2>Map map01 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type1>[] sum01 = new <type1>[1];
         map01.forEachKey(each -> sum01[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("1")>, sum01[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("1")>, sum01[0]<wideDelta.(type1)>);
 
         <name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <type1>[] sum = new <type1>[1];
         map.forEachKey(each -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("7")>, sum[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("7")>, sum[0]<wideDelta.(type1)>);
 
         <name1><name2>Map map2 = this.getEmptyMap();
         <type1>[] sum2 = new <type1>[1];
         map2.forEachKey(each -> sum2[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("0")>, sum2[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("0")>, sum2[0]<wideDelta.(type1)>);
 
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>);
         <type1>[] sum3 = new <type1>[1];
         map3.forEachKey(each -> sum3[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type1))("1")>, sum3[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("1")>, sum3[0]<wideDelta.(type1)>);
     }
 
     @Test
@@ -393,8 +398,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey0[0] += eachKey;
             sumValue0[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, sumKey0[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, sumValue0[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, sumKey0[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("5")>, sumValue0[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         <type1>[] sumKey1 = new <type1>[1];
@@ -404,8 +409,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey1[0] += eachKey;
             sumValue1[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("4")>, sumKey1[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("6")>, sumValue1[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("4")>, sumKey1[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("6")>, sumValue1[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map01 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>);
         <type1>[] sumKey01 = new <type1>[1];
@@ -415,8 +420,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey01[0] += eachKey;
             sumValue01[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("1")>, sumKey01[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, sumValue01[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("1")>, sumKey01[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("3")>, sumValue01[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <type1>[] sumKey = new <type1>[1];
@@ -426,8 +431,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey[0] += eachKey;
             sumValue[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("7")>, sumKey[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("9")>, sumValue[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("7")>, sumKey[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("9")>, sumValue[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map2 = this.getEmptyMap();
         <type1>[] sumKey2 = new <type1>[1];
@@ -437,8 +442,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey2[0] += eachKey;
             sumValue2[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("0")>, sumKey2[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, sumValue2[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("0")>, sumKey2[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, sumValue2[0]<wideDelta.(type2)>);
 
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("3")>, <(literal.(type2))("5")>);
         <type1>[] sumKey3 = new <type1>[1];
@@ -448,8 +453,8 @@ public abstract class Abstract<name1><name2>MapTestCase
             sumKey3[0] += eachKey;
             sumValue3[0] += eachValue;
         });
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, sumKey3[0]<wideDelta.(type1)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, sumValue3[0]<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, sumKey3[0]<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type2))("5")>, sumValue3[0]<wideDelta.(type2)>);
     }
 
     @Test
@@ -461,44 +466,44 @@ public abstract class Abstract<name1><name2>MapTestCase
         {
             return Long.valueOf((long) (sum + eachKey + eachValue));
         });
-        Assert.assertEquals(Long.valueOf(8), sum0);
+        assertEquals(Long.valueOf(8), sum0);
 
         <name1><name2>Map copy = map0.injectIntoKeyValue(<name1><name2>Maps.mutable.empty(), Mutable<name1><name2>Map::withKeyValue);
-        Assert.assertEquals(map0, copy);
+        assertEquals(map0, copy);
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", this.getEmptyMap().makeString());
-        Assert.assertEquals("", this.getEmptyMap().makeString(", "));
-        Assert.assertEquals("[]", this.getEmptyMap().makeString("[", "/", "]"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("0")>", this.newWithKeysValues(<keyValue("0")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("0")>", this.newWithKeysValues(<keyValue("0")>).makeString(", "));
-        Assert.assertEquals("[<(toStringLiteral.(type2))("0")>]", this.newWithKeysValues(<keyValue("0")>).makeString("[", "/", "]"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("5")>", this.newWithKeysValues(<(literal.(type1))("5")>, <(literal.(type2))("5")>).makeString());
+        assertEquals("", this.getEmptyMap().makeString());
+        assertEquals("", this.getEmptyMap().makeString(", "));
+        assertEquals("[]", this.getEmptyMap().makeString("[", "/", "]"));
+        assertEquals("<(toStringLiteral.(type2))("0")>", this.newWithKeysValues(<keyValue("0")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("0")>", this.newWithKeysValues(<keyValue("0")>).makeString(", "));
+        assertEquals("[<(toStringLiteral.(type2))("0")>]", this.newWithKeysValues(<keyValue("0")>).makeString("[", "/", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("5")>", this.newWithKeysValues(<(literal.(type1))("5")>, <(literal.(type2))("5")>).makeString());
 
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 map1.makeString(),
                 "<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type2))("1")>".equals(map1.makeString())
                         || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(map1.makeString()));
 
         <name1><name2>Map map2 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(map2.makeString("[", "/", "]"))
                         || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(map2.makeString("[", "/", "]")));
 
         <name1><name2>Map map3 = this.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
-        Assert.assertTrue(
+        assertTrue(
                 map3.makeString("~"),
                 "<(toStringLiteral.(type2))("0")>~<(toStringLiteral.(type2))("32")>".equals(map3.makeString("~"))
                         || "<(toStringLiteral.(type2))("32")>~<(toStringLiteral.(type2))("0")>".equals(map3.makeString("~")));
 
         <name1><name2>Map map4 = this.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>, <(literal.(type1))("33")>, <(literal.(type2))("33")>);
-        Assert.assertTrue(
+        assertTrue(
                 map4.makeString("[", ", ", "]"),
                 "[<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type2))("33")>]".equals(map4.makeString("[", ", ", "]"))
                         || "[<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type2))("32")>]".equals(map4.makeString("[", ", ", "]")));
@@ -509,38 +514,38 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         Appendable appendable = new StringBuilder();
         this.getEmptyMap().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         this.getEmptyMap().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         this.getEmptyMap().appendString(appendable, "{", "/", "}");
-        Assert.assertEquals("{}", appendable.toString());
+        assertEquals("{}", appendable.toString());
 
         Appendable appendable0 = new StringBuilder();
         this.newWithKeysValues(<keyValue("0")>).appendString(appendable0);
-        Assert.assertEquals("<(toStringLiteral.(type2))("0")>", appendable0.toString());
+        assertEquals("<(toStringLiteral.(type2))("0")>", appendable0.toString());
 
         Appendable appendable01 = new StringBuilder();
         this.newWithKeysValues(<keyValue("0")>).appendString(appendable01, "/");
-        Assert.assertEquals("<(toStringLiteral.(type2))("0")>", appendable01.toString());
+        assertEquals("<(toStringLiteral.(type2))("0")>", appendable01.toString());
 
         Appendable appendable02 = new StringBuilder();
         this.newWithKeysValues(<keyValue("0")>).appendString(appendable02, "{", "/", "}");
-        Assert.assertEquals("{<(toStringLiteral.(type2))("0")>}", appendable02.toString());
+        assertEquals("{<(toStringLiteral.(type2))("0")>}", appendable02.toString());
 
         Appendable appendable1 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
 
         Appendable appendable2 = new StringBuilder();
         this.newWithKeysValues(<(literal.(type1))("5")>, <(literal.(type2))("5")>).appendString(appendable2);
-        Assert.assertEquals("<(toStringLiteral.(type2))("5")>", appendable2.toString());
+        assertEquals("<(toStringLiteral.(type2))("5")>", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
         map1.appendString(appendable3);
-        Assert.assertTrue(
+        assertTrue(
                 appendable3.toString(),
                 "<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type2))("1")>".equals(appendable3.toString())
                         || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(appendable3.toString()));
@@ -548,7 +553,7 @@ public abstract class Abstract<name1><name2>MapTestCase
         Appendable appendable4 = new StringBuilder();
         <name1><name2>Map map2 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         map2.appendString(appendable4, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable4.toString(),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(appendable4.toString())
                         || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable4.toString()));
@@ -556,14 +561,14 @@ public abstract class Abstract<name1><name2>MapTestCase
         Appendable appendable5 = new StringBuilder();
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         map3.appendString(appendable5, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable5.toString(),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(appendable5.toString())
                         || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable5.toString()));
 
         Appendable appendable6 = new StringBuilder();
         map1.appendString(appendable6, "/");
-        Assert.assertTrue(
+        assertTrue(
                 appendable6.toString(),
                 "<(toStringLiteral.(type2))("0")>/<(toStringLiteral.(type2))("1")>".equals(appendable6.toString())
                         || "<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("0")>".equals(appendable6.toString()));
@@ -574,9 +579,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name1><name2>Map actual1 = map.select((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("1")>})> || <(equals.(type2))("value", {<(literal.(type2))("3")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), actual1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), actual1);
         <name1><name2>Map actual2 = map.select((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("0")>})> || <(equals.(type2))("value", {<(literal.(type2))("2")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), actual2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), actual2);
     }
 
     @Test
@@ -584,9 +589,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name1><name2>Map actual1 = map.reject((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("1")>})> || <(equals.(type2))("value", {<(literal.(type2))("3")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), actual1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), actual1);
         <name1><name2>Map actual2 = map.reject((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("0")>})> || <(equals.(type2))("value", {<(literal.(type2))("2")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), actual2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), actual2);
     }
 
     @Test
@@ -594,9 +599,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name2>Iterable actual1 = map.select(<name2>Predicates.greaterThan(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
         <name2>Iterable actual2 = map.select(<name2>Predicates.lessThan(<(literal.(type2))("2")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
     }
 
     @Test
@@ -604,9 +609,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name2>Iterable actual1 = map.reject(<name2>Predicates.lessThan(<(literal.(type2))("2")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
         <name2>Iterable actual2 = map.reject(<name2>Predicates.greaterThan(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
     }
 
     @Test
@@ -615,17 +620,17 @@ public abstract class Abstract<name1><name2>MapTestCase
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
 
         <name2>ToObjectFunction\<<primitive2.wrapperName>\> function = parameter -> <(castIntToNarrowTypeWithParens.(type2))("parameter + 1")>;
-        Assert.assertEquals(Bags.immutable.with(<["1", "2", "3", "4"]:(literal.(type2))(); separator=", ">), map.collect(function));
-        Assert.assertEquals(Bags.immutable.empty(), this.getEmptyMap().collect(function));
-        Assert.assertEquals(Bags.immutable.with(<(literal.(type2))("2")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).collect(function));
+        assertEquals(Bags.immutable.with(<["1", "2", "3", "4"]:(literal.(type2))(); separator=", ">), map.collect(function));
+        assertEquals(Bags.immutable.empty(), this.getEmptyMap().collect(function));
+        assertEquals(Bags.immutable.with(<(literal.(type2))("2")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).collect(function));
     }
 
     @Test
     public void count()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(2, map.count(<name2>Predicates.greaterThan(<(literal.(type2))("1")>)));
-        Assert.assertEquals(2, map.count(<name2>Predicates.lessThan(<(literal.(type2))("2")>)));
+        assertEquals(2, map.count(<name2>Predicates.greaterThan(<(literal.(type2))("1")>)));
+        assertEquals(2, map.count(<name2>Predicates.lessThan(<(literal.(type2))("2")>)));
     }
 
     @Test
@@ -633,167 +638,167 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <type2> resultNotFound = map.detectIfNone(<name2>Predicates.greaterThan(<(literal.(type2))("5")>), <(literal.(type2))("5")>);
-        Assert.assertEquals(<(literal.(type2))("5")>, resultNotFound<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("5")>, resultNotFound<(wideDelta.(type2))>);
 
-        Assert.assertEquals(<(literal.(type2))("5")>, this.getEmptyMap().detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("5")>, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("1")>, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).detectIfNone(<name2>Predicates.equal(<(literal.(type2))("1")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("0")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("1")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("1")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("2")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("2")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("5")>, this.getEmptyMap().detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("5")>, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("1")>, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).detectIfNone(<name2>Predicates.equal(<(literal.(type2))("1")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("0")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("0")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("1")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("1")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("2")>, map.detectIfNone(<name2>Predicates.equal(<(literal.(type2))("2")>), <(literal.(type2))("5")>)<(wideDelta.(type2))>);
     }
 
     @Test
     public void anySatisfy()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertFalse(this.getEmptyMap().anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).anySatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
-        Assert.assertFalse(map.anySatisfy(<name2>Predicates.greaterThan(<(literal.(type2))("5")>)));
+        assertFalse(this.getEmptyMap().anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).anySatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertTrue(map.anySatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
+        assertFalse(map.anySatisfy(<name2>Predicates.greaterThan(<(literal.(type2))("5")>)));
     }
 
     @Test
     public void allSatisfy()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertTrue(this.getEmptyMap().allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).allSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
-        Assert.assertTrue(map.allSatisfy(<name2>Predicates.lessThan(<(literal.(type2))("5")>)));
+        assertTrue(this.getEmptyMap().allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).allSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertFalse(map.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
+        assertTrue(map.allSatisfy(<name2>Predicates.lessThan(<(literal.(type2))("5")>)));
         <name1><name2>Map map1 = this.newWithKeysValues(<["2", "3"]:keyValue(); separator=", ">);
-        Assert.assertFalse(map1.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(map1.allSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
     }
 
     @Test
     public void allSatisfyKeyValue()
     {
-        Assert.assertTrue(this.getEmptyMap().allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        assertTrue(this.getEmptyMap().allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertTrue(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
-        Assert.assertFalse(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
+        assertTrue(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        assertFalse(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
         <name1><name2>Map map2 = this.newWithKeysValues(<["0"]:keyValue(); separator=", ">);
-        Assert.assertTrue(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
-        Assert.assertFalse(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
+        assertTrue(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        assertFalse(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
     }
 
     @Test
     public void noneSatisfy()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertTrue(this.getEmptyMap().noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
-        Assert.assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
-        Assert.assertTrue(map.noneSatisfy(<name2>Predicates.lessThan(<(literal.(type2))("0")>)));
+        assertTrue(this.getEmptyMap().noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertTrue(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertFalse(map.noneSatisfy(<name2>Predicates.equal(<(literal.(type2))("2")>)));
+        assertTrue(map.noneSatisfy(<name2>Predicates.lessThan(<(literal.(type2))("0")>)));
     }
 
     @Test
     public void max()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("3")>, map.max()<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).max()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("3")>, map.max()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).max()<(wideDelta.(type2))>);
     }
 
     @Test
     public void min()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["1", "2", "3", "0"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("0")>, map.min()<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).min()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("0")>, map.min()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).min()<(wideDelta.(type2))>);
     }
 
     @Test
     public void max_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().max());
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().max());
     }
 
     @Test
     public void min_empty_throws()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().min());
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().min());
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.getEmptyMap().minIfEmpty(<(literal.(type2))("0")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.getEmptyMap().minIfEmpty(<(literal.(type2))("0")>)<(wideDelta.(type2))>);
         <name1><name2>Map map = this.newWithKeysValues(<["1", "0", "9", "7"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map.minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map.minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, this.getEmptyMap().maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.getEmptyMap().maxIfEmpty(<(literal.(type2))("0")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("5")>, this.getEmptyMap().maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.getEmptyMap().maxIfEmpty(<(literal.(type2))("0")>)<(wideDelta.(type2))>);
         <name1><name2>Map map = this.newWithKeysValues(<["1", "0", "9", "7"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type2))("9")>, map.maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("9")>, map.maxIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).minIfEmpty(<(literal.(type2))("5")>)<(wideDelta.(type2))>);
     }
 
     @Test
     public void sum()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("6")>, map.sum()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("6")>, map.sum()<(wideDelta.(type2))>);
         <name1><name2>Map map2 = this.newWithKeysValues(<["2", "3", "4"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("9")>, map2.sum()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("9")>, map2.sum()<(wideDelta.(type2))>);
         <name1><name2>Map map3 = this.newWithKeysValues(<["2"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("2")>, map3.sum()<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("2")>, map3.sum()<(wideDelta.(type2))>);
     }
 
     @Test
     public void average()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(1.5, map.average(), 0.0);
+        assertEquals(1.5, map.average(), 0.0);
         <name1><name2>Map map1 = this.newWithKeysValues(<["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(1.0, map1.average(), 0.0);
+        assertEquals(1.0, map1.average(), 0.0);
     }
 
     @Test
     public void averageThrowsOnEmpty()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
+        assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
     }
 
     @Test
     public void median()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(1.5, map.median(), 0.0);
+        assertEquals(1.5, map.median(), 0.0);
         <name1><name2>Map map2 = this.newWithKeysValues(<["0", "1", "2"]:keyValue(); separator=", ">);
-        Assert.assertEquals(1.0, map2.median(), 0.0);
+        assertEquals(1.0, map2.median(), 0.0);
         <name1><name2>Map map3 = this.newWithKeysValues(<["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(1.0, map3.median(), 0.0);
+        assertEquals(1.0, map3.median(), 0.0);
     }
 
     @Test
     public void medianThrowsOnEmpty()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
+        assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), this.newWithKeysValues(<keyValue("0")>).toList());
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("1")>), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toList());
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("2")>), this.newWithKeysValues(<(literal.(type1))("2")>, <(literal.(type2))("2")>).toList());
-        Assert.assertTrue(this.newWithKeysValues(<["2", "3"]:keyValue(); separator=", ">).toList().equals(<name2>ArrayList.newListWith(<["2", "3"]:(literal.(type2))(); separator=", ">))
+        assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), this.newWithKeysValues(<keyValue("0")>).toList());
+        assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("1")>), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toList());
+        assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("2")>), this.newWithKeysValues(<(literal.(type1))("2")>, <(literal.(type2))("2")>).toList());
+        assertTrue(this.newWithKeysValues(<["2", "3"]:keyValue(); separator=", ">).toList().equals(<name2>ArrayList.newListWith(<["2", "3"]:(literal.(type2))(); separator=", ">))
                 || this.newWithKeysValues(<["2", "3"]:keyValue(); separator=", ">).toList().equals(<name2>ArrayList.newListWith(<["3", "2"]:(literal.(type2))(); separator=", ">)));
     }
 
@@ -801,27 +806,27 @@ public abstract class Abstract<name1><name2>MapTestCase
     public void toSortedList()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<name2>ArrayList.newListWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toSortedList());
-        Assert.assertEquals(<name2>ArrayList.newListWith(), this.getEmptyMap().toSortedList());
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toSortedList());
+        assertEquals(<name2>ArrayList.newListWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toSortedList());
+        assertEquals(<name2>ArrayList.newListWith(), this.getEmptyMap().toSortedList());
+        assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toSortedList());
     }
 
     @Test
     public void toSet()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<name2>HashSet.newSetWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toSet());
-        Assert.assertEquals(<name2>HashSet.newSetWith(), this.getEmptyMap().toSet());
-        Assert.assertEquals(<name2>HashSet.newSetWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toSet());
+        assertEquals(<name2>HashSet.newSetWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toSet());
+        assertEquals(<name2>HashSet.newSetWith(), this.getEmptyMap().toSet());
+        assertEquals(<name2>HashSet.newSetWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toSet());
     }
 
     @Test
     public void toBag()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<name2>HashBag.newBagWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toBag());
-        Assert.assertEquals(<name2>HashBag.newBagWith(), this.getEmptyMap().toBag());
-        Assert.assertEquals(<name2>HashBag.newBagWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toBag());
+        assertEquals(<name2>HashBag.newBagWith(<["0", "1", "2", "3"]:(literal.(type2))(); separator=", ">), map.toBag());
+        assertEquals(<name2>HashBag.newBagWith(), this.getEmptyMap().toBag());
+        assertEquals(<name2>HashBag.newBagWith(<(literal.(type2))("1")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toBag());
     }
 
     @Test
@@ -831,30 +836,30 @@ public abstract class Abstract<name1><name2>MapTestCase
         Mutable<name2>Set actual = <name2>HashSet.newSetWith();
 
         <name2>Iterator iterator = this.map.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().<type2>Iterator().next());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().<type2>Iterator().next());
     }
 
     @Test
     public void asLazy()
     {
         Lazy<name2>Iterable lazy = this.map.asLazy();
-        Assert.assertTrue(lazy.toList().containsAll(<(literal.(type2))("0")>, <(literal.(type2))("31")>, <(literal.(type2))("32")>));
+        assertTrue(lazy.toList().containsAll(<(literal.(type2))("0")>, <(literal.(type2))("31")>, <(literal.(type2))("32")>));
     }
 
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("31")>, <(literal.(type1))("32")>), this.map.keysView().toSortedList());
+        assertEquals(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("31")>, <(literal.(type1))("32")>), this.map.keysView().toSortedList());
     }
 
     @Test
@@ -862,13 +867,13 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         MutableBag\<<name1><name2>Pair> expected = Bags.mutable.of();
         this.map.forEachKeyValue((<type1> key, <type2> value) -> expected.add(PrimitiveTuples.pair(key, value)));
-        Assert.assertEquals(expected, this.map.keyValuesView().toBag());
+        assertEquals(expected, this.map.keyValuesView().toBag());
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("0")>, <(literal.(type2))("31")>, <(literal.(type2))("32")>}, this.map.toSortedArray()));
+        assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("0")>, <(literal.(type2))("31")>, <(literal.(type2))("32")>}, this.map.toSortedArray()));
     }
 
     @Test
@@ -876,16 +881,16 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["1", "2"]:keyValue(); separator=", ">);
         <type2>[] array = map.toArray();
-        Assert.assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("1")>, <(literal.(type2))("2")>}, array)
+        assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("1")>, <(literal.(type2))("2")>}, array)
                 || Arrays.equals(new <type2>[]{<(literal.(type2))("2")>, <(literal.(type2))("1")>}, array));
-        Assert.assertEquals(0, this.getEmptyMap().toArray().length);
-        Assert.assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("1")>}, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toArray()));
+        assertEquals(0, this.getEmptyMap().toArray().length);
+        assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("1")>}, this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).toArray()));
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(Immutable<name1><name2>Map.class, this.classUnderTest().toImmutable());
     }
 
@@ -893,13 +898,13 @@ public abstract class Abstract<name1><name2>MapTestCase
     public void chunk()
     {
         <name2>Iterable iterable = this.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(1).toSet());
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["3"]:(literal.(type2))(); separator=", ">)).toSet().equals(iterable.chunk(2).toSet())
@@ -909,22 +914,22 @@ public abstract class Abstract<name1><name2>MapTestCase
                 || Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(iterable.chunk(2).toSet()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">)).toSet(),
                 this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).chunk(1).toSet());
 
         Verify.assertIterablesEqual(Lists.mutable.empty(), this.getEmptyMap().chunk(1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutableObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutableObjectPrimitiveMapTestCase.stg
@@ -27,8 +27,11 @@ import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.map.primitive.AbstractObject<name>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * Abstract JUnit test for {@link ImmutableObject<name>HashMap}.
@@ -75,7 +78,7 @@ public abstract class AbstractImmutableObject<name>MapTestCase extends AbstractO
     {
         super.toImmutable();
         ImmutableObject<name>Map\<String> map = this.classUnderTest();
-        Assert.assertSame(map, map.toImmutable());
+        assertSame(map, map.toImmutable());
     }
 
     @Override
@@ -83,29 +86,29 @@ public abstract class AbstractImmutableObject<name>MapTestCase extends AbstractO
     public void keySet()
     {
         super.keySet();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().keySet().remove("0"));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().keySet().remove("0"));
     }
 
     @Override
     public void values()
     {
         super.values();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().values().remove(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().values().remove(<(literal.(type))("0")>));
     }
 
     @Test
     public void flipUniqueValues()
     {
-        Assert.assertEquals(<name>ObjectMaps.immutable.empty(), Object<name>Maps.immutable.empty().flipUniqueValues());
+        assertEquals(<name>ObjectMaps.immutable.empty(), Object<name>Maps.immutable.empty().flipUniqueValues());
         Verify.assertInstanceOf(Immutable<name>ObjectEmptyMap.class, Object<name>Maps.immutable.empty().flipUniqueValues());
 
-        Assert.assertEquals(<name>ObjectMaps.immutable.with(<(literal.(type))("2")>, "1"), this.newWithKeysValues("1", <(literal.(type))("2")>).flipUniqueValues());
+        assertEquals(<name>ObjectMaps.immutable.with(<(literal.(type))("2")>, "1"), this.newWithKeysValues("1", <(literal.(type))("2")>).flipUniqueValues());
 
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, "1", <(literal.(type))("3")>, "2").toImmutable(),
                 this.newWithKeysValues("1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>).flipUniqueValues());
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("1")>).flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> this.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("1")>).flipUniqueValues());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveBooleanMapTestCase.stg
@@ -26,8 +26,9 @@ import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 import org.eclipse.collections.impl.map.primitive.Abstract<name>BooleanMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>BooleanMap}.
@@ -89,11 +90,11 @@ public abstract class AbstractImmutable<name>BooleanMapTestCase extends Abstract
         Verify.assertPostSerializedEqualsAndHashCode(map6);
         Verify.assertPostSerializedEqualsAndHashCode(map8);
         Verify.assertPostSerializedIdentity(this.getEmptyMap());
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map7, map6);
-        Assert.assertNotEquals(map7, map8);
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map7, map6);
+        assertNotEquals(map7, map8);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveObjectMapTestCase.stg
@@ -28,8 +28,11 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.map.primitive.Abstract<name>ObjectMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>ObjectMap}.
@@ -70,7 +73,7 @@ public abstract class AbstractImmutable<name>ObjectMapTestCase extends Abstract<
     {
         super.toImmutable();
         Immutable<name>ObjectMap\<String> map = this.classUnderTest();
-        Assert.assertSame(map, map.toImmutable());
+        assertSame(map, map.toImmutable());
     }
 
     @Override
@@ -80,7 +83,7 @@ public abstract class AbstractImmutable<name>ObjectMapTestCase extends Abstract<
         super.iterator();
         Iterator\<String> iterator = this.classUnderTest().iterator();
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -88,29 +91,29 @@ public abstract class AbstractImmutable<name>ObjectMapTestCase extends Abstract<
     public void keySet()
     {
         super.keySet();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> { this.classUnderTest().keySet().remove(<(literal.(type))("0")>); });
+        assertThrows(UnsupportedOperationException.class, () -> { this.classUnderTest().keySet().remove(<(literal.(type))("0")>); });
     }
 
     @Override
     public void values()
     {
         super.values();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> { this.classUnderTest().values().remove("zero"); });
+        assertThrows(UnsupportedOperationException.class, () -> { this.classUnderTest().values().remove("zero"); });
     }
 
     @Test
     public void flipUniqueValues()
     {
-        Assert.assertEquals(Object<name>Maps.immutable.empty(), <name>ObjectMaps.immutable.empty().flipUniqueValues());
+        assertEquals(Object<name>Maps.immutable.empty(), <name>ObjectMaps.immutable.empty().flipUniqueValues());
         Verify.assertInstanceOf(ImmutableObject<name>EmptyMap.class, <name>ObjectMaps.immutable.empty().flipUniqueValues());
 
-        Assert.assertEquals(Object<name>Maps.immutable.with("2", <(literal.(type))("1")>), this.newWithKeysValues(<(literal.(type))("1")>, "2").flipUniqueValues());
+        assertEquals(Object<name>Maps.immutable.with("2", <(literal.(type))("1")>), this.newWithKeysValues(<(literal.(type))("1")>, "2").flipUniqueValues());
 
-        Assert.assertEquals(
+        assertEquals(
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("2")>).toImmutable(),
                 this.newWithKeysValues(<(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3").flipUniqueValues());
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "1").flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "1").flipUniqueValues());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitivePrimitiveMapTestCase.stg
@@ -30,8 +30,11 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.map.mutable.primitive.<name2><name1>HashMap;<endif>
 import org.eclipse.collections.impl.map.primitive.Abstract<name1><name2>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Abstract JUnit test for {@link Immutable<name1><name2>Map}.
@@ -93,11 +96,11 @@ public abstract class AbstractImmutable<name1><name2>MapTestCase extends Abstrac
         Verify.assertPostSerializedEqualsAndHashCode(map6);
         Verify.assertPostSerializedEqualsAndHashCode(map8);
         Verify.assertPostSerializedIdentity(this.getEmptyMap());
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map7, map6);
-        Assert.assertNotEquals(map7, map8);
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map7, map6);
+        assertNotEquals(map7, map8);
     }
 
     @Override
@@ -105,7 +108,7 @@ public abstract class AbstractImmutable<name1><name2>MapTestCase extends Abstrac
     public void keySet()
     {
         super.keySet();
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.classUnderTest().keySet().remove(<(literal.(type1))("0")>));
     }
@@ -114,7 +117,7 @@ public abstract class AbstractImmutable<name1><name2>MapTestCase extends Abstrac
     public void values()
     {
         super.values();
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.classUnderTest().values().remove(<(literal.(type2))("0")>));
     }
@@ -122,16 +125,16 @@ public abstract class AbstractImmutable<name1><name2>MapTestCase extends Abstrac
     @Test
     public void flipUniqueValues()
     {
-        Assert.assertEquals(<name2><name1>Maps.immutable.empty(), <name1><name2>Maps.immutable.empty().flipUniqueValues());
+        assertEquals(<name2><name1>Maps.immutable.empty(), <name1><name2>Maps.immutable.empty().flipUniqueValues());
         Verify.assertInstanceOf(Immutable<name2><name1>EmptyMap.class, <name1><name2>Maps.immutable.empty().flipUniqueValues());
 
-        Assert.assertEquals(<name2><name1>Maps.immutable.with(<(literal.(type2))("2")>, <(literal.(type1))("1")>), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).flipUniqueValues());
+        assertEquals(<name2><name1>Maps.immutable.with(<(literal.(type2))("2")>, <(literal.(type1))("1")>), this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>).flipUniqueValues());
 
-        Assert.assertEquals(
+        assertEquals(
                 <name2><name1>HashMap.newWithKeysValues(<(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("3")>, <(literal.(type1))("2")>, <(literal.(type2))("4")>, <(literal.(type1))("3")>, <(literal.(type2))("5")>, <(literal.(type1))("4")>).toImmutable(),
                 this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>).flipUniqueValues());
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("1")>).flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("1")>).flipUniqueValues());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
@@ -32,8 +32,15 @@ import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>EmptyMap}.
@@ -52,9 +59,9 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected = Object<name>HashMap.newWithKeysValues("3", <(literal.(type))("3")>).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -62,9 +69,9 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected1 = this.getEmptyMap();
-        Assert.assertEquals(expected1, map1.newWithoutKey("2"));
-        Assert.assertSame(map1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutKey("2"));
+        assertSame(map1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -72,29 +79,29 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected1 = this.getEmptyMap();
-        Assert.assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey("0"));
-        Assert.assertFalse(this.classUnderTest().containsKey("1"));
-        Assert.assertFalse(this.classUnderTest().containsKey("2"));
-        Assert.assertFalse(this.classUnderTest().containsKey("3"));
-        Assert.assertFalse(this.classUnderTest().containsKey(null));
+        assertFalse(this.classUnderTest().containsKey("0"));
+        assertFalse(this.classUnderTest().containsKey("1"));
+        assertFalse(this.classUnderTest().containsKey("2"));
+        assertFalse(this.classUnderTest().containsKey("3"));
+        assertFalse(this.classUnderTest().containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().containsValue(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsValue(<(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().containsValue(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().containsValue(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsValue(<(literal.(type))("2")>));
     }
 
     @Override
@@ -102,67 +109,67 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     public void detectIfNone()
     {
         <type> detect = this.classUnderTest().detectIfNone((<type> value) -> true, <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, detect<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, detect<delta.(type)>);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.classUnderTest().getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.classUnderTest().getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
     }
 
     @Override
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("9")>, this.getEmptyMap().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, this.getEmptyMap().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
     }
 
     @Override
     @Test
     public void median()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy((<type> value) -> false));
+        assertTrue(this.classUnderTest().allSatisfy((<type> value) -> false));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy((<type> value) -> true));
+        assertFalse(this.classUnderTest().anySatisfy((<type> value) -> true));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((String object, <type> value) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((String object, <type> value) -> false));
 
-        Assert.assertEquals(new <name>HashBag(), this.classUnderTest().reject((<type> value) -> false).toBag());
+        assertEquals(new <name>HashBag(), this.classUnderTest().reject((<type> value) -> false).toBag());
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((String object, <type> value) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((String object, <type> value) -> true));
 
-        Assert.assertEquals(new <name>HashBag(), this.classUnderTest().select((<type> value) -> true).toBag());
+        assertEquals(new <name>HashBag(), this.classUnderTest().select((<type> value) -> true).toBag());
     }
 
     @Test
@@ -176,110 +183,110 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     public void <type>Iterator()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void average()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("2")>));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("0")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("1")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("1")<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().get(null)<delta.(type)>);
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().sum()<wideDelta.(type)>);
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0L, this.classUnderTest().count((<type> value) -> true));
+        assertEquals(0L, this.classUnderTest().count((<type> value) -> true));
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(), this.classUnderTest().toBag());
     }
 
     @Override
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(), this.classUnderTest().toSet());
+        assertEquals(<name>HashSet.newSetWith(), this.classUnderTest().toSet());
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
-        Assert.assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new <name>ArrayList()));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertTrue(this.classUnderTest().containsAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("6")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("6")>, this.getEmptyMap().minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
     }
 
     @Override
@@ -289,7 +296,7 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
         Object<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, null, <(literal.(type))("2")>);
         Object<name>Map\<String> map2 = this.getEmptyMap();
 
-        Assert.assertNotEquals(this.classUnderTest(), map1);
+        assertNotEquals(this.classUnderTest(), map1);
         Verify.assertEqualsAndHashCode(this.classUnderTest(), map2);
         Verify.assertPostSerializedIdentity(this.classUnderTest());
     }
@@ -305,14 +312,14 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy((<type> value) -> true));
+        assertTrue(this.classUnderTest().noneSatisfy((<type> value) -> true));
     }
 
     @Test
@@ -320,7 +327,7 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     {
         ImmutableObject<name>EmptyMap\<Object> iterable = new ImmutableObject<name>EmptyMap\<>();
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value) -> object.add(value));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveHashMapTest.stg
@@ -24,8 +24,10 @@ import org.eclipse.collections.api.map.primitive.ImmutableObject<name>Map;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>HashMap}.
@@ -44,9 +46,9 @@ public class ImmutableObject<name>HashMapTest extends AbstractImmutableObject<na
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected = Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -54,9 +56,9 @@ public class ImmutableObject<name>HashMapTest extends AbstractImmutableObject<na
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
-        Assert.assertEquals(expected, map1.newWithoutKey("2"));
-        Assert.assertNotSame(map1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutKey("2"));
+        assertNotSame(map1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -64,9 +66,9 @@ public class ImmutableObject<name>HashMapTest extends AbstractImmutableObject<na
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected = this.newWithKeysValues("1", <(literal.(type))("1")>);
-        Assert.assertEquals(expected, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -74,7 +76,7 @@ public class ImmutableObject<name>HashMapTest extends AbstractImmutableObject<na
     {
         ImmutableObject<name>HashMap\<String> iterable = new ImmutableObject<name>HashMap\<>(Object<name>HashMap.newWithKeysValues("3", <(literal.(type))("3")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>));
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value) -> object.add(value));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveSingletonMapTest.stg
@@ -32,8 +32,14 @@ import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>SingletonMap}.
@@ -52,9 +58,9 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected = Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "3", <(literal.(type))("3")>).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertNotSame(map1, map1.newWithKeyValue("3", <(literal.(type))("3")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -62,13 +68,13 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected1 = this.newWithKeysValues("1", <(literal.(type))("1")>);
-        Assert.assertEquals(expected1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
 
         ImmutableObject<name>Map\<String> expected2 = this.getEmptyMap();
-        Assert.assertEquals(expected2, map1.newWithoutKey("1"));
-        Assert.assertNotSame(map1, map1.newWithoutKey("1"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected2, map1.newWithoutKey("1"));
+        assertNotSame(map1, map1.newWithoutKey("1"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -76,34 +82,34 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     {
         ImmutableObject<name>Map\<String> map1 = this.classUnderTest();
         ImmutableObject<name>Map\<String> expected1 = this.newWithKeysValues("1", <(literal.(type))("1")>);
-        Assert.assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertEquals(this.classUnderTest(), map1);
 
         ImmutableObject<name>Map\<String> expected2 = this.getEmptyMap();
-        Assert.assertEquals(expected2, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected2, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey("0"));
-        Assert.assertTrue(this.classUnderTest().containsKey("1"));
-        Assert.assertFalse(this.classUnderTest().containsKey("2"));
-        Assert.assertFalse(this.classUnderTest().containsKey("3"));
-        Assert.assertFalse(this.classUnderTest().containsKey(null));
+        assertFalse(this.classUnderTest().containsKey("0"));
+        assertTrue(this.classUnderTest().containsKey("1"));
+        assertFalse(this.classUnderTest().containsKey("2"));
+        assertFalse(this.classUnderTest().containsKey("3"));
+        assertFalse(this.classUnderTest().containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(<(literal.(type))("0")>));
-        Assert.assertTrue(this.classUnderTest().containsValue(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsValue(<(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().containsValue(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().containsValue(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsValue(<(literal.(type))("2")>));
     }
 
     @Override
@@ -111,79 +117,79 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     public void detectIfNone()
     {
         <type> detect = this.classUnderTest().detectIfNone((<type> value) -> true, <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("1")>, detect<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, detect<delta.(type)>);
 
         <type> detect1 = this.classUnderTest().detectIfNone((<type> value) -> false, <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, detect1<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, detect1<delta.(type)>);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().getIfAbsent(null, <(literal.(type))("0")>)<delta.(type)>);
     }
 
     @Override
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("9")>)<delta.(type)>);
     }
 
     @Override
     @Test
     public void median()
     {
-        Assert.assertEquals(1.0, this.classUnderTest().median(), 0.0);
+        assertEquals(1.0, this.classUnderTest().median(), 0.0);
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfy((<type> value) -> false));
+        assertFalse(this.classUnderTest().allSatisfy((<type> value) -> false));
 
-        Assert.assertTrue(this.classUnderTest().allSatisfy((<type> value) -> true));
+        assertTrue(this.classUnderTest().allSatisfy((<type> value) -> true));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((String object, <type> value) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((String object, <type> value) -> false));
 
-        Assert.assertEquals(this.getEmptyMap(), this.classUnderTest().reject((String object, <type> value) -> true));
+        assertEquals(this.getEmptyMap(), this.classUnderTest().reject((String object, <type> value) -> true));
 
-        Assert.assertEquals(new <name>HashBag(), this.classUnderTest().reject((<type> value) -> true).toBag());
+        assertEquals(new <name>HashBag(), this.classUnderTest().reject((<type> value) -> true).toBag());
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().reject((<type> value) -> false).toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().reject((<type> value) -> false).toBag());
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((String object, <type> value) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((String object, <type> value) -> true));
 
-        Assert.assertEquals(this.getEmptyMap(), this.classUnderTest().select((String object, <type> value) -> false));
+        assertEquals(this.getEmptyMap(), this.classUnderTest().select((String object, <type> value) -> false));
 
-        Assert.assertEquals(new <name>HashBag(), this.classUnderTest().select((<type> value) -> false).toBag());
+        assertEquals(new <name>HashBag(), this.classUnderTest().select((<type> value) -> false).toBag());
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().select((<type> value) -> true).toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().select((<type> value) -> true).toBag());
     }
 
     @Test
     public void keysView()
     {
-        Assert.assertEquals(FastList.newListWith("1"), this.classUnderTest().keysView().toList());
+        assertEquals(FastList.newListWith("1"), this.classUnderTest().keysView().toList());
     }
 
     @Override
@@ -191,108 +197,108 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     public void <type>Iterator()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<wideDelta.(type)>);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<wideDelta.(type)>);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("0")>));
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().contains(<(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().contains(<(literal.(type))("2")>));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().getOrThrow("1")<delta.(type)>);
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().getOrThrow("1")<delta.(type)>);
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("0")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().get("1")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.classUnderTest().get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().get("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().get("1")<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.classUnderTest().get(null)<delta.(type)>);
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().max()<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().max()<delta.(type)>);
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().max()<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().max()<delta.(type)>);
     }
 
     @Override
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().sum()<wideDelta.(type)>);
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.classUnderTest().count((<type> value) -> true));
-        Assert.assertEquals(0L, this.classUnderTest().count((<type> value) -> false));
+        assertEquals(1L, this.classUnderTest().count((<type> value) -> true));
+        assertEquals(0L, this.classUnderTest().count((<type> value) -> false));
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("1")>), this.classUnderTest().toBag());
     }
 
     @Override
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), this.classUnderTest().toSet());
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), this.classUnderTest().toSet());
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
-        Assert.assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertTrue(this.classUnderTest().containsAll(<(literal.(type))("1")>));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>));
+        assertFalse(this.classUnderTest().containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertTrue(this.classUnderTest().containsAll(<(literal.(type))("1")>));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
-        Assert.assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new <name>ArrayList()));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>)));
+        assertFalse(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertTrue(this.classUnderTest().containsAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertTrue(this.classUnderTest().containsAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("6")>)<delta.(type)>);
     }
 
     @Override
@@ -303,8 +309,8 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
         Object<name>Map\<String> map2 = this.newWithKeysValues("0", <(literal.(type))("0")>);
         Object<name>Map\<String> map3 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
 
-        Assert.assertNotEquals(this.classUnderTest(), map3);
-        Assert.assertNotEquals(this.classUnderTest(), map2);
+        assertNotEquals(this.classUnderTest(), map3);
+        assertNotEquals(this.classUnderTest(), map2);
         Verify.assertEqualsAndHashCode(this.classUnderTest(), map1);
         Verify.assertPostSerializedEqualsAndHashCode(this.classUnderTest());
     }
@@ -320,16 +326,16 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy((<type> value) -> true));
+        assertFalse(this.classUnderTest().noneSatisfy((<type> value) -> true));
 
-        Assert.assertTrue(this.classUnderTest().noneSatisfy((<type> value) -> false));
+        assertTrue(this.classUnderTest().noneSatisfy((<type> value) -> false));
     }
 
     @Test
@@ -337,7 +343,7 @@ public class ImmutableObject<name>SingletonMapTest extends AbstractImmutableObje
     {
         ImmutableObject<name>SingletonMap\<String> iterable = new ImmutableObject<name>SingletonMap\<>("1", <(literal.(type))("1")>);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("1")>), (Mutable<wrapperName> object, <type> value) -> object.add(value));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
@@ -30,8 +30,14 @@ import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanEmptyMap}.
@@ -50,52 +56,52 @@ public class Immutable<name>BooleanEmptyMapTest extends AbstractImmutable<name>B
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
         Immutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("0")>, true);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("0")>, true));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("0")>, true));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("0")>, true));
+        assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("0")>, true));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
     public void newWithoutKeyValue()
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
     public void newWithoutAllKeys()
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(true));
-        Assert.assertFalse(this.classUnderTest().containsValue(false));
+        assertFalse(this.classUnderTest().containsValue(true));
+        assertFalse(this.classUnderTest().containsValue(false));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(true));
-        Assert.assertFalse(this.classUnderTest().contains(false));
+        assertFalse(this.classUnderTest().contains(true));
+        assertFalse(this.classUnderTest().contains(false));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, true));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, false));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
     }
 
     @Override
@@ -110,126 +116,126 @@ public class Immutable<name>BooleanEmptyMapTest extends AbstractImmutable<name>B
     public void booleanIterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(true, false));
-        Assert.assertFalse(this.classUnderTest().containsAll(false));
-        Assert.assertFalse(this.classUnderTest().containsAll(true));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(true, false));
+        assertFalse(this.classUnderTest().containsAll(false));
+        assertFalse(this.classUnderTest().containsAll(true));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().keysView().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().keysView().toSortedList());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false)));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Override
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().isEmpty());
+        assertTrue(this.classUnderTest().isEmpty());
     }
 
     @Override
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((key, value) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((key, value) -> true));
     }
 
     @Override
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((key, value) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((key, value) -> false));
     }
 
     @Override
     public void select_value()
     {
-        Assert.assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().select(value -> true));
+        assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().select(value -> true));
     }
 
     @Override
     public void reject_value()
     {
-        Assert.assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().reject(value -> false));
+        assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().reject(value -> false));
     }
 
     @Override
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count(value -> true));
+        assertEquals(0, this.classUnderTest().count(value -> true));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanHashMapTest.stg
@@ -22,8 +22,11 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 
 import org.eclipse.collections.api.map.primitive.Immutable<name>BooleanMap;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanHashMap}.
@@ -37,7 +40,7 @@ public class Immutable<name>BooleanHashMapTest extends AbstractImmutable<name>Bo
     {
         super.toImmutable();
         Immutable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertSame(map1, map1.toImmutable());
+        assertSame(map1, map1.toImmutable());
     }
 
     @Test
@@ -45,9 +48,9 @@ public class Immutable<name>BooleanHashMapTest extends AbstractImmutable<name>Bo
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
         Immutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true, <(literal.(type))("33")>, false);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("33")>, false));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("33")>, false));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("33")>, false));
+        assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("33")>, false));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -55,9 +58,9 @@ public class Immutable<name>BooleanHashMapTest extends AbstractImmutable<name>Bo
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
         Immutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false);
-        Assert.assertEquals(expected, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertNotSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertNotSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -65,9 +68,9 @@ public class Immutable<name>BooleanHashMapTest extends AbstractImmutable<name>Bo
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
         Immutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("31")>, false);
-        Assert.assertEquals(expected, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
@@ -32,8 +32,14 @@ import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanSingletonMap}.
@@ -52,67 +58,67 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
         Immutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("1")>, true));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("1")>, true));
+        assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("1")>, true));
+        assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("1")>, true));
     }
 
     @Test
     public void newWithoutKeyValue()
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertEquals(this.classUnderTest(), map1);
 
         Immutable<name>BooleanMap map2 = this.classUnderTest();
-        Assert.assertEquals(this.getEmptyMap(), map2.newWithoutKey(<(literal.(type))("0")>));
-        Assert.assertNotSame(map2, map2.newWithoutKey(<(literal.(type))("0")>));
-        Assert.assertEquals(this.classUnderTest(), map2);
+        assertEquals(this.getEmptyMap(), map2.newWithoutKey(<(literal.(type))("0")>));
+        assertNotSame(map2, map2.newWithoutKey(<(literal.(type))("0")>));
+        assertEquals(this.classUnderTest(), map2);
     }
 
     @Test
     public void newWithoutAllKeys()
     {
         Immutable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertEquals(this.getEmptyMap(), map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(this.getEmptyMap(), map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
 
         Immutable<name>BooleanMap map2 = this.classUnderTest();
-        Assert.assertEquals(map2, map2.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("31")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map2);
+        assertEquals(map2, map2.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("31")>, <(literal.(type))("32")>)));
+        assertEquals(this.classUnderTest(), map2);
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
-        Assert.assertFalse(this.classUnderTest().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(true));
+        assertFalse(this.classUnderTest().containsValue(false));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(true));
-        Assert.assertFalse(this.classUnderTest().contains(false));
+        assertTrue(this.classUnderTest().contains(true));
+        assertFalse(this.classUnderTest().contains(false));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
     }
 
     @Override
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.classUnderTest().asLazy().toList());
+        assertEquals(BooleanArrayList.newListWith(true), this.classUnderTest().asLazy().toList());
     }
 
     @Override
@@ -120,89 +126,89 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void booleanIterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(true, false));
-        Assert.assertFalse(this.classUnderTest().containsAll(false));
-        Assert.assertTrue(this.classUnderTest().containsAll(true));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(true, false));
+        assertFalse(this.classUnderTest().containsAll(false));
+        assertTrue(this.classUnderTest().containsAll(true));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.classUnderTest().keysView().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.classUnderTest().keysView().toSortedList());
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
     }
 
     @Override
@@ -210,9 +216,9 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void select()
     {
         <name>BooleanMap actual1 = this.classUnderTest().select((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("0")>})>);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), actual1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), actual1);
         <name>BooleanMap actual2 = this.classUnderTest().select((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("1")>})>);
-        Assert.assertEquals(this.getEmptyMap(), actual2);
+        assertEquals(this.getEmptyMap(), actual2);
     }
 
     @Override
@@ -220,9 +226,9 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void reject()
     {
         <name>BooleanMap actual1 = this.classUnderTest().reject((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("1")>})>);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), actual1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), actual1);
         <name>BooleanMap actual2 = this.classUnderTest().reject((<type> key, boolean value) -> <(equals.(type))("key", {<(literal.(type))("0")>})>);
-        Assert.assertEquals(this.getEmptyMap(), actual2);
+        assertEquals(this.getEmptyMap(), actual2);
     }
 
     @Override
@@ -230,10 +236,10 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void select_value()
     {
         BooleanIterable actual1 = this.classUnderTest().select(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanBags.immutable.empty(), actual1);
+        assertEquals(BooleanBags.immutable.empty(), actual1);
 
         BooleanIterable actual2 = this.classUnderTest().select(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanBags.immutable.with(true), actual2);
+        assertEquals(BooleanBags.immutable.with(true), actual2);
     }
 
     @Override
@@ -241,18 +247,18 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void reject_value()
     {
         BooleanIterable actual1 = this.classUnderTest().reject(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanBags.immutable.empty(), actual1);
+        assertEquals(BooleanBags.immutable.empty(), actual1);
 
         BooleanIterable actual2 = this.classUnderTest().reject(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanBags.immutable.with(true), actual2);
+        assertEquals(BooleanBags.immutable.with(true), actual2);
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(1, this.classUnderTest().count(BooleanPredicates.isTrue()));
+        assertEquals(0, this.classUnderTest().count(BooleanPredicates.isFalse()));
+        assertEquals(1, this.classUnderTest().count(BooleanPredicates.isTrue()));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
@@ -58,8 +58,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectEmptyMap}.
@@ -81,109 +88,109 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(null));
-        Assert.assertFalse(this.classUnderTest().containsValue("zero"));
-        Assert.assertFalse(this.classUnderTest().containsValue("thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().containsValue("thirtyTwo"));
+        assertFalse(this.classUnderTest().containsValue(null));
+        assertFalse(this.classUnderTest().containsValue("zero"));
+        assertFalse(this.classUnderTest().containsValue("thirtyOne"));
+        assertFalse(this.classUnderTest().containsValue("thirtyTwo"));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(null));
-        Assert.assertFalse(this.classUnderTest().contains("zero"));
-        Assert.assertFalse(this.classUnderTest().contains("thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().contains("thirtyTwo"));
+        assertFalse(this.classUnderTest().contains(null));
+        assertFalse(this.classUnderTest().contains("zero"));
+        assertFalse(this.classUnderTest().contains("thirtyOne"));
+        assertFalse(this.classUnderTest().contains("thirtyTwo"));
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith()));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
-        Assert.assertTrue(this.classUnderTest().containsAll(FastList.newListWith()));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAll(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsAnyIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("two", "one", "nine")));
-        Assert.assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith()));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith("two", "one", "nine")));
+        assertFalse(this.classUnderTest().containsAnyIterable(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsAny()
     {
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith("two", "one", "nine")));
-        Assert.assertFalse(this.classUnderTest().containsAny(FastList.newListWith()));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith("two", "one", "nine")));
+        assertFalse(this.classUnderTest().containsAny(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsNoneIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("two", "one", "nine")));
-        Assert.assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith()));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsNoneIterable(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsNone()
     {
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith("two", "one", "nine")));
-        Assert.assertTrue(this.classUnderTest().containsNone(FastList.newListWith()));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne")));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsNone(FastList.newListWith()));
     }
 
     @Override
     @Test
     public void containsAllArguments()
     {
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
-        Assert.assertTrue(this.classUnderTest().containsAllArguments());
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
+        assertTrue(this.classUnderTest().containsAllArguments());
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
     }
 
     @Override
@@ -192,23 +199,23 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     {
         Function0\<String> ifAbsent = () -> "ifAbsent";
 
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
 
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("32")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("0")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
     }
 
     @Override
@@ -216,44 +223,44 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void iterator()
     {
         Iterator\<String> iterator = this.classUnderTest().iterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().isEmpty());
+        assertTrue(this.classUnderTest().isEmpty());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNull(this.classUnderTest().getFirst());
+        assertNull(this.classUnderTest().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNull(this.classUnderTest().getLast());
+        assertNull(this.classUnderTest().getLast());
     }
 
     @Override
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
@@ -261,49 +268,49 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void tap()
     {
         Immutable<name>ObjectMap\<String> map = this.classUnderTest();
-        Assert.assertSame(map, map.tap(Procedures.cast(each -> Assert.fail())));
+        assertSame(map, map.tap(Procedures.cast(each -> fail())));
     }
 
     @Override
     @Test
     public void forEach()
     {
-        this.classUnderTest().forEach(Procedures.cast(each -> Assert.fail()));
+        this.classUnderTest().forEach(Procedures.cast(each -> fail()));
     }
 
     @Override
     @Test
     public void forEachWithIndex()
     {
-        this.classUnderTest().forEachWithIndex((String each, int param) -> Assert.fail());
+        this.classUnderTest().forEachWithIndex((String each, int param) -> fail());
     }
 
     @Override
     @Test
     public void forEachWith()
     {
-        this.classUnderTest().forEachWith((String each, String param) -> Assert.fail(), "");
+        this.classUnderTest().forEachWith((String each, String param) -> fail(), "");
     }
 
     @Override
     @Test
     public void forEachKey()
     {
-        this.classUnderTest().forEachKey((<primitive.type> each) -> Assert.fail());
+        this.classUnderTest().forEachKey((<primitive.type> each) -> fail());
     }
 
     @Override
     @Test
     public void forEachValue()
     {
-        this.classUnderTest().forEachValue((String each) -> Assert.fail());
+        this.classUnderTest().forEachValue((String each) -> fail());
     }
 
     @Override
     @Test
     public void forEachKeyValue()
     {
-        this.classUnderTest().forEachKeyValue((<primitive.type> eachKey, String eachValue) -> Assert.fail());
+        this.classUnderTest().forEachKeyValue((<primitive.type> eachKey, String eachValue) -> fail());
     }
 
     @Override
@@ -314,7 +321,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
         Verify.assertIterableEmpty(this.classUnderTest().select((<primitive.type> value, String object) -> true));
 
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().select(Predicates.alwaysTrue(), target));
+        assertSame(target, this.classUnderTest().select(Predicates.alwaysTrue(), target));
         Verify.assertEmpty(target);
     }
 
@@ -330,7 +337,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void selectWith_withTarget()
     {
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().selectWith(Predicates2.alwaysTrue(), "", target));
+        assertSame(target, this.classUnderTest().selectWith(Predicates2.alwaysTrue(), "", target));
         Verify.assertEmpty(target);
     }
 
@@ -349,7 +356,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
         Verify.assertIterableEmpty(this.classUnderTest().reject((<primitive.type> value, String object) -> false));
 
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().reject(Predicates.alwaysFalse(), target));
+        assertSame(target, this.classUnderTest().reject(Predicates.alwaysFalse(), target));
         Verify.assertEmpty(target);
     }
 
@@ -365,7 +372,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void rejectWith_withTarget()
     {
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().rejectWith(Predicates2.alwaysFalse(), "", target));
+        assertSame(target, this.classUnderTest().rejectWith(Predicates2.alwaysFalse(), "", target));
         Verify.assertEmpty(target);
     }
 
@@ -373,98 +380,98 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     @Test
     public void detect()
     {
-        Assert.assertNull(this.classUnderTest().detect(Predicates.alwaysTrue()));
+        assertNull(this.classUnderTest().detect(Predicates.alwaysTrue()));
     }
 
     @Override
     @Test
     public void detectWith()
     {
-        Assert.assertNull(this.classUnderTest().detectWith(Predicates2.alwaysTrue(), ""));
+        assertNull(this.classUnderTest().detectWith(Predicates2.alwaysTrue(), ""));
     }
 
     @Override
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(Optional.empty(), this.classUnderTest().detectOptional(Predicates.alwaysTrue()));
+        assertEquals(Optional.empty(), this.classUnderTest().detectOptional(Predicates.alwaysTrue()));
     }
 
     @Override
     @Test
     public void detectWithOptional()
     {
-        Assert.assertEquals(Optional.empty(), this.classUnderTest().detectWithOptional(Predicates2.alwaysTrue(), ""));
+        assertEquals(Optional.empty(), this.classUnderTest().detectWithOptional(Predicates2.alwaysTrue(), ""));
     }
 
     @Override
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals("default", this.classUnderTest().detectIfNone(Predicates.alwaysTrue(), Functions0.value("default")));
+        assertEquals("default", this.classUnderTest().detectIfNone(Predicates.alwaysTrue(), Functions0.value("default")));
     }
 
     @Override
     @Test
     public void detectWithIfNone()
     {
-        Assert.assertEquals("default", this.classUnderTest().detectWithIfNone(Predicates2.alwaysTrue(), "", Functions0.value("default")));
+        assertEquals("default", this.classUnderTest().detectWithIfNone(Predicates2.alwaysTrue(), "", Functions0.value("default")));
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count(Predicates.alwaysTrue()));
+        assertEquals(0, this.classUnderTest().count(Predicates.alwaysTrue()));
     }
 
     @Override
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.classUnderTest().countWith(Predicates2.alwaysTrue(), ""));
+        assertEquals(0, this.classUnderTest().countWith(Predicates2.alwaysTrue(), ""));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(ERROR_THROWING_PREDICATE));
+        assertFalse(this.classUnderTest().anySatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
+        assertFalse(this.classUnderTest().anySatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(this.classUnderTest().allSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
+        assertTrue(this.classUnderTest().allSatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(this.classUnderTest().noneSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
+        assertTrue(this.classUnderTest().noneSatisfyWith(ERROR_THROWING_PREDICATE_2, "e"));
     }
 
     @Override
@@ -488,69 +495,69 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     @Test
     public void min_withComparator()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_withComparator()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max(Comparators.naturalOrder()));
     }
 
     @Override
     @Test
     public void minBy()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().minBy(String::valueOf));
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().minBy(String::valueOf));
     }
 
     @Override
     @Test
     public void maxBy()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().maxBy(String::valueOf));
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void sumOfInt()
     {
-        Assert.assertEquals(0L, this.classUnderTest().sumOfInt(String::length));
+        assertEquals(0L, this.classUnderTest().sumOfInt(String::length));
     }
 
     @Override
     @Test
     public void sumOfFloat()
     {
-        Assert.assertEquals(0.0d, this.classUnderTest().sumOfFloat((String value) -> (float) value.length()), 0.0d);
+        assertEquals(0.0d, this.classUnderTest().sumOfFloat((String value) -> (float) value.length()), 0.0d);
     }
 
     @Override
     @Test
     public void sumOfLong()
     {
-        Assert.assertEquals(0L, this.classUnderTest().sumOfLong((String value) -> (long) value.length()));
+        assertEquals(0L, this.classUnderTest().sumOfLong((String value) -> (long) value.length()));
     }
 
     @Override
     @Test
     public void sumOfDouble()
     {
-        Assert.assertEquals(0.0d, this.classUnderTest().sumOfDouble((String value) -> (double) value.length()), 0.0d);
+        assertEquals(0.0d, this.classUnderTest().sumOfDouble((String value) -> (double) value.length()), 0.0d);
     }
 
     @Override
@@ -567,7 +574,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     {
         Verify.assertIterableEmpty(this.classUnderTest().flatCollect(StringIterate::toSet));
         UnifiedSet\<Character> target = UnifiedSet.newSet();
-        Assert.assertSame(target, this.classUnderTest().flatCollect(StringIterate::toSet, target));
+        assertSame(target, this.classUnderTest().flatCollect(StringIterate::toSet, target));
         Verify.assertIterableEmpty(target);
     }
 
@@ -578,7 +585,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
         Verify.assertIterableEmpty(this.classUnderTest().collect(StringFunctions.toUpperCase()));
 
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().collect(StringFunctions.toUpperCase(), target));
+        assertSame(target, this.classUnderTest().collect(StringFunctions.toUpperCase(), target));
         Verify.assertEmpty(target);
     }
 
@@ -590,7 +597,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
         Verify.assertIterableEmpty(this.classUnderTest().collectWith(function, "!"));
 
         FastList\<String> target = FastList.newList();
-        Assert.assertSame(target, this.classUnderTest().collectWith(function, "!", target));
+        assertSame(target, this.classUnderTest().collectWith(function, "!", target));
         Verify.assertEmpty(target);
     }
 
@@ -606,7 +613,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectBoolean_withTarget()
     {
         BooleanArrayList target = new BooleanArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
+        assertSame(target, this.classUnderTest().collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
         Verify.assertEmpty(target);
     }
 
@@ -622,7 +629,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectByte_withTarget()
     {
         ByteArrayList target = new ByteArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectByte(Byte::parseByte, target));
+        assertSame(target, this.classUnderTest().collectByte(Byte::parseByte, target));
         Verify.assertEmpty(target);
     }
 
@@ -638,7 +645,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectChar_withTarget()
     {
         CharArrayList target = new CharArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectChar(StringFunctions.toPrimitiveChar(), target));
+        assertSame(target, this.classUnderTest().collectChar(StringFunctions.toPrimitiveChar(), target));
         Verify.assertEmpty(target);
     }
 
@@ -654,7 +661,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectDouble_withTarget()
     {
         DoubleArrayList target = new DoubleArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectDouble(Double::parseDouble, target));
+        assertSame(target, this.classUnderTest().collectDouble(Double::parseDouble, target));
         Verify.assertEmpty(target);
     }
 
@@ -670,7 +677,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectFloat_withTarget()
     {
         FloatArrayList target = new FloatArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectFloat(Float::parseFloat, target));
+        assertSame(target, this.classUnderTest().collectFloat(Float::parseFloat, target));
         Verify.assertEmpty(target);
     }
 
@@ -686,7 +693,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectInt_withTarget()
     {
         IntArrayList target = new IntArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectInt(Integer::parseInt, target));
+        assertSame(target, this.classUnderTest().collectInt(Integer::parseInt, target));
         Verify.assertEmpty(target);
     }
 
@@ -702,7 +709,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectLong_withTarget()
     {
         LongArrayList target = new LongArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectLong(Long::parseLong, target));
+        assertSame(target, this.classUnderTest().collectLong(Long::parseLong, target));
         Verify.assertEmpty(target);
     }
 
@@ -718,7 +725,7 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     public void collectShort_withTarget()
     {
         ShortArrayList target = new ShortArrayList();
-        Assert.assertSame(target, this.classUnderTest().collectShort(Short::parseShort, target));
+        assertSame(target, this.classUnderTest().collectShort(Short::parseShort, target));
         Verify.assertEmpty(target);
     }
 
@@ -786,38 +793,38 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
 
         Map\<Long, String> targetMap3 = new HashMap\<>();
 
-        Assert.assertEquals(targetMap1, map.toMap(keyStringFunction, valueFunction, new HashMap\<String, String>()));
-        Assert.assertEquals(targetMap2, map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
-        Assert.assertEquals(targetMap3, map1.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
-        Assert.assertTrue(map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()) instanceof HashMap);
+        assertEquals(targetMap1, map.toMap(keyStringFunction, valueFunction, new HashMap\<String, String>()));
+        assertEquals(targetMap2, map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
+        assertEquals(targetMap3, map1.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()));
+        assertTrue(map.toMap(keyLongFunction, valueFunction, new HashMap\<Long, String>()) instanceof HashMap);
     }
 
     @Test
     public void sumByInt()
     {
         Immutable<name>ObjectMap\<Integer> map = new Immutable<name>ObjectEmptyMap\<>();
-        Assert.assertEquals(ObjectLongMaps.immutable.empty(), map.sumByInt(Object::toString, Integer::valueOf));
+        assertEquals(ObjectLongMaps.immutable.empty(), map.sumByInt(Object::toString, Integer::valueOf));
     }
 
     @Test
     public void sumByFloat()
     {
         Immutable<name>ObjectMap\<Integer> map = new Immutable<name>ObjectEmptyMap\<>();
-        Assert.assertEquals(ObjectDoubleMaps.immutable.empty(), map.sumByFloat(Object::toString, Float::valueOf));
+        assertEquals(ObjectDoubleMaps.immutable.empty(), map.sumByFloat(Object::toString, Float::valueOf));
     }
 
     @Test
     public void sumByLong()
     {
         Immutable<name>ObjectMap\<Integer> map = new Immutable<name>ObjectEmptyMap\<>();
-        Assert.assertEquals(ObjectLongMaps.immutable.empty(), map.sumByLong(Object::toString, Long::valueOf));
+        assertEquals(ObjectLongMaps.immutable.empty(), map.sumByLong(Object::toString, Long::valueOf));
     }
 
     @Test
     public void sumByDouble()
     {
         Immutable<name>ObjectMap\<Integer> map = new Immutable<name>ObjectEmptyMap\<>();
-        Assert.assertEquals(ObjectDoubleMaps.immutable.empty(), map.sumByDouble(Object::toString, Double::valueOf));
+        assertEquals(ObjectDoubleMaps.immutable.empty(), map.sumByDouble(Object::toString, Double::valueOf));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectHashMapTest.stg
@@ -22,8 +22,10 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectHashMap}.
@@ -42,9 +44,9 @@ public class Immutable<name>ObjectHashMapTest extends AbstractImmutable<name>Obj
     {
         Immutable<name>ObjectMap\<String> map1 = this.classUnderTest();
         Immutable<name>ObjectMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo").withKeyValue(<(literal.(type))("33")>, "thirtyThree").toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("33")>, "thirtyThree"));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("33")>, "thirtyThree"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue(<(literal.(type))("33")>, "thirtyThree"));
+        assertNotSame(map1, map1.newWithKeyValue(<(literal.(type))("33")>, "thirtyThree"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -52,9 +54,9 @@ public class Immutable<name>ObjectHashMapTest extends AbstractImmutable<name>Obj
     {
         Immutable<name>ObjectMap\<String> map1 = this.classUnderTest();
         Immutable<name>ObjectMap\<String> expected = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne");
-        Assert.assertEquals(expected, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertNotSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertNotSame(map1, map1.newWithoutKey(<(literal.(type))("32")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -62,9 +64,9 @@ public class Immutable<name>ObjectHashMapTest extends AbstractImmutable<name>Obj
     {
         Immutable<name>ObjectMap\<String> map1 = this.classUnderTest();
         Immutable<name>ObjectMap\<String> expected = this.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne");
-        Assert.assertEquals(expected, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertNotSame(map1, map1.newWithoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
@@ -58,8 +58,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectSingletonMap}.
@@ -77,68 +83,68 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(null));
-        Assert.assertTrue(this.classUnderTest().containsValue("zero"));
-        Assert.assertFalse(this.classUnderTest().containsValue("thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().containsValue("thirtyTwo"));
+        assertFalse(this.classUnderTest().containsValue(null));
+        assertTrue(this.classUnderTest().containsValue("zero"));
+        assertFalse(this.classUnderTest().containsValue("thirtyOne"));
+        assertFalse(this.classUnderTest().containsValue("thirtyTwo"));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(null));
-        Assert.assertTrue(this.classUnderTest().contains("zero"));
-        Assert.assertFalse(this.classUnderTest().contains("thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().contains("thirtyTwo"));
+        assertFalse(this.classUnderTest().contains(null));
+        assertTrue(this.classUnderTest().contains("zero"));
+        assertFalse(this.classUnderTest().contains("thirtyOne"));
+        assertFalse(this.classUnderTest().contains("thirtyTwo"));
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero")));
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith()));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith("zero")));
+        assertTrue(this.classUnderTest().containsAllIterable(FastList.newListWith()));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith("two", "one", "nine")));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(FastList.newListWith()));
-        Assert.assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
+        assertTrue(this.classUnderTest().containsAll(FastList.newListWith()));
+        assertTrue(this.classUnderTest().containsAll(FastList.newListWith("zero")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "thirtyOne", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("zero", "one", "thirtyTwo")));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith("two", "one", "nine")));
     }
 
     @Override
     @Test
     public void containsAllArguments()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllArguments());
-        Assert.assertTrue(this.classUnderTest().containsAllArguments("zero"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
-        Assert.assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
+        assertTrue(this.classUnderTest().containsAllArguments());
+        assertTrue(this.classUnderTest().containsAllArguments("zero"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "thirtyOne", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("zero", "one", "thirtyTwo"));
+        assertFalse(this.classUnderTest().containsAllArguments("two", "one", "nine"));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
     }
 
     @Override
@@ -147,23 +153,23 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     {
         Function0\<String> ifAbsent = () -> "ifAbsent";
 
-        Assert.assertEquals("zero", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
+        assertEquals("zero", this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, ifAbsent));
 
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, ifAbsent));
+        assertEquals("ifAbsent", this.classUnderTest().getIfAbsent(<(literal.(type))("33")>, ifAbsent));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals("zero", this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("32")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
-        Assert.assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
+        assertEquals("zero", this.classUnderTest().get(<(literal.(type))("0")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("1")>));
+        assertNull(this.classUnderTest().get(<(literal.(type))("33")>));
     }
 
     @Override
@@ -171,32 +177,32 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void iterator()
     {
         Iterator\<String> iterator = this.classUnderTest().iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals("zero", iterator.next());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertTrue(iterator.hasNext());
+        assertEquals("zero", iterator.next());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertEquals("zero", this.classUnderTest().getFirst());
+        assertEquals("zero", this.classUnderTest().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertEquals("zero", this.classUnderTest().getLast());
+        assertEquals("zero", this.classUnderTest().getLast());
     }
 
     @Override
     @Test
     public void getOnly()
     {
-        Assert.assertEquals("zero", this.classUnderTest().getOnly());
+        assertEquals("zero", this.classUnderTest().getOnly());
     }
 
     @Override
@@ -205,8 +211,8 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     {
         StringBuilder concat = new StringBuilder();
         Immutable<name>ObjectMap\<String> map = this.classUnderTest();
-        Assert.assertSame(map, map.tap(concat::append));
-        Assert.assertEquals("zero", concat.toString());
+        assertSame(map, map.tap(concat::append));
+        assertEquals("zero", concat.toString());
     }
 
     @Override
@@ -217,7 +223,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
 
         this.classUnderTest().forEach(Procedures.cast(each -> concat[0] += each));
 
-        Assert.assertEquals("zero", concat[0]);
+        assertEquals("zero", concat[0]);
     }
 
     @Override
@@ -232,7 +238,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
             concat[0] += parameter;
         });
 
-        Assert.assertEquals("zero0", concat[0]);
+        assertEquals("zero0", concat[0]);
     }
 
     @Override
@@ -247,7 +253,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
             concat[0] += argument2;
         }, "-");
 
-        Assert.assertEquals("zero-", concat[0]);
+        assertEquals("zero-", concat[0]);
     }
 
     @Override
@@ -258,7 +264,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
 
         this.classUnderTest().forEachValue((String each) -> concat[0] += each);
 
-        Assert.assertEquals("zero", concat[0]);
+        assertEquals("zero", concat[0]);
     }
 
     @Override
@@ -269,7 +275,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
 
         this.classUnderTest().forEachKey((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Override
@@ -284,42 +290,42 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
             concat[0] += parameter;
         });
 
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>zero", concat[0]);
+        assertEquals("<(toStringLiteral.(type))("0")>zero", concat[0]);
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"),
                 this.classUnderTest().select((<type> value, String object) -> value == 0));
 
         Verify.assertIterableEmpty(this.classUnderTest().select((<type> value, String object) -> value != 0));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().select(Predicates.equal("zero")));
+        assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().select(Predicates.equal("zero")));
         Verify.assertIterableEmpty(this.classUnderTest().select(Predicates.equal("one")));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().select(Predicates.equal("zero"), target));
-        Assert.assertEquals(HashBag.newBagWith("zero"), target);
+        assertSame(target, this.classUnderTest().select(Predicates.equal("zero"), target));
+        assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     public void selectWith()
     {
-        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectWith(Object::equals, "zero"));
+        assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectWith(Object::equals, "zero"));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().selectWith(Object::equals, "zero", target));
-        Assert.assertEquals(HashBag.newBagWith("zero"), target);
+        assertSame(target, this.classUnderTest().selectWith(Object::equals, "zero", target));
+        assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectInstancesOf(String.class));
+        assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectInstancesOf(String.class));
         Verify.assertIterableEmpty(this.classUnderTest().selectInstancesOf(Integer.class));
     }
 
@@ -327,94 +333,94 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void reject()
     {
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"),
                 this.classUnderTest().reject((value, object) -> value != 0));
 
         Verify.assertIterableEmpty(this.classUnderTest().reject((value, object) -> value == 0));
 
-        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().reject(Predicates.equal("one")));
+        assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().reject(Predicates.equal("one")));
         Verify.assertIterableEmpty(this.classUnderTest().reject(Predicates.equal("zero")));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().reject(Predicates.equal("one"), target));
-        Assert.assertEquals(HashBag.newBagWith("zero"), target);
+        assertSame(target, this.classUnderTest().reject(Predicates.equal("one"), target));
+        assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().rejectWith(Object::equals, "one"));
+        assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().rejectWith(Object::equals, "one"));
         Verify.assertIterableEmpty(this.classUnderTest().rejectWith(Object::equals, "zero"));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().rejectWith(Object::equals, "one", target));
-        Assert.assertEquals(HashBag.newBagWith("zero"), target);
+        assertSame(target, this.classUnderTest().rejectWith(Object::equals, "one", target));
+        assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     @Test
     public void detect()
     {
-        Assert.assertEquals("zero", this.classUnderTest().detect(Predicates.equal("zero")));
-        Assert.assertNull(this.classUnderTest().detect(Predicates.equal("one")));
+        assertEquals("zero", this.classUnderTest().detect(Predicates.equal("zero")));
+        assertNull(this.classUnderTest().detect(Predicates.equal("one")));
     }
 
     @Override
     @Test
     public void detectWith()
     {
-        Assert.assertEquals("zero", this.classUnderTest().detectWith(Object::equals, "zero"));
-        Assert.assertNull(this.classUnderTest().detectWith(Object::equals, "one"));
+        assertEquals("zero", this.classUnderTest().detectWith(Object::equals, "zero"));
+        assertNull(this.classUnderTest().detectWith(Object::equals, "one"));
     }
 
     @Override
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(Optional.of("zero"), this.classUnderTest().detectOptional(Predicates.equal("zero")));
-        Assert.assertEquals(Optional.empty(), this.classUnderTest().detectOptional(Predicates.equal("one")));
+        assertEquals(Optional.of("zero"), this.classUnderTest().detectOptional(Predicates.equal("zero")));
+        assertEquals(Optional.empty(), this.classUnderTest().detectOptional(Predicates.equal("one")));
     }
 
     @Override
     @Test
     public void detectWithOptional()
     {
-        Assert.assertEquals(Optional.of("zero"), this.classUnderTest().detectWithOptional(Object::equals, "zero"));
-        Assert.assertEquals(Optional.empty(), this.classUnderTest().detectWithOptional(Object::equals, "one"));
+        assertEquals(Optional.of("zero"), this.classUnderTest().detectWithOptional(Object::equals, "zero"));
+        assertEquals(Optional.empty(), this.classUnderTest().detectWithOptional(Object::equals, "one"));
     }
 
     @Override
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals("zero", this.classUnderTest().detectIfNone(Predicates.equal("zero"), Functions0.value("default")));
-        Assert.assertEquals("default", this.classUnderTest().detectIfNone(Predicates.equal("one"), Functions0.value("default")));
+        assertEquals("zero", this.classUnderTest().detectIfNone(Predicates.equal("zero"), Functions0.value("default")));
+        assertEquals("default", this.classUnderTest().detectIfNone(Predicates.equal("one"), Functions0.value("default")));
     }
 
     @Override
     @Test
     public void detectWithIfNone()
     {
-        Assert.assertEquals("zero", this.classUnderTest().detectWithIfNone(Object::equals, "zero", Functions0.value("default")));
-        Assert.assertEquals("default", this.classUnderTest().detectWithIfNone(Object::equals, "one", Functions0.value("default")));
+        assertEquals("zero", this.classUnderTest().detectWithIfNone(Object::equals, "zero", Functions0.value("default")));
+        assertEquals("default", this.classUnderTest().detectWithIfNone(Object::equals, "one", Functions0.value("default")));
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(1, this.classUnderTest().count(Predicates.equal("zero")));
-        Assert.assertEquals(0, this.classUnderTest().count(Predicates.equal("one")));
+        assertEquals(1, this.classUnderTest().count(Predicates.equal("zero")));
+        assertEquals(0, this.classUnderTest().count(Predicates.equal("one")));
     }
 
     @Override
     @Test
     public void countWith()
     {
-        Assert.assertEquals(1, this.classUnderTest().countWith(Object::equals, "zero"));
-        Assert.assertEquals(0, this.classUnderTest().countWith(Object::equals, "one"));
+        assertEquals(1, this.classUnderTest().countWith(Object::equals, "zero"));
+        assertEquals(0, this.classUnderTest().countWith(Object::equals, "one"));
     }
 
     @Override
@@ -422,47 +428,47 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void anySatisfy()
     {
         Verify.assertAnySatisfy(this.classUnderTest(), StringPredicates.endsWith("o"));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.equal("ten")));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.equal("ten")));
     }
 
     @Override
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(StringPredicates2.endsWith(), "o"));
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Object::equals, "ten"));
+        assertTrue(this.classUnderTest().anySatisfyWith(StringPredicates2.endsWith(), "o"));
+        assertFalse(this.classUnderTest().anySatisfyWith(Object::equals, "ten"));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(StringPredicates.endsWith("o")));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.equal("nine")));
+        assertTrue(this.classUnderTest().allSatisfy(StringPredicates.endsWith("o")));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.equal("nine")));
     }
 
     @Override
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(StringPredicates2.contains(), "o"));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Object::equals, "nine"));
+        assertTrue(this.classUnderTest().allSatisfyWith(StringPredicates2.contains(), "o"));
+        assertFalse(this.classUnderTest().allSatisfyWith(Object::equals, "nine"));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(StringPredicates.endsWith("o")));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.equal("ten")));
+        assertFalse(this.classUnderTest().noneSatisfy(StringPredicates.endsWith("o")));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.equal("ten")));
     }
 
     @Override
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(StringPredicates2.notContains(), "e"));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(StringPredicates2.endsWith(), "o"));
+        assertTrue(this.classUnderTest().noneSatisfyWith(StringPredicates2.notContains(), "e"));
+        assertFalse(this.classUnderTest().noneSatisfyWith(StringPredicates2.endsWith(), "o"));
     }
 
     @Override
@@ -471,7 +477,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     {
         PartitionIterable\<String> result = this.classUnderTest().partition(StringPredicates.endsWith("ne"));
         Verify.assertIterableEmpty(result.getSelected());
-        Assert.assertEquals(HashBag.newBagWith("zero"), result.getRejected());
+        assertEquals(HashBag.newBagWith("zero"), result.getRejected());
     }
 
     @Override
@@ -479,91 +485,91 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void partitionWith()
     {
         PartitionIterable\<String> result = this.classUnderTest().partitionWith(StringPredicates2.endsWith(), "ro");
-        Assert.assertEquals(HashBag.newBagWith("zero"), result.getSelected());
+        assertEquals(HashBag.newBagWith("zero"), result.getSelected());
         Verify.assertIterableEmpty(result.getRejected());
     }
 
     @Test
     public void min_withComparator()
     {
-        Assert.assertEquals("zero", this.classUnderTest().min(Comparators.naturalOrder()));
+        assertEquals("zero", this.classUnderTest().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max_withComparator()
     {
-        Assert.assertEquals("zero", this.classUnderTest().max(Comparators.naturalOrder()));
+        assertEquals("zero", this.classUnderTest().max(Comparators.naturalOrder()));
     }
 
     @Override
     @Test
     public void minBy()
     {
-        Assert.assertEquals("zero", this.classUnderTest().minBy(String::valueOf));
+        assertEquals("zero", this.classUnderTest().minBy(String::valueOf));
     }
 
     @Override
     @Test
     public void maxBy()
     {
-        Assert.assertEquals("zero", this.classUnderTest().maxBy(String::valueOf));
+        assertEquals("zero", this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertEquals("zero", this.classUnderTest().min());
+        assertEquals("zero", this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertEquals("zero", this.classUnderTest().max());
+        assertEquals("zero", this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void sumOfInt()
     {
-        Assert.assertEquals(4L, this.classUnderTest().sumOfInt(String::length));
+        assertEquals(4L, this.classUnderTest().sumOfInt(String::length));
     }
 
     @Override
     @Test
     public void sumOfFloat()
     {
-        Assert.assertEquals(4.0d, this.classUnderTest().sumOfFloat(value -> (float) value.length()), 0.0d);
+        assertEquals(4.0d, this.classUnderTest().sumOfFloat(value -> (float) value.length()), 0.0d);
     }
 
     @Override
     @Test
     public void sumOfLong()
     {
-        Assert.assertEquals(4L, this.classUnderTest().sumOfLong(value -> (long) value.length()));
+        assertEquals(4L, this.classUnderTest().sumOfLong(value -> (long) value.length()));
     }
 
     @Override
     @Test
     public void sumOfDouble()
     {
-        Assert.assertEquals(4.0d, this.classUnderTest().sumOfDouble(value -> (double) value.length()), 0.0d);
+        assertEquals(4.0d, this.classUnderTest().sumOfDouble(value -> (double) value.length()), 0.0d);
     }
 
     @Override
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith("ZERO"),
                 this.classUnderTest().collectIf(StringPredicates.endsWith("ro"), StringFunctions.toUpperCase()));
         Verify.assertIterableEmpty(this.classUnderTest().collectIf(StringPredicates.endsWith("ne"), StringFunctions.toUpperCase()));
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(
+        assertSame(
                 target,
                 this.classUnderTest().collectIf(StringPredicates.endsWith("ro"), StringFunctions.toUpperCase(), target));
-        Assert.assertEquals(HashBag.newBagWith("ZERO"), target);
+        assertEquals(HashBag.newBagWith("ZERO"), target);
     }
 
     @Override
@@ -572,7 +578,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     {
         Verify.assertBagsEqual(HashBag.newBagWith('z', 'e', 'r', 'o'), this.classUnderTest().flatCollect(StringIterate::toSet));
         MutableBag\<Character> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().flatCollect(StringIterate::toSet, target));
+        assertSame(target, this.classUnderTest().flatCollect(StringIterate::toSet, target));
         Verify.assertBagsEqual(HashBag.newBagWith('z', 'e', 'r', 'o'), target);
     }
 
@@ -580,11 +586,11 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collect()
     {
-        Assert.assertEquals(HashBag.newBagWith("ZERO"), this.classUnderTest().collect(StringFunctions.toUpperCase()));
+        assertEquals(HashBag.newBagWith("ZERO"), this.classUnderTest().collect(StringFunctions.toUpperCase()));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().collect(StringFunctions.toUpperCase(), target));
-        Assert.assertEquals(HashBag.newBagWith("ZERO"), target);
+        assertSame(target, this.classUnderTest().collect(StringFunctions.toUpperCase(), target));
+        assertEquals(HashBag.newBagWith("ZERO"), target);
     }
 
     @Override
@@ -592,18 +598,18 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectWith()
     {
         Function2\<String, String, String> function = (String each, String param) -> each.toUpperCase() + param;
-        Assert.assertEquals(HashBag.newBagWith("ZERO!"), this.classUnderTest().collectWith(function, "!"));
+        assertEquals(HashBag.newBagWith("ZERO!"), this.classUnderTest().collectWith(function, "!"));
 
         MutableBag\<String> target = HashBag.newBag();
-        Assert.assertSame(target, this.classUnderTest().collectWith(function, "!", target));
-        Assert.assertEquals(HashBag.newBagWith("ZERO!"), target);
+        assertSame(target, this.classUnderTest().collectWith(function, "!", target));
+        assertEquals(HashBag.newBagWith("ZERO!"), target);
     }
 
     @Override
     @Test
     public void collectBoolean()
     {
-        Assert.assertEquals(
+        assertEquals(
                 BooleanHashBag.newBagWith(true),
                 this.newWithKeysValues(<(literal.(type))("0")>, "true").collectBoolean(StringFunctions.toPrimitiveBoolean()));
     }
@@ -613,15 +619,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectBoolean_withTarget()
     {
         MutableBooleanBag target = new BooleanHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "true").collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "true").collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
+        assertEquals(BooleanHashBag.newBagWith(true), target);
     }
 
     @Override
     @Test
     public void collectByte()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ByteHashBag.newBagWith((byte) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectByte(Byte::parseByte));
     }
@@ -631,15 +637,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectByte_withTarget()
     {
         MutableByteBag target = new ByteHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectByte(Byte::parseByte, target));
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectByte(Byte::parseByte, target));
+        assertEquals(ByteHashBag.newBagWith((byte) 0), target);
     }
 
     @Override
     @Test
     public void collectChar()
     {
-        Assert.assertEquals(
+        assertEquals(
                 CharHashBag.newBagWith((char) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectChar(StringFunctions.toPrimitiveChar()));
     }
@@ -649,15 +655,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectChar_withTarget()
     {
         MutableCharBag target = new CharHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectChar(StringFunctions.toPrimitiveChar(), target));
-        Assert.assertEquals(CharHashBag.newBagWith((char) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectChar(StringFunctions.toPrimitiveChar(), target));
+        assertEquals(CharHashBag.newBagWith((char) 0), target);
     }
 
     @Override
     @Test
     public void collectDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashBag.newBagWith((double) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectDouble(Double::parseDouble));
     }
@@ -667,15 +673,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectDouble_withTarget()
     {
         MutableDoubleBag target = new DoubleHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectDouble(Double::parseDouble, target));
-        Assert.assertEquals(DoubleHashBag.newBagWith((double) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectDouble(Double::parseDouble, target));
+        assertEquals(DoubleHashBag.newBagWith((double) 0), target);
     }
 
     @Override
     @Test
     public void collectFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashBag.newBagWith((float) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectFloat(Float::parseFloat));
     }
@@ -685,15 +691,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectFloat_withTarget()
     {
         MutableFloatBag target = new FloatHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectFloat(Float::parseFloat, target));
-        Assert.assertEquals(FloatHashBag.newBagWith((float) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectFloat(Float::parseFloat, target));
+        assertEquals(FloatHashBag.newBagWith((float) 0), target);
     }
 
     @Override
     @Test
     public void collectInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 IntHashBag.newBagWith((int) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectInt(Integer::parseInt));
     }
@@ -703,15 +709,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectInt_withTarget()
     {
         MutableIntBag target = new IntHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectInt(Integer::parseInt, target));
-        Assert.assertEquals(IntHashBag.newBagWith((int) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectInt(Integer::parseInt, target));
+        assertEquals(IntHashBag.newBagWith((int) 0), target);
     }
 
     @Override
     @Test
     public void collectLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LongHashBag.newBagWith(0L),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectLong(Long::parseLong));
     }
@@ -721,15 +727,15 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectLong_withTarget()
     {
         MutableLongBag target = new LongHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectLong(Long::parseLong, target));
-        Assert.assertEquals(LongHashBag.newBagWith(0L), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectLong(Long::parseLong, target));
+        assertEquals(LongHashBag.newBagWith(0L), target);
     }
 
     @Override
     @Test
     public void collectShort()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ShortHashBag.newBagWith((short) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectShort(Short::parseShort));
     }
@@ -739,8 +745,8 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectShort_withTarget()
     {
         MutableShortBag target = new ShortHashBag();
-        Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectShort(Short::parseShort, target));
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 0), target);
+        assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectShort(Short::parseShort, target));
+        assertEquals(ShortHashBag.newBagWith((short) 0), target);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
@@ -32,8 +32,14 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;<endif>
 import org.eclipse.collections.impl.math.Mutable<wrapperName2>;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>EmptyMap}.
@@ -52,54 +58,54 @@ public class Immutable<name1><name2>EmptyMapTest extends AbstractImmutable<name1
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
         Immutable<name1><name2>Map expected = this.newWithKeysValues(<["0"]:keyValue(); separator=", ">);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
+        assertNotSame(map1, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
     public void newWithoutKeyValue()
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
     public void newWithoutAllKeys()
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.map.containsValue(<(literal.(type2))("0")>));
-        Assert.assertFalse(this.map.containsValue(<(literal.(type2))("31")>));
-        Assert.assertFalse(this.map.containsValue(<(literal.(type2))("32")>));
+        assertFalse(this.map.containsValue(<(literal.(type2))("0")>));
+        assertFalse(this.map.containsValue(<(literal.(type2))("31")>));
+        assertFalse(this.map.containsValue(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(this.map.contains(<(literal.(type2))("31")>));
-        Assert.assertFalse(this.map.contains(<(literal.(type2))("32")>));
+        assertFalse(this.map.contains(<(literal.(type2))("0")>));
+        assertFalse(this.map.contains(<(literal.(type2))("31")>));
+        assertFalse(this.map.contains(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("15")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("15")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("25")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("25")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("5")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("15")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("15")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("25")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("25")>)<wideDelta.(type2)>);
     }
 
     @Override
@@ -114,121 +120,121 @@ public class Immutable<name1><name2>EmptyMapTest extends AbstractImmutable<name1
     public void <type2>Iterator()
     {
         <name2>Iterator iterator = this.map.<type2>Iterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type1))("0")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type1))("32")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type1))("0")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type1))("32")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
-        Assert.assertFalse(this.map.containsAll(<["0", "31", "35"]:(literal.(type2))(); separator=", ">));
-        Assert.assertTrue(this.map.containsAll());
+        assertFalse(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
+        assertFalse(this.map.containsAll(<["0", "31", "35"]:(literal.(type2))(); separator=", ">));
+        assertTrue(this.map.containsAll());
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("0")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("31")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("0")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("31")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("32")>));
     }
 
     @Override
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name1>ArrayList.newListWith(), this.map.keysView().toSortedList());
+        assertEquals(<name1>ArrayList.newListWith(), this.map.keysView().toSortedList());
     }
 
     @Override
     @Test
     public void toSortedArray()
     {
-        Assert.assertEquals(this.map.toSortedArray().length, 0);
+        assertEquals(this.map.toSortedArray().length, 0);
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertTrue(this.map.containsAll(new <name2>ArrayList()));
+        assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
+        assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
+        assertTrue(this.map.containsAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().isEmpty());
+        assertTrue(this.classUnderTest().isEmpty());
     }
 
     @Override
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((<type1> value1, <type2> value2) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((<type1> value1, <type2> value2) -> true));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((<type1> value1, <type2> value2) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((<type1> value1, <type2> value2) -> false));
     }
 
     @Override
     @Test
     public void select_value()
     {
-        Assert.assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().select(value -> true));
+        assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().select(value -> true));
     }
 
     @Override
     @Test
     public void reject_value()
     {
-        Assert.assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().reject(value -> false));
+        assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().reject(value -> false));
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count((<type2> value) -> true));
+        assertEquals(0, this.classUnderTest().count((<type2> value) -> true));
     }
 
     @Override
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.classUnderTest().sum()<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.classUnderTest().sum()<wideDelta.(type2)>);
     }
 
     @Test
@@ -236,7 +242,7 @@ public class Immutable<name1><name2>EmptyMapTest extends AbstractImmutable<name1
     {
         Immutable<name1><name2>EmptyMap iterable = new Immutable<name1><name2>EmptyMap();
         Mutable<wrapperName2> result = iterable.injectInto(new Mutable<wrapperName2>(<(literal.(type2))("0")>), Mutable<wrapperName2>::add);
-        Assert.assertEquals(new Mutable<wrapperName2>(<(literal.(type2))("0")>), result);
+        assertEquals(new Mutable<wrapperName2>(<(literal.(type2))("0")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveHashMapTest.stg
@@ -26,8 +26,11 @@ import org.eclipse.collections.api.map.primitive.Immutable<name1><name2>Map;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.math.Mutable<primitive2.wrapperName>;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>HashMap}.
@@ -41,7 +44,7 @@ public class Immutable<name1><name2>HashMapTest extends AbstractImmutable<name1>
     {
         super.toImmutable();
         Immutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertSame(map1, map1.toImmutable());
+        assertSame(map1, map1.toImmutable());
     }
 
     @Test
@@ -49,9 +52,9 @@ public class Immutable<name1><name2>HashMapTest extends AbstractImmutable<name1>
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
         Immutable<name1><name2>Map expected = this.newWithKeysValues(<["0", "31", "32", "33"]:keyValue(); separator=", ">);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<["33"]:keyValue(); separator=", ">));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<["33"]:keyValue(); separator=", ">));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue(<["33"]:keyValue(); separator=", ">));
+        assertNotSame(map1, map1.newWithKeyValue(<["33"]:keyValue(); separator=", ">));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -59,9 +62,9 @@ public class Immutable<name1><name2>HashMapTest extends AbstractImmutable<name1>
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
         Immutable<name1><name2>Map expected = this.newWithKeysValues(<["0", "31"]:keyValue(); separator=", ">);
-        Assert.assertEquals(expected, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertNotSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertNotSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -69,9 +72,9 @@ public class Immutable<name1><name2>HashMapTest extends AbstractImmutable<name1>
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
         Immutable<name1><name2>Map expected = this.newWithKeysValues(<["31"]:keyValue(); separator=", ">);
-        Assert.assertEquals(expected, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertNotSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -79,7 +82,7 @@ public class Immutable<name1><name2>HashMapTest extends AbstractImmutable<name1>
     {
         Immutable<name1><name2>HashMap iterable = new Immutable<name1><name2>HashMap(<name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">));
         Mutable<primitive2.wrapperName> result = iterable.injectInto(new Mutable<primitive2.wrapperName>(<(literal.(type2))("0")>), Mutable<primitive2.wrapperName>::add);
-        Assert.assertEquals(new Mutable<primitive2.wrapperName>(<(literal.(type2))("6")>), result);
+        assertEquals(new Mutable<primitive2.wrapperName>(<(literal.(type2))("6")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
@@ -36,8 +36,14 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;<endif>
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.math.Mutable<primitive2.wrapperName>;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>SingletonMap}.
@@ -56,69 +62,69 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
         Immutable<name1><name2>Map expected = this.newWithKeysValues(<["0"]:keyValue(); separator=", ">);
-        Assert.assertEquals(expected, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
-        Assert.assertNotSame(map1, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
+        assertEquals(expected, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
+        assertNotSame(map1, map1.newWithKeyValue(<["0"]:keyValue(); separator=", ">));
     }
 
     @Test
     public void newWithoutKeyValue()
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertEquals(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertSame(map1, map1.newWithoutKey(<(literal.(type1))("32")>));
+        assertEquals(this.classUnderTest(), map1);
 
         Immutable<name1><name2>Map map2 = this.classUnderTest();
-        Assert.assertEquals(this.getEmptyMap(), map2.newWithoutKey(<(literal.(type1))("0")>));
-        Assert.assertNotSame(map2, map2.newWithoutKey(<(literal.(type1))("0")>));
-        Assert.assertEquals(this.classUnderTest(), map2);
+        assertEquals(this.getEmptyMap(), map2.newWithoutKey(<(literal.(type1))("0")>));
+        assertNotSame(map2, map2.newWithoutKey(<(literal.(type1))("0")>));
+        assertEquals(this.classUnderTest(), map2);
     }
 
     @Test
     public void newWithoutAllKeys()
     {
         Immutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertEquals(this.getEmptyMap(), map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(this.getEmptyMap(), map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertNotSame(map1, map1.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertEquals(this.classUnderTest(), map1);
 
         Immutable<name1><name2>Map map2 = this.classUnderTest();
-        Assert.assertEquals(map2, map2.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("31")>, <(literal.(type1))("32")>)));
-        Assert.assertEquals(this.classUnderTest(), map2);
+        assertEquals(map2, map2.newWithoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("31")>, <(literal.(type1))("32")>)));
+        assertEquals(this.classUnderTest(), map2);
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
-        Assert.assertFalse(this.map.containsValue(<(literal.(type2))("31")>));
-        Assert.assertFalse(this.map.containsValue(<(literal.(type2))("32")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
+        assertFalse(this.map.containsValue(<(literal.(type2))("31")>));
+        assertFalse(this.map.containsValue(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(this.map.contains(<(literal.(type2))("31")>));
-        Assert.assertFalse(this.map.contains(<(literal.(type2))("32")>));
+        assertTrue(this.map.contains(<(literal.(type2))("0")>));
+        assertFalse(this.map.contains(<(literal.(type2))("31")>));
+        assertFalse(this.map.contains(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("15")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("15")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("25")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("25")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("15")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("15")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("25")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("25")>)<wideDelta.(type2)>);
     }
 
     @Override
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), this.map.asLazy().toList());
+        assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), this.map.asLazy().toList());
     }
 
     @Override
@@ -126,72 +132,72 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void <type2>Iterator()
     {
         <name2>Iterator iterator = this.map.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, iterator.next()<wideDelta.(type2)>);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type2))("0")>, iterator.next()<wideDelta.(type2)>);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("31")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("32")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("31")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("32")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
-        Assert.assertFalse(this.map.containsAll(<["31", "35"]:(literal.(type2))(); separator=", ">));
-        Assert.assertTrue(this.map.containsAll(<(literal.(type2))("0")>));
-        Assert.assertTrue(this.map.containsAll());
+        assertFalse(this.map.containsAll(<["0", "31", "32"]:(literal.(type2))(); separator=", ">));
+        assertFalse(this.map.containsAll(<["31", "35"]:(literal.(type2))(); separator=", ">));
+        assertTrue(this.map.containsAll(<(literal.(type2))("0")>));
+        assertTrue(this.map.containsAll());
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("31")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("32")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("31")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("32")>));
     }
 
     @Override
     @Test
     public void keysView()
     {
-        Assert.assertEquals(<name1>ArrayList.newListWith(<(literal.(type1))("0")>), this.map.keysView().toSortedList());
+        assertEquals(<name1>ArrayList.newListWith(<(literal.(type1))("0")>), this.map.keysView().toSortedList());
     }
 
     @Override
     @Test
     public void toSortedArray()
     {
-        Assert.assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("0")>}, this.map.toSortedArray()));
+        assertTrue(Arrays.equals(new <type2>[]{<(literal.(type2))("0")>}, this.map.toSortedArray()));
     }
 
     @Override
     @Test
     public void containsAll_Iterable()
     {
-        Assert.assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertTrue(this.map.containsAll(<name2>ArrayList.newListWith(<["0"]:(literal.(type2))(); separator=", ">)));
-        Assert.assertTrue(this.map.containsAll(new <name2>ArrayList()));
+        assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "32"]:(literal.(type2))(); separator=", ">)));
+        assertFalse(this.map.containsAll(<name2>ArrayList.newListWith(<["0", "31", "35"]:(literal.(type2))(); separator=", ">)));
+        assertTrue(this.map.containsAll(<name2>ArrayList.newListWith(<["0"]:(literal.(type2))(); separator=", ">)));
+        assertTrue(this.map.containsAll(new <name2>ArrayList()));
     }
 
     @Override
@@ -199,9 +205,9 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void select()
     {
         <name1><name2>Map actual1 = this.classUnderTest().select((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("0")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), actual1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), actual1);
         <name1><name2>Map actual2 = this.classUnderTest().select((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("1")>})>);
-        Assert.assertEquals(this.getEmptyMap(), actual2);
+        assertEquals(this.getEmptyMap(), actual2);
     }
 
     @Override
@@ -209,9 +215,9 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void reject()
     {
         <name1><name2>Map actual1 = this.classUnderTest().reject((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("1")>})>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), actual1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), actual1);
         <name1><name2>Map actual2 = this.classUnderTest().reject((<type1> key, <type2> value) -> <(equals.(type1))("key", {<(literal.(type1))("0")>})>);
-        Assert.assertEquals(this.getEmptyMap(), actual2);
+        assertEquals(this.getEmptyMap(), actual2);
     }
 
     @Override
@@ -219,10 +225,10 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void select_value()
     {
         <name2>Iterable actual1 = this.classUnderTest().select(<name2>Predicates.equal(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>Bags.immutable.empty(), actual1);
+        assertEquals(<name2>Bags.immutable.empty(), actual1);
 
         <name2>Iterable actual2 = this.classUnderTest().select(<name2>Predicates.equal(<(literal.(type2))("0")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
     }
 
     @Override
@@ -230,18 +236,18 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void reject_value()
     {
         <name2>Iterable actual1 = this.classUnderTest().reject(<name2>Predicates.equal(<(literal.(type2))("0")>));
-        Assert.assertEquals(<name2>Bags.immutable.empty(), actual1);
+        assertEquals(<name2>Bags.immutable.empty(), actual1);
 
         <name2>Iterable actual2 = this.classUnderTest().reject(<name2>Predicates.equal(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
+        assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count(<name2>Predicates.equal(<(literal.(type2))("1")>)));
-        Assert.assertEquals(1, this.classUnderTest().count(<name2>Predicates.equal(<(literal.(type2))("0")>)));
+        assertEquals(0, this.classUnderTest().count(<name2>Predicates.equal(<(literal.(type2))("1")>)));
+        assertEquals(1, this.classUnderTest().count(<name2>Predicates.equal(<(literal.(type2))("0")>)));
     }
 
     @Test
@@ -249,7 +255,7 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     {
         Immutable<name1><name2>SingletonMap iterable = new Immutable<name1><name2>SingletonMap(<["1"]:keyValue(); separator=", ">);
         Mutable<primitive2.wrapperName> result = iterable.injectInto(new Mutable<primitive2.wrapperName>(<(literal.(type2))("0")>), Mutable<primitive2.wrapperName>::add);
-        Assert.assertEquals(new Mutable<primitive2.wrapperName>(<(literal.(type2))("1")>), result);
+        assertEquals(new Mutable<primitive2.wrapperName>(<(literal.(type2))("1")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
@@ -32,8 +32,13 @@ import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.map.primitive.AbstractObject<name>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutableObjectPrimitiveMapTestCase.stg.
@@ -80,15 +85,15 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
         hashMap.put("0", <(literal.(type))("0")>);
         hashMap.clear();
-        Assert.assertEquals(Object<name>HashMap.newMap(), hashMap);
+        assertEquals(Object<name>HashMap.newMap(), hashMap);
 
         hashMap.put("1", <(literal.(type))("0")>);
         hashMap.clear();
-        Assert.assertEquals(Object<name>HashMap.newMap(), hashMap);
+        assertEquals(Object<name>HashMap.newMap(), hashMap);
 
         hashMap.put(null, <(literal.(type))("0")>);
         hashMap.clear();
-        Assert.assertEquals(Object<name>HashMap.newMap(), hashMap);
+        assertEquals(Object<name>HashMap.newMap(), hashMap);
     }
 
     @Test
@@ -96,45 +101,45 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         MutableObject<name>Map\<String> map0 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
         map0.removeKey("1");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>), map0);
+        assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>), map0);
         map0.removeKey("0");
-        Assert.assertEquals(Object<name>HashMap.newMap(), map0);
+        assertEquals(Object<name>HashMap.newMap(), map0);
 
         MutableObject<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
         map1.removeKey("0");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), map1);
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), map1);
         map1.removeKey("1");
-        Assert.assertEquals(Object<name>HashMap.newMap(), map1);
+        assertEquals(Object<name>HashMap.newMap(), map1);
 
         this.map.removeKey("5");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
         this.map.removeKey("0");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
         this.map.removeKey("1");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
         this.map.removeKey("2");
-        Assert.assertEquals(Object<name>HashMap.newMap(), this.map);
+        assertEquals(Object<name>HashMap.newMap(), this.map);
         this.map.removeKey("0");
         this.map.removeKey("1");
         this.map.removeKey("2");
-        Assert.assertEquals(Object<name>HashMap.newMap(), this.map);
+        assertEquals(Object<name>HashMap.newMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0), <(literal.(type))("1")>);
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1), <(literal.(type))("2")>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
         this.map.removeKey(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
         this.map.removeKey(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("3")>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
         this.map.removeKey(null);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
     }
 
     @Test
@@ -142,45 +147,45 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         MutableObject<name>Map\<String> map0 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
         map0.remove("1");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>), map0);
+        assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>), map0);
         map0.remove("0");
-        Assert.assertEquals(Object<name>HashMap.newMap(), map0);
+        assertEquals(Object<name>HashMap.newMap(), map0);
 
         MutableObject<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
         map1.remove("0");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), map1);
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>), map1);
         map1.remove("1");
-        Assert.assertEquals(Object<name>HashMap.newMap(), map1);
+        assertEquals(Object<name>HashMap.newMap(), map1);
 
         this.map.remove("5");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
         this.map.remove("0");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
         this.map.remove("1");
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
         this.map.remove("2");
-        Assert.assertEquals(Object<name>HashMap.newMap(), this.map);
+        assertEquals(Object<name>HashMap.newMap(), this.map);
         this.map.remove("0");
         this.map.remove("1");
         this.map.remove("2");
-        Assert.assertEquals(Object<name>HashMap.newMap(), this.map);
+        assertEquals(Object<name>HashMap.newMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0), <(literal.(type))("1")>);
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1), <(literal.(type))("2")>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
         this.map.remove(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(0))<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
         this.map.remove(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(generateCollisions().get(1))<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("3")>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
         this.map.remove(null);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
     }
 
     @Test
@@ -190,15 +195,15 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         this.map.put("1", <(literal.(type))("2")>);
         this.map.put("2", <(literal.(type))("3")>);
         Object<name>HashMap\<String> expected = Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put("5", <(literal.(type))("6")>);
         expected.put("5", <(literal.(type))("6")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put(null, <(literal.(type))("7")>);
         expected.put(null, <(literal.(type))("7")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
     }
 
     @Test
@@ -207,17 +212,17 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         MutableObject<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("11")>, "1", <(literal.(type))("12")>, "2", <(literal.(type))("13")>);
         map1.updateValues((k, v) -> v);
         MutableObject<name>Map\<String> expected1 = this.newWithKeysValues("0", <(literal.(type))("11")>, "1", <(literal.(type))("12")>, "2", <(literal.(type))("13")>);
-        Assert.assertEquals(expected1, map1);
+        assertEquals(expected1, map1);
 
         MutableObject<name>Map\<String> map2 = this.newWithKeysValues("0", <(literal.(type))("11")>, "1", <(literal.(type))("12")>, "2", <(literal.(type))("13")>);
         map2.updateValues((k, v) -> <(castIntToNarrowTypeWithParens.(type))({v + <(literal.(type))("1")>})>);
         MutableObject<name>Map\<String> expected2 = this.newWithKeysValues("0", <(literal.(type))("12")>, "1", <(literal.(type))("13")>, "2", <(literal.(type))("14")>);
-        Assert.assertEquals(expected2, map2);
+        assertEquals(expected2, map2);
 
         MutableObject<name>Map\<String> map3 = this.newWithKeysValues("0", <(literal.(type))("11")>, "1", <(literal.(type))("12")>, "2", <(literal.(type))("13")>);
         map3.updateValues((k, v) -> k.equals("0") ? <(literal.(type))("10")> : v);
         MutableObject<name>Map\<String> expected3 = this.newWithKeysValues("0", <(literal.(type))("10")>, "1", <(literal.(type))("12")>, "2", <(literal.(type))("13")>);
-        Assert.assertEquals(expected3, map3);
+        assertEquals(expected3, map3);
     }
 
     @Test
@@ -227,15 +232,15 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         this.map.putPair(PrimitiveTuples.pair("1", <(literal.(type))("2")>));
         this.map.putPair(PrimitiveTuples.pair("2", <(literal.(type))("3")>));
         Object<name>HashMap\<String> expected = Object<name>HashMap.newWithKeysValues("0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.putPair(PrimitiveTuples.pair("5", <(literal.(type))("6")>));
         expected.put("5", <(literal.(type))("6")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.putPair(PrimitiveTuples.pair(null, <(literal.(type))("7")>));
         expected.put(null, <(literal.(type))("7")>);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
     }
 
     @Test
@@ -250,34 +255,34 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         hashMap.put(collision1, <(literal.(type))("1")>);
         hashMap.put(collision2, <(literal.(type))("2")>);
         hashMap.put(collision3, <(literal.(type))("3")>);
-        Assert.assertEquals(<(literal.(type))("2")>, hashMap.get(collision2)<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, hashMap.get(collision2)<delta.(type)>);
         hashMap.removeKey(collision2);
         hashMap.put(collision4, <(literal.(type))("4")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(collision1, <(literal.(type))("1")>, collision3, <(literal.(type))("3")>, collision4, <(literal.(type))("4")>), hashMap);
+        assertEquals(Object<name>HashMap.newWithKeysValues(collision1, <(literal.(type))("1")>, collision3, <(literal.(type))("3")>, collision4, <(literal.(type))("4")>), hashMap);
 
         MutableObject<name>Map\<String> hashMap1 = this.getEmptyMap();
         hashMap1.put(collision1, <(literal.(type))("1")>);
         hashMap1.put(collision2, <(literal.(type))("2")>);
         hashMap1.put(collision3, <(literal.(type))("3")>);
-        Assert.assertEquals(<(literal.(type))("1")>, hashMap1.get(collision1)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, hashMap1.get(collision1)<delta.(type)>);
         hashMap1.removeKey(collision1);
         hashMap1.put(collision4, <(literal.(type))("4")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(collision2, <(literal.(type))("2")>, collision3, <(literal.(type))("3")>, collision4, <(literal.(type))("4")>), hashMap1);
+        assertEquals(Object<name>HashMap.newWithKeysValues(collision2, <(literal.(type))("2")>, collision3, <(literal.(type))("3")>, collision4, <(literal.(type))("4")>), hashMap1);
 
         MutableObject<name>Map\<String> hashMap2 = this.getEmptyMap();
         hashMap2.put(collision1, <(literal.(type))("1")>);
         hashMap2.put(collision2, <(literal.(type))("2")>);
         hashMap2.put(collision3, <(literal.(type))("3")>);
-        Assert.assertEquals(<(literal.(type))("3")>, hashMap2.get(collision3)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, hashMap2.get(collision3)<delta.(type)>);
         hashMap2.removeKey(collision3);
         hashMap2.put(collision4, <(literal.(type))("4")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(collision1, <(literal.(type))("1")>, collision2, <(literal.(type))("2")>, collision4, <(literal.(type))("4")>), hashMap2);
+        assertEquals(Object<name>HashMap.newWithKeysValues(collision1, <(literal.(type))("1")>, collision2, <(literal.(type))("2")>, collision4, <(literal.(type))("4")>), hashMap2);
 
         MutableObject<name>Map\<String> hashMap3 = this.getEmptyMap();
         hashMap3.put(null, <(literal.(type))("1")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), hashMap3);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), hashMap3);
         hashMap3.put(null, <(literal.(type))("2")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("2")>), hashMap3);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("2")>), hashMap3);
     }
 
     @Override
@@ -286,16 +291,16 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         super.get();
 
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("5")<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get("5")<delta.(type)>);
 
         this.map.put("0", <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.get("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.get("0")<delta.(type)>);
 
         this.map.put("5", <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, this.map.get("5")<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.map.get("5")<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("6")>);
-        Assert.assertEquals(<(literal.(type))("6")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("6")>, this.map.get(null)<delta.(type)>);
     }
 
     @Override
@@ -305,16 +310,16 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         super.getOrThrow();
 
         this.map.removeKey("0");
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("0"));
 
         this.map.put("0", <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getOrThrow("0")<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getOrThrow("0")<delta.(type)>);
 
         this.map.put("5", <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, this.map.getOrThrow("5")<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.map.getOrThrow("5")<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("6")>);
-        Assert.assertEquals(<(literal.(type))("6")>, this.map.getOrThrow(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("6")>, this.map.getOrThrow(null)<delta.(type)>);
     }
 
     @Override
@@ -324,57 +329,57 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         super.getIfAbsent();
 
         this.map.removeKey("0");
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("5")>, this.map.getIfAbsent("0", <(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.map.getIfAbsent("0", <(literal.(type))("5")>)<delta.(type)>);
 
         this.map.put("0", <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("0", <(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.getIfAbsent("0", <(literal.(type))("5")>)<delta.(type)>);
 
         this.map.put("5", <(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, this.map.getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, this.map.getIfAbsent("5", <(literal.(type))("0")>)<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("6")>);
-        Assert.assertEquals(<(literal.(type))("6")>, this.map.getIfAbsent(null, <(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("6")>, this.map.getIfAbsent(null, <(literal.(type))("5")>)<delta.(type)>);
     }
 
     @Test
     public void getIfAbsentPut_Value()
     {
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(0, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(0, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>), map1);
-        Assert.assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(1, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(1, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>, 1, <(literal.(type))("50")>), map1);
+        assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(0, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(0, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>), map1);
+        assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(1, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("50")>, map1.getIfAbsentPut(1, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>, 1, <(literal.(type))("50")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(1, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(1, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("50")>), map2);
-        Assert.assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(0, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(0, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>, 1, <(literal.(type))("50")>), map2);
+        assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(1, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(1, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("50")>), map2);
+        assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(0, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("50")>, map2.getIfAbsentPut(0, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("50")>, 1, <(literal.(type))("50")>), map2);
 
         MutableObject<name>Map\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("50")>, map3.getIfAbsentPut(null, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("50")>, map3.getIfAbsentPut(null, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("50")>), map3);
+        assertEquals(<(literal.(type))("50")>, map3.getIfAbsentPut(null, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("50")>, map3.getIfAbsentPut(null, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("50")>), map3);
     }
 
     @Test
     public void getAndPut()
     {
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("20")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("100")>, <(literal.(type))("20")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.get(Integer.valueOf(5))<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("70")>, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("70")>, map1.get(Integer.valueOf(5))<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("70")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("77")>, <(literal.(type))("50")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("77")>, map1.get(Integer.valueOf(5))<delta.(type)>);
+        assertEquals(<(literal.(type))("20")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("100")>, <(literal.(type))("20")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.get(Integer.valueOf(5))<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("70")>, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("70")>, map1.get(Integer.valueOf(5))<delta.(type)>);
+        assertEquals(<(literal.(type))("70")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("77")>, <(literal.(type))("50")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("77")>, map1.get(Integer.valueOf(5))<delta.(type)>);
         map1.removeKey(Integer.valueOf(5));
-        Assert.assertEquals(<(literal.(type))("20")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("100")>, <(literal.(type))("20")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.get(Integer.valueOf(5))<delta.(type)>);
+        assertEquals(<(literal.(type))("20")>, map1.getAndPut(Integer.valueOf(5), <(literal.(type))("100")>, <(literal.(type))("20")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.get(Integer.valueOf(5))<delta.(type)>);
     }
 
     @Test
@@ -383,31 +388,31 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         <name>Function0 factory = () -> <(literal.(type))("100")>;
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(0, factory)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(0, factory)<delta.(type)>);
 
         <name>Function0 factoryThrows = () ->
         {
             throw new AssertionError();
         };
 
-        Assert.assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(0, factoryThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>), map1);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(1, factory)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(1, factoryThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>, 1, <(literal.(type))("100")>), map1);
+        assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(0, factoryThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>), map1);
+        assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(1, factory)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.getIfAbsentPut(1, factoryThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>, 1, <(literal.(type))("100")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(1, factory)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(1, factoryThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("100")>), map2);
-        Assert.assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(0, factory)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(0, factoryThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>, 1, <(literal.(type))("100")>), map2);
+        assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(1, factory)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(1, factoryThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("100")>), map2);
+        assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(0, factory)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map2.getIfAbsentPut(0, factoryThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("100")>, 1, <(literal.(type))("100")>), map2);
 
         MutableObject<name>Map\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("100")>, map3.getIfAbsentPut(null, factory)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map3.getIfAbsentPut(null, factoryThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("100")>), map3);
+        assertEquals(<(literal.(type))("100")>, map3.getIfAbsentPut(null, factory)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map3.getIfAbsentPut(null, factoryThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("100")>), map3);
     }
 
     @Test
@@ -416,29 +421,29 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         <name>Function\<String> functionLength = (String string) -> <(castIntToNarrowType.(type))("string.length()")>;
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(0, functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(0, functionLength, "123456789")<delta.(type)>);
         <name>Function\<String> functionThrows = (String each) ->
         {
             throw new AssertionError();
         };
-        Assert.assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(0, functionThrows, "unused")<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>), map1);
-        Assert.assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(1, functionLength, "123456789")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(1, functionThrows, "unused")<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>, 1, <(literal.(type))("9")>), map1);
+        assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(0, functionThrows, "unused")<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>), map1);
+        assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(1, functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, map1.getIfAbsentPutWith(1, functionThrows, "unused")<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>, 1, <(literal.(type))("9")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(1, functionLength, "123456789")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(1, functionThrows, "unused")<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("9")>), map2);
-        Assert.assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(0, functionLength, "123456789")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(0, functionThrows, "unused")<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>, 1, <(literal.(type))("9")>), map2);
+        assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(1, functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(1, functionThrows, "unused")<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("9")>), map2);
+        assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(0, functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, map2.getIfAbsentPutWith(0, functionThrows, "unused")<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("9")>, 1, <(literal.(type))("9")>), map2);
 
         MutableObject<name>Map\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("9")>, map3.getIfAbsentPutWith(null, functionLength, "123456789")<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, map3.getIfAbsentPutWith(null, functionThrows, "unused")<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("9")>), map3);
+        assertEquals(<(literal.(type))("9")>, map3.getIfAbsentPutWith(null, functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, map3.getIfAbsentPutWith(null, functionThrows, "unused")<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("9")>), map3);
     }
 
     @Test
@@ -447,29 +452,29 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         <name>Function\<Integer> function = (Integer anObject) -> anObject == null ? <(literal.(type))("32")> : <(castIntToNarrowType.(type))("anObject.intValue()")>;
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("0")>, map1.getIfAbsentPutWithKey(0, function)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, map1.getIfAbsentPutWithKey(0, function)<delta.(type)>);
         <name>Function\<Integer> functionThrows = (Integer <type>Parameter) ->
         {
             throw new AssertionError();
         };
-        Assert.assertEquals(<(literal.(type))("0")>, map1.getIfAbsentPutWithKey(0, functionThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>), map1);
-        Assert.assertEquals(<(literal.(type))("1")>, map1.getIfAbsentPutWithKey(1, function)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, map1.getIfAbsentPutWithKey(1, functionThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>), map1);
+        assertEquals(<(literal.(type))("0")>, map1.getIfAbsentPutWithKey(0, functionThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>), map1);
+        assertEquals(<(literal.(type))("1")>, map1.getIfAbsentPutWithKey(1, function)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, map1.getIfAbsentPutWithKey(1, functionThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map2.getIfAbsentPutWithKey(1, function)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, map2.getIfAbsentPutWithKey(1, functionThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), map2);
-        Assert.assertEquals(<(literal.(type))("0")>, map2.getIfAbsentPutWithKey(0, function)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, map2.getIfAbsentPutWithKey(0, functionThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>), map2);
+        assertEquals(<(literal.(type))("1")>, map2.getIfAbsentPutWithKey(1, function)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, map2.getIfAbsentPutWithKey(1, functionThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), map2);
+        assertEquals(<(literal.(type))("0")>, map2.getIfAbsentPutWithKey(0, function)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, map2.getIfAbsentPutWithKey(0, functionThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>), map2);
 
         MutableObject<name>Map\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("32")>, map3.getIfAbsentPutWithKey(null, function)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("32")>, map3.getIfAbsentPutWithKey(null, functionThrows)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("32")>), map3);
+        assertEquals(<(literal.(type))("32")>, map3.getIfAbsentPutWithKey(null, function)<delta.(type)>);
+        assertEquals(<(literal.(type))("32")>, map3.getIfAbsentPutWithKey(null, functionThrows)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("32")>), map3);
     }
 
     @Test
@@ -478,56 +483,56 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         <name>To<name>Function incrementFunction = (<type> value) -> <(castIntToNarrowTypeWithParens.(type))("value + 1")>;
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map1.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>), map1);
-        Assert.assertEquals(<(literal.(type))("2")>, map1.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>), map1);
-        Assert.assertEquals(<(literal.(type))("1")>, map1.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("1")>), map1);
-        Assert.assertEquals(<(literal.(type))("2")>, map1.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("2")>), map1);
+        assertEquals(<(literal.(type))("1")>, map1.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>), map1);
+        assertEquals(<(literal.(type))("2")>, map1.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>), map1);
+        assertEquals(<(literal.(type))("1")>, map1.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("1")>), map1);
+        assertEquals(<(literal.(type))("2")>, map1.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("2")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map2.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), map2);
-        Assert.assertEquals(<(literal.(type))("2")>, map2.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("2")>), map2);
-        Assert.assertEquals(<(literal.(type))("1")>, map2.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>, 1, <(literal.(type))("2")>), map2);
-        Assert.assertEquals(<(literal.(type))("2")>, map2.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("2")>), map2);
+        assertEquals(<(literal.(type))("1")>, map2.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), map2);
+        assertEquals(<(literal.(type))("2")>, map2.updateValue(1, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("2")>), map2);
+        assertEquals(<(literal.(type))("1")>, map2.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>, 1, <(literal.(type))("2")>), map2);
+        assertEquals(<(literal.(type))("2")>, map2.updateValue(0, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("2")>, 1, <(literal.(type))("2")>), map2);
 
         MutableObject<name>Map\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map3.updateValue(null, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), map3);
-        Assert.assertEquals(<(literal.(type))("2")>, map3.updateValue(null, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("2")>), map3);
+        assertEquals(<(literal.(type))("1")>, map3.updateValue(null, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), map3);
+        assertEquals(<(literal.(type))("2")>, map3.updateValue(null, <(literal.(type))("0")>, incrementFunction)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("2")>), map3);
     }
 
     @Test
     public void addToValue()
     {
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map1.addToValue(0, <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>), map1);
-        Assert.assertEquals(<(literal.(type))("5")>, map1.addToValue(0, <(literal.(type))("4")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>), map1);
-        Assert.assertEquals(<(literal.(type))("2")>, map1.addToValue(1, <(literal.(type))("2")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>, 1, <(literal.(type))("2")>), map1);
-        Assert.assertEquals(<(literal.(type))("10")>, map1.addToValue(1, <(literal.(type))("8")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>, 1, <(literal.(type))("10")>), map1);
+        assertEquals(<(literal.(type))("1")>, map1.addToValue(0, <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("1")>), map1);
+        assertEquals(<(literal.(type))("5")>, map1.addToValue(0, <(literal.(type))("4")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>), map1);
+        assertEquals(<(literal.(type))("2")>, map1.addToValue(1, <(literal.(type))("2")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>, 1, <(literal.(type))("2")>), map1);
+        assertEquals(<(literal.(type))("10")>, map1.addToValue(1, <(literal.(type))("8")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("5")>, 1, <(literal.(type))("10")>), map1);
 
         MutableObject<name>Map\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type))("1")>, map2.addToValue(null, <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), map2);
-        Assert.assertEquals(<(literal.(type))("5")>, map2.addToValue(null, <(literal.(type))("4")>)<delta.(type)>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("5")>), map2);
+        assertEquals(<(literal.(type))("1")>, map2.addToValue(null, <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), map2);
+        assertEquals(<(literal.(type))("5")>, map2.addToValue(null, <(literal.(type))("4")>)<delta.(type)>);
+        assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("5")>), map2);
 
         MutableObject<name>Map\<String> map3 = this.getEmptyMap();
         IntInterval.zeroTo(10).forEachWithIndex((each, index) ->
         {
             <type> v = <(castIntToNarrowTypeWithParens.(type))("each + index")>;
-            Assert.assertEquals("Key:" + each, v, map3.addToValue(String.valueOf(each), v)<delta.(type)>);
+            assertEquals("Key:" + each, v, map3.addToValue(String.valueOf(each), v)<delta.(type)>);
         });
     }
 
@@ -538,26 +543,26 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         super.containsKey();
 
         this.map.removeKey("0");
-        Assert.assertFalse(this.map.containsKey("0"));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
+        assertFalse(this.map.containsKey("0"));
+        assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
         this.map.removeKey("0");
-        Assert.assertFalse(this.map.containsKey("0"));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
+        assertFalse(this.map.containsKey("0"));
+        assertEquals(<(literal.(type))("0")>, this.map.get("0")<delta.(type)>);
 
         this.map.removeKey("1");
-        Assert.assertFalse(this.map.containsKey("1"));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("1")<delta.(type)>);
+        assertFalse(this.map.containsKey("1"));
+        assertEquals(<(literal.(type))("0")>, this.map.get("1")<delta.(type)>);
 
         this.map.removeKey("2");
-        Assert.assertFalse(this.map.containsKey("2"));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("2")<delta.(type)>);
+        assertFalse(this.map.containsKey("2"));
+        assertEquals(<(literal.(type))("0")>, this.map.get("2")<delta.(type)>);
 
         this.map.removeKey("3");
-        Assert.assertFalse(this.map.containsKey("3"));
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get("3")<delta.(type)>);
+        assertFalse(this.map.containsKey("3"));
+        assertEquals(<(literal.(type))("0")>, this.map.get("3")<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("5")>);
-        Assert.assertTrue(this.map.containsKey(null));
+        assertTrue(this.map.containsKey(null));
     }
 
     @Override
@@ -566,13 +571,13 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         super.containsValue();
         this.map.put("5", <(literal.(type))("5")>);
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("5")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("5")>));
 
         this.map.put(null, <(literal.(type))("6")>);
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("6")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("6")>));
 
         this.map.removeKey("0");
-        Assert.assertFalse(this.map.containsValue(<(literal.(type))("0")>));
+        assertFalse(this.map.containsValue(<(literal.(type))("0")>));
     }
 
     @Override
@@ -597,8 +602,8 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         MutableObject<name>Map\<Integer> emptyMap = this.getEmptyMap();
         MutableObject<name>Map\<Integer> hashMap = emptyMap.withKeyValue(1, <(literal.(type))("1")>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), hashMap);
-        Assert.assertSame(emptyMap, hashMap);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>), hashMap);
+        assertSame(emptyMap, hashMap);
     }
 
     @Test
@@ -606,8 +611,8 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         MutableObject<name>Map\<Integer> map = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>);
         MutableObject<name>Map\<Integer> mapWithout = map.withoutKey(3);
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(Object<name>HashMap.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>), mapWithout);
     }
 
     @Test
@@ -615,8 +620,8 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
     {
         MutableObject<name>Map\<Integer> map = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>);
         MutableObject<name>Map\<Integer> mapWithout = map.withoutAllKeys(FastList.newListWith(0, 3));
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(Object<name>HashMap.newWithKeysValues(1, <(literal.(type))("1")>, 2, <(literal.(type))("2")>), mapWithout);
     }
 
     @Test
@@ -628,15 +633,15 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         Iterable\<Object<name>Pair\<String>\> emptyIterable = Iterables.iList();
         Iterable\<Object<name>Pair\<String>\> partialIterable = Iterables.iList(PrimitiveTuples.pair("one", <(literal.(type))("1")>), PrimitiveTuples.pair("three", <(literal.(type))("3")>));
         Iterable\<Object<name>Pair\<String>\> completeIterable = Iterables.iList(PrimitiveTuples.pair("one", <(literal.(type))("1")>), PrimitiveTuples.pair("two", <(literal.(type))("2")>), PrimitiveTuples.pair("three", <(literal.(type))("3")>));
-        Assert.assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
+        assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
     }
 
     @Override
@@ -646,37 +651,37 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         super.contains();
 
         this.map.put("5", <(literal.(type))("5")>);
-        Assert.assertTrue(this.map.contains(<(literal.(type))("5")>));
+        assertTrue(this.map.contains(<(literal.(type))("5")>));
 
         this.map.put(null, <(literal.(type))("6")>);
-        Assert.assertTrue(this.map.contains(<(literal.(type))("6")>));
+        assertTrue(this.map.contains(<(literal.(type))("6")>));
 
         this.map.removeKey("0");
-        Assert.assertFalse(this.map.contains(<(literal.(type))("0")>));
+        assertFalse(this.map.contains(<(literal.(type))("0")>));
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(UnmodifiableObject<name>Map.class, this.map.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableObject<name>Map\<>(this.map), this.map.asUnmodifiable());
+        assertEquals(new UnmodifiableObject<name>Map\<>(this.map), this.map.asUnmodifiable());
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(SynchronizedObject<name>Map.class, this.map.asSynchronized());
-        Assert.assertEquals(new SynchronizedObject<name>Map\<>(this.map), this.map.asSynchronized());
+        assertEquals(new SynchronizedObject<name>Map\<>(this.map), this.map.asSynchronized());
     }
 
     @Test
     public void flipUniqueValues()
     {
         MutableObject<name>Map\<String> map = this.newWithKeysValues("1", <(literal.(type))("2")>, "2", <(literal.(type))("3")>);
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, "1", <(literal.(type))("3")>, "2"),
                 map.flipUniqueValues());
-        Assert.assertThrows(
+        assertThrows(
                 IllegalStateException.class,
                 () -> this.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("1")>).flipUniqueValues());
     }

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveBooleanMapTestCase.stg
@@ -35,8 +35,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.primitive.Abstract<name>BooleanMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitiveBooleanMapTestCase.stg.
@@ -81,17 +86,17 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
     public void clear()
     {
         this.map.clear();
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertEquals(new <name>BooleanHashMap(), this.map);
 
         this.map.put(<(literal.(type))("1")>, false);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), this.map);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), this.map);
         this.map.clear();
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertEquals(new <name>BooleanHashMap(), this.map);
 
         this.map.put(<(literal.(type))("33")>, false);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), this.map);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), this.map);
         this.map.clear();
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertEquals(new <name>BooleanHashMap(), this.map);
     }
 
     @Test
@@ -99,73 +104,73 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
     {
         this.map.removeKey(<(literal.(type))("5")>);
         this.map.removeKey(<(literal.(type))("50")>);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
         this.map.removeKey(<(literal.(type))("31")>);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), this.map);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), this.map);
         this.map.removeKey(<(literal.(type))("32")>);
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertEquals(new <name>BooleanHashMap(), this.map);
         this.map.removeKey(<(literal.(type))("0")>);
         this.map.removeKey(<(literal.(type))("31")>);
         this.map.removeKey(<(literal.(type))("32")>);
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertEquals(new <name>BooleanHashMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0), true);
         this.map.put(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1), false);
 
-        Assert.assertTrue(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
+        assertTrue(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
         this.map.removeKey(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0));
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
 
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
         this.map.removeKey(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1));
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
 
         Mutable<name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("1")>, true);
         map1.removeKey(<(literal.(type))("1")>);
-        Assert.assertEquals(new <name>BooleanHashMap(), map1);
+        assertEquals(new <name>BooleanHashMap(), map1);
     }
 
     @Test
     public void removeKeyIfAbsent()
     {
-        Assert.assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("5")>, true));
-        Assert.assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("50")>, false));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
-        Assert.assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
-        Assert.assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("31")>, true));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), this.map);
-        Assert.assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("32")>, false));
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
-        Assert.assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("0")>, true));
-        Assert.assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("31")>, false));
-        Assert.assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("32")>, false));
-        Assert.assertEquals(new <name>BooleanHashMap(), this.map);
+        assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("5")>, true));
+        assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("50")>, false));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
+        assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("0")>, false));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, false, <(literal.(type))("32")>, true), this.map);
+        assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("31")>, true));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), this.map);
+        assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("32")>, false));
+        assertEquals(new <name>BooleanHashMap(), this.map);
+        assertTrue(this.map.removeKeyIfAbsent(<(literal.(type))("0")>, true));
+        assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("31")>, false));
+        assertFalse(this.map.removeKeyIfAbsent(<(literal.(type))("32")>, false));
+        assertEquals(new <name>BooleanHashMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0), true);
         this.map.put(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1), false);
 
-        Assert.assertTrue(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
-        Assert.assertTrue(this.map.removeKeyIfAbsent(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0), false));
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
+        assertTrue(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
+        assertTrue(this.map.removeKeyIfAbsent(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0), false));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(0)));
 
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
-        Assert.assertFalse(this.map.removeKeyIfAbsent(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1), true));
-        Assert.assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
+        assertFalse(this.map.removeKeyIfAbsent(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1), true));
+        assertFalse(this.map.get(AbstractMutable<name>BooleanMapTestCase.generateCollisions().get(1)));
 
-        Assert.assertTrue(this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true).removeKeyIfAbsent(<(literal.(type))("0")>, false));
+        assertTrue(this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true).removeKeyIfAbsent(<(literal.(type))("0")>, false));
 
         Mutable<name>BooleanMap map1 = this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true);
-        Assert.assertTrue(map1.removeKeyIfAbsent(<(literal.(type))("1")>, false));
-        Assert.assertTrue(map1.removeKeyIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertFalse(map1.removeKeyIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(map1.removeKeyIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(map1.removeKeyIfAbsent(<(literal.(type))("0")>, false));
+        assertFalse(map1.removeKeyIfAbsent(<(literal.(type))("1")>, false));
 
         Mutable<name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, true);
-        Assert.assertTrue(map2.removeKeyIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(map2.removeKeyIfAbsent(<(literal.(type))("1")>, false));
     }
 
     @Test
@@ -175,19 +180,19 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         this.map.put(<(literal.(type))("31")>, true);
         this.map.put(<(literal.(type))("32")>, false);
         Mutable<name>BooleanMap expected = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("31")>, true, <(literal.(type))("32")>, false);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put(<(literal.(type))("1")>, true);
         expected.put(<(literal.(type))("1")>, true);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put(<(literal.(type))("33")>, false);
         expected.put(<(literal.(type))("33")>, false);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put(<(literal.(type))("30")>, true);
         expected.put(<(literal.(type))("30")>, true);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
     }
 
     @Test
@@ -196,17 +201,17 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         Mutable<name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false);
         map1.updateValues((k, v) -> v);
         Mutable<name>BooleanMap expected1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false);
-        Assert.assertEquals(expected1, map1);
+        assertEquals(expected1, map1);
 
         Mutable<name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false);
         map2.updateValues((k, v) -> !v);
         Mutable<name>BooleanMap expected2 = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true, <(literal.(type))("2")>, true);
-        Assert.assertEquals(expected2, map2);
+        assertEquals(expected2, map2);
 
         Mutable<name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, false);
         map3.updateValues((k, v) -> k == <(literal.(type))("2")> ? true : v);
         Mutable<name>BooleanMap expected3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true);
-        Assert.assertEquals(expected3, map3);
+        assertEquals(expected3, map3);
     }
 
     @Test
@@ -221,28 +226,28 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         hashMap.put(collision1, true);
         hashMap.put(collision2, false);
         hashMap.put(collision3, true);
-        Assert.assertFalse(hashMap.get(collision2));
+        assertFalse(hashMap.get(collision2));
         hashMap.removeKey(collision2);
         hashMap.put(collision4, false);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(collision1, true, collision3, true, collision4, false), hashMap);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(collision1, true, collision3, true, collision4, false), hashMap);
 
         Mutable<name>BooleanMap hashMap1 = this.getEmptyMap();
         hashMap1.put(collision1, false);
         hashMap1.put(collision2, true);
         hashMap1.put(collision3, false);
-        Assert.assertFalse(hashMap1.get(collision1));
+        assertFalse(hashMap1.get(collision1));
         hashMap1.removeKey(collision1);
         hashMap1.put(collision4, true);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(collision2, true, collision3, false, collision4, true), hashMap1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(collision2, true, collision3, false, collision4, true), hashMap1);
 
         Mutable<name>BooleanMap hashMap2 = this.getEmptyMap();
         hashMap2.put(collision1, true);
         hashMap2.put(collision2, false);
         hashMap2.put(collision3, true);
-        Assert.assertTrue(hashMap2.get(collision3));
+        assertTrue(hashMap2.get(collision3));
         hashMap2.removeKey(collision3);
         hashMap2.put(collision4, false);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(collision1, true, collision2, false, collision4, false), hashMap2);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(collision1, true, collision2, false, collision4, false), hashMap2);
     }
 
     @Override
@@ -252,16 +257,16 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         super.get();
 
         this.map.put(<(literal.(type))("0")>, false);
-        Assert.assertFalse(this.map.get(<(literal.(type))("0")>));
+        assertFalse(this.map.get(<(literal.(type))("0")>));
 
         this.map.put(<(literal.(type))("1")>, true);
-        Assert.assertTrue(this.map.get(<(literal.(type))("1")>));
+        assertTrue(this.map.get(<(literal.(type))("1")>));
 
         this.map.put(<(literal.(type))("5")>, true);
-        Assert.assertTrue(this.map.get(<(literal.(type))("5")>));
+        assertTrue(this.map.get(<(literal.(type))("5")>));
 
         this.map.put(<(literal.(type))("35")>, false);
-        Assert.assertFalse(this.map.get(<(literal.(type))("35")>));
+        assertFalse(this.map.get(<(literal.(type))("35")>));
     }
 
     @Override
@@ -271,26 +276,26 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         super.getIfAbsent();
 
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertFalse(this.map.getIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertTrue(this.map.getIfAbsent(<(literal.(type))("0")>, true));
+        assertFalse(this.map.getIfAbsent(<(literal.(type))("0")>, false));
+        assertTrue(this.map.getIfAbsent(<(literal.(type))("0")>, true));
 
-        Assert.assertFalse(this.map.getIfAbsent(<(literal.(type))("1")>, false));
-        Assert.assertTrue(this.map.getIfAbsent(<(literal.(type))("1")>, true));
+        assertFalse(this.map.getIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(this.map.getIfAbsent(<(literal.(type))("1")>, true));
 
-        Assert.assertFalse(this.map.getIfAbsent(<(literal.(type))("33")>, false));
-        Assert.assertTrue(this.map.getIfAbsent(<(literal.(type))("33")>, true));
+        assertFalse(this.map.getIfAbsent(<(literal.(type))("33")>, false));
+        assertTrue(this.map.getIfAbsent(<(literal.(type))("33")>, true));
 
         this.map.put(<(literal.(type))("0")>, false);
-        Assert.assertFalse(this.map.getIfAbsent(<(literal.(type))("0")>, true));
+        assertFalse(this.map.getIfAbsent(<(literal.(type))("0")>, true));
 
         this.map.put(<(literal.(type))("1")>, true);
-        Assert.assertTrue(this.map.getIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(this.map.getIfAbsent(<(literal.(type))("1")>, false));
 
         this.map.put(<(literal.(type))("5")>, false);
-        Assert.assertFalse(this.map.getIfAbsent(<(literal.(type))("5")>, true));
+        assertFalse(this.map.getIfAbsent(<(literal.(type))("5")>, true));
 
         this.map.put(<(literal.(type))("35")>, true);
-        Assert.assertTrue(this.map.getIfAbsent(<(literal.(type))("35")>, false));
+        assertTrue(this.map.getIfAbsent(<(literal.(type))("35")>, false));
     }
 
     @Override
@@ -300,49 +305,49 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         super.getOrThrow();
 
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type))("0")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type))("0")>));
 
         this.map.put(<(literal.(type))("0")>, false);
-        Assert.assertFalse(this.map.getOrThrow(<(literal.(type))("0")>));
+        assertFalse(this.map.getOrThrow(<(literal.(type))("0")>));
 
         this.map.put(<(literal.(type))("1")>, true);
-        Assert.assertTrue(this.map.getOrThrow(<(literal.(type))("1")>));
+        assertTrue(this.map.getOrThrow(<(literal.(type))("1")>));
 
         this.map.put(<(literal.(type))("5")>, false);
-        Assert.assertFalse(this.map.getOrThrow(<(literal.(type))("5")>));
+        assertFalse(this.map.getOrThrow(<(literal.(type))("5")>));
 
         this.map.put(<(literal.(type))("35")>, true);
-        Assert.assertTrue(this.map.getOrThrow(<(literal.(type))("35")>));
+        assertTrue(this.map.getOrThrow(<(literal.(type))("35")>));
     }
 
     @Test
     public void getIfAbsentPut()
     {
         Mutable<name>BooleanMap map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, true));
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, false));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
-        Assert.assertFalse(map1.getIfAbsentPut(<(literal.(type))("1")>, false));
-        Assert.assertFalse(map1.getIfAbsentPut(<(literal.(type))("1")>, true));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, true));
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, false));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
+        assertFalse(map1.getIfAbsentPut(<(literal.(type))("1")>, false));
+        assertFalse(map1.getIfAbsentPut(<(literal.(type))("1")>, true));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
 
         Mutable<name>BooleanMap map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, true));
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, false));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
-        Assert.assertFalse(map2.getIfAbsentPut(<(literal.(type))("0")>, false));
-        Assert.assertFalse(map2.getIfAbsentPut(<(literal.(type))("0")>, true));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map2);
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, true));
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, false));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
+        assertFalse(map2.getIfAbsentPut(<(literal.(type))("0")>, false));
+        assertFalse(map2.getIfAbsentPut(<(literal.(type))("0")>, true));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map2);
 
         Mutable<name>BooleanMap map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, true));
-        Assert.assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, false));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
+        assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, true));
+        assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, false));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
 
         Mutable<name>BooleanMap map4 = this.getEmptyMap();
-        Assert.assertFalse(map4.getIfAbsentPut(<(literal.(type))("33")>, false));
-        Assert.assertFalse(map4.getIfAbsentPut(<(literal.(type))("33")>, true));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map4);
+        assertFalse(map4.getIfAbsentPut(<(literal.(type))("33")>, false));
+        assertFalse(map4.getIfAbsentPut(<(literal.(type))("33")>, true));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map4);
     }
 
     @Test
@@ -352,30 +357,30 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         BooleanFunction0 factoryThrows = () -> { throw new AssertionError(); };
 
         Mutable<name>BooleanMap map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, factory));
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("1")>, factory));
-        Assert.assertTrue(map1.getIfAbsentPut(<(literal.(type))("1")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true), map1);
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, factory));
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("0")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("1")>, factory));
+        assertTrue(map1.getIfAbsentPut(<(literal.(type))("1")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true), map1);
 
         Mutable<name>BooleanMap map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, factory));
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("0")>, factory));
-        Assert.assertTrue(map2.getIfAbsentPut(<(literal.(type))("0")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true), map2);
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, factory));
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("1")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("0")>, factory));
+        assertTrue(map2.getIfAbsentPut(<(literal.(type))("0")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, true), map2);
 
         Mutable<name>BooleanMap map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, factory));
-        Assert.assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
+        assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, factory));
+        assertTrue(map3.getIfAbsentPut(<(literal.(type))("32")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
 
         Mutable<name>BooleanMap map4 = this.getEmptyMap();
-        Assert.assertTrue(map4.getIfAbsentPut(<(literal.(type))("33")>, factory));
-        Assert.assertTrue(map4.getIfAbsentPut(<(literal.(type))("33")>, factoryThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map4);
+        assertTrue(map4.getIfAbsentPut(<(literal.(type))("33")>, factory));
+        assertTrue(map4.getIfAbsentPut(<(literal.(type))("33")>, factoryThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map4);
     }
 
     @Test
@@ -385,30 +390,30 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         BooleanFunction\<String> functionThrows = (String string) -> { throw new AssertionError(); };
 
         Mutable<name>BooleanMap map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "12345678"));
-        Assert.assertTrue(map1.getIfAbsentPutWith(<(literal.(type))("0")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
-        Assert.assertFalse(map1.getIfAbsentPutWith(<(literal.(type))("1")>, functionLengthEven, "123456789"));
-        Assert.assertFalse(map1.getIfAbsentPutWith(<(literal.(type))("1")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
+        assertTrue(map1.getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "12345678"));
+        assertTrue(map1.getIfAbsentPutWith(<(literal.(type))("0")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
+        assertFalse(map1.getIfAbsentPutWith(<(literal.(type))("1")>, functionLengthEven, "123456789"));
+        assertFalse(map1.getIfAbsentPutWith(<(literal.(type))("1")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
 
         Mutable<name>BooleanMap map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.getIfAbsentPutWith(<(literal.(type))("1")>, functionLengthEven, "12345678"));
-        Assert.assertTrue(map2.getIfAbsentPutWith(<(literal.(type))("1")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
-        Assert.assertFalse(map2.getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "123456789"));
-        Assert.assertFalse(map2.getIfAbsentPutWith(<(literal.(type))("0")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map2);
+        assertTrue(map2.getIfAbsentPutWith(<(literal.(type))("1")>, functionLengthEven, "12345678"));
+        assertTrue(map2.getIfAbsentPutWith(<(literal.(type))("1")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
+        assertFalse(map2.getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "123456789"));
+        assertFalse(map2.getIfAbsentPutWith(<(literal.(type))("0")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map2);
 
         Mutable<name>BooleanMap map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPutWith(<(literal.(type))("32")>, functionLengthEven, "12345678"));
-        Assert.assertTrue(map3.getIfAbsentPutWith(<(literal.(type))("32")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
+        assertTrue(map3.getIfAbsentPutWith(<(literal.(type))("32")>, functionLengthEven, "12345678"));
+        assertTrue(map3.getIfAbsentPutWith(<(literal.(type))("32")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
 
         Mutable<name>BooleanMap map4 = this.getEmptyMap();
-        Assert.assertTrue(map4.getIfAbsentPutWith(<(literal.(type))("33")>, functionLengthEven, "12345678"));
-        Assert.assertTrue(map4.getIfAbsentPutWith(<(literal.(type))("33")>, functionThrows, "unused"));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map4);
+        assertTrue(map4.getIfAbsentPutWith(<(literal.(type))("33")>, functionLengthEven, "12345678"));
+        assertTrue(map4.getIfAbsentPutWith(<(literal.(type))("33")>, functionThrows, "unused"));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map4);
     }
 
     @Test
@@ -418,30 +423,30 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         <name>ToBooleanFunction functionThrows = (<type> <type>Parameter) -> { throw new AssertionError(); };
 
         Mutable<name>BooleanMap map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
-        Assert.assertTrue(map1.getIfAbsentPutWithKey(<(literal.(type))("0")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
-        Assert.assertFalse(map1.getIfAbsentPutWithKey(<(literal.(type))("1")>, keyIsEven));
-        Assert.assertFalse(map1.getIfAbsentPutWithKey(<(literal.(type))("1")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
+        assertTrue(map1.getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
+        assertTrue(map1.getIfAbsentPutWithKey(<(literal.(type))("0")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
+        assertFalse(map1.getIfAbsentPutWithKey(<(literal.(type))("1")>, keyIsEven));
+        assertFalse(map1.getIfAbsentPutWithKey(<(literal.(type))("1")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map1);
 
         Mutable<name>BooleanMap map2 = this.getEmptyMap();
-        Assert.assertFalse(map2.getIfAbsentPutWithKey(<(literal.(type))("1")>, keyIsEven));
-        Assert.assertFalse(map2.getIfAbsentPutWithKey(<(literal.(type))("1")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), map2);
-        Assert.assertTrue(map2.getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
-        Assert.assertTrue(map2.getIfAbsentPutWithKey(<(literal.(type))("0")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map2);
+        assertFalse(map2.getIfAbsentPutWithKey(<(literal.(type))("1")>, keyIsEven));
+        assertFalse(map2.getIfAbsentPutWithKey(<(literal.(type))("1")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), map2);
+        assertTrue(map2.getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
+        assertTrue(map2.getIfAbsentPutWithKey(<(literal.(type))("0")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map2);
 
         Mutable<name>BooleanMap map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPutWithKey(<(literal.(type))("32")>, keyIsEven));
-        Assert.assertTrue(map3.getIfAbsentPutWithKey(<(literal.(type))("32")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
+        assertTrue(map3.getIfAbsentPutWithKey(<(literal.(type))("32")>, keyIsEven));
+        assertTrue(map3.getIfAbsentPutWithKey(<(literal.(type))("32")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true), map3);
 
         Mutable<name>BooleanMap map4 = this.getEmptyMap();
-        Assert.assertFalse(map4.getIfAbsentPutWithKey(<(literal.(type))("33")>, keyIsEven));
-        Assert.assertFalse(map4.getIfAbsentPutWithKey(<(literal.(type))("33")>, functionThrows));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map4);
+        assertFalse(map4.getIfAbsentPutWithKey(<(literal.(type))("33")>, keyIsEven));
+        assertFalse(map4.getIfAbsentPutWithKey(<(literal.(type))("33")>, functionThrows));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map4);
     }
 
     @Test
@@ -450,30 +455,30 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         BooleanToBooleanFunction flip = (boolean value) -> !value;
 
         Mutable<name>BooleanMap map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.updateValue(<(literal.(type))("0")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
-        Assert.assertFalse(map1.updateValue(<(literal.(type))("0")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false), map1);
-        Assert.assertFalse(map1.updateValue(<(literal.(type))("1")>, true, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, false), map1);
-        Assert.assertTrue(map1.updateValue(<(literal.(type))("1")>, true, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map1);
+        assertTrue(map1.updateValue(<(literal.(type))("0")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true), map1);
+        assertFalse(map1.updateValue(<(literal.(type))("0")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false), map1);
+        assertFalse(map1.updateValue(<(literal.(type))("1")>, true, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, false), map1);
+        assertTrue(map1.updateValue(<(literal.(type))("1")>, true, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true), map1);
 
         Mutable<name>BooleanMap map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.updateValue(<(literal.(type))("1")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
-        Assert.assertFalse(map2.updateValue(<(literal.(type))("1")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), map2);
-        Assert.assertFalse(map2.updateValue(<(literal.(type))("0")>, true, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, false), map2);
-        Assert.assertTrue(map2.updateValue(<(literal.(type))("0")>, true, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map2);
+        assertTrue(map2.updateValue(<(literal.(type))("1")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true), map2);
+        assertFalse(map2.updateValue(<(literal.(type))("1")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), map2);
+        assertFalse(map2.updateValue(<(literal.(type))("0")>, true, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, false), map2);
+        assertTrue(map2.updateValue(<(literal.(type))("0")>, true, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false), map2);
 
         Mutable<name>BooleanMap map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.updateValue(<(literal.(type))("33")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map3);
-        Assert.assertFalse(map3.updateValue(<(literal.(type))("33")>, false, flip));
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map3);
+        assertTrue(map3.updateValue(<(literal.(type))("33")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, true), map3);
+        assertFalse(map3.updateValue(<(literal.(type))("33")>, false, flip));
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("33")>, false), map3);
     }
 
     @Override
@@ -483,23 +488,23 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         super.containsKey();
 
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.map.get(<(literal.(type))("0")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("0")>));
+        assertFalse(this.map.get(<(literal.(type))("0")>));
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.map.get(<(literal.(type))("0")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("0")>));
+        assertFalse(this.map.get(<(literal.(type))("0")>));
 
         this.map.removeKey(<(literal.(type))("1")>);
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.map.get(<(literal.(type))("1")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("1")>));
+        assertFalse(this.map.get(<(literal.(type))("1")>));
 
         this.map.removeKey(<(literal.(type))("31")>);
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.map.get(<(literal.(type))("31")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("31")>));
+        assertFalse(this.map.get(<(literal.(type))("31")>));
 
         this.map.removeKey(<(literal.(type))("32")>);
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.map.get(<(literal.(type))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("32")>));
+        assertFalse(this.map.get(<(literal.(type))("32")>));
     }
 
     @Override
@@ -510,11 +515,11 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
 
         this.map.clear();
         this.map.put(<(literal.(type))("35")>, true);
-        Assert.assertTrue(this.map.containsValue(true));
+        assertTrue(this.map.containsValue(true));
 
         this.map.removeKey(<(literal.(type))("35")>);
-        Assert.assertFalse(this.map.containsValue(false));
-        Assert.assertFalse(this.map.containsValue(true));
+        assertFalse(this.map.containsValue(false));
+        assertFalse(this.map.containsValue(true));
     }
 
     @Override
@@ -525,11 +530,11 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
 
         this.map.clear();
         this.map.put(<(literal.(type))("35")>, true);
-        Assert.assertTrue(this.map.contains(true));
+        assertTrue(this.map.contains(true));
 
         this.map.removeKey(<(literal.(type))("35")>);
-        Assert.assertFalse(this.map.contains(false));
-        Assert.assertFalse(this.map.contains(true));
+        assertFalse(this.map.contains(false));
+        assertFalse(this.map.contains(true));
     }
 
     @Override
@@ -540,21 +545,21 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         this.map.clear();
 
         this.map.put(<(literal.(type))("5")>, true);
-        Assert.assertTrue(this.map.containsAll(true));
-        Assert.assertFalse(this.map.containsAll(true, false));
-        Assert.assertFalse(this.map.containsAll(false, false));
+        assertTrue(this.map.containsAll(true));
+        assertFalse(this.map.containsAll(true, false));
+        assertFalse(this.map.containsAll(false, false));
 
         this.map.put(<(literal.(type))("0")>, false);
-        Assert.assertTrue(this.map.containsAll(false));
-        Assert.assertTrue(this.map.containsAll(true, false));
+        assertTrue(this.map.containsAll(false));
+        assertTrue(this.map.containsAll(true, false));
 
         this.map.removeKey(<(literal.(type))("5")>);
-        Assert.assertFalse(this.map.containsAll(true));
-        Assert.assertFalse(this.map.containsAll(true, false));
-        Assert.assertTrue(this.map.containsAll(false, false));
+        assertFalse(this.map.containsAll(true));
+        assertFalse(this.map.containsAll(true, false));
+        assertTrue(this.map.containsAll(false, false));
 
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertFalse(this.map.containsAll(false, true));
+        assertFalse(this.map.containsAll(false, true));
     }
 
     @Override
@@ -565,21 +570,21 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         this.map.clear();
 
         this.map.put(<(literal.(type))("5")>, true);
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
 
         this.map.put(<(literal.(type))("0")>, false);
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
 
         this.map.removeKey(<(literal.(type))("5")>);
-        Assert.assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
 
         this.map.removeKey(<(literal.(type))("0")>);
-        Assert.assertFalse(this.map.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(this.map.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
@@ -605,8 +610,8 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
     {
         Mutable<name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true);
         Mutable<name>BooleanMap mapWithout = map.withoutKey(<(literal.(type))("32")>);
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true, <(literal.(type))("31")>, false), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, false, <(literal.(type))("1")>, true, <(literal.(type))("31")>, false), mapWithout);
     }
 
     @Test
@@ -614,16 +619,16 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
     {
         Mutable<name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true, <(literal.(type))("32")>, false);
         Mutable<name>BooleanMap mapWithout = map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>));
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("31")>, true), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("31")>, true), mapWithout);
     }
 
     @Test
     public void withKeysValues()
     {
         Mutable<name>BooleanMap hashMap = this.getEmptyMap();
-        Assert.assertSame(hashMap.withKeyValue(<(literal.(type))("1")>, false), hashMap);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), hashMap);
+        assertSame(hashMap.withKeyValue(<(literal.(type))("1")>, false), hashMap);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false), hashMap);
     }
 
     @Test
@@ -635,29 +640,29 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
         Iterable\<<name>BooleanPair> emptyIterable = Iterables.iList();
         Iterable\<<name>BooleanPair> partialIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false));
         Iterable\<<name>BooleanPair> completeIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, true), PrimitiveTuples.pair(<(literal.(type))("2")>, true), PrimitiveTuples.pair(<(literal.(type))("3")>, false), PrimitiveTuples.pair(<(literal.(type))("4")>, false));
-        Assert.assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
+        assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(Synchronized<name>BooleanMap.class, this.map.asSynchronized());
-        Assert.assertEquals(new Synchronized<name>BooleanMap(this.map), this.map.asSynchronized());
+        assertEquals(new Synchronized<name>BooleanMap(this.map), this.map.asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(Unmodifiable<name>BooleanMap.class, this.map.asUnmodifiable());
-        Assert.assertEquals(new Unmodifiable<name>BooleanMap(this.map), this.map.asUnmodifiable());
+        assertEquals(new Unmodifiable<name>BooleanMap(this.map), this.map.asUnmodifiable());
     }
 
     @Test
@@ -670,27 +675,27 @@ public abstract class AbstractMutable<name>BooleanMapTestCase extends Abstract<n
             iterator.next();
             iterator.remove();
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         Verify.assertEmpty(map);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
     public void iterator_throws_on_consecutive_invocation_of_remove()
     {
         MutableBooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
         iterator.remove();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveObjectMapTestCase.stg
@@ -39,8 +39,14 @@ import org.eclipse.collections.impl.map.primitive.Abstract<name>ObjectMapTestCas
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitiveObjectMapTestCase.stg.
@@ -84,187 +90,187 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         Mutable<name>ObjectMap\<Object> hashMap = this.getEmptyMap();
         hashMap.put(<(literal.(type))("0")>, new Object());
         hashMap.clear();
-        Assert.assertEquals(new <name>ObjectHashMap\<>(), hashMap);
+        assertEquals(new <name>ObjectHashMap\<>(), hashMap);
 
         hashMap.put(<(literal.(type))("1")>, new Object());
         hashMap.clear();
-        Assert.assertEquals(new <name>ObjectHashMap\<>(), hashMap);
+        assertEquals(new <name>ObjectHashMap\<>(), hashMap);
 
         hashMap.put(<(literal.(type))("33")>, new Object());
         hashMap.clear();
-        Assert.assertEquals(new <name>ObjectHashMap\<>(), hashMap);
+        assertEquals(new <name>ObjectHashMap\<>(), hashMap);
     }
 
     @Test
     public void removeKey()
     {
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("5")>));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("50")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("zero", this.map.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("thirtyOne", this.map.removeKey(<(literal.(type))("31")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("thirtyTwo", this.map.removeKey(<(literal.(type))("32")>));
-        Assert.assertEquals(new <name>ObjectHashMap\<String>(), this.map);
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("0")>));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("1")>));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("31")>));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("32")>));
-        Assert.assertEquals(new <name>ObjectHashMap\<String>(), this.map);
-        Assert.assertTrue(this.map.isEmpty());
+        assertNull(this.map.removeKey(<(literal.(type))("5")>));
+        assertNull(this.map.removeKey(<(literal.(type))("50")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("zero", this.map.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("thirtyOne", this.map.removeKey(<(literal.(type))("31")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("thirtyTwo", this.map.removeKey(<(literal.(type))("32")>));
+        assertEquals(new <name>ObjectHashMap\<String>(), this.map);
+        assertNull(this.map.removeKey(<(literal.(type))("0")>));
+        assertNull(this.map.removeKey(<(literal.(type))("1")>));
+        assertNull(this.map.removeKey(<(literal.(type))("31")>));
+        assertNull(this.map.removeKey(<(literal.(type))("32")>));
+        assertEquals(new <name>ObjectHashMap\<String>(), this.map);
+        assertTrue(this.map.isEmpty());
 
-        Assert.assertNull(this.map.put(<(literal.(type))("1")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("1")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.removeKey(<(literal.(type))("1")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("0")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("0")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.removeKey(<(literal.(type))("0")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("35")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("35")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.removeKey(<(literal.(type))("35")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst(), "collision1"));
-        Assert.assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1), "collision2"));
-        Assert.assertEquals("collision2", this.map.removeKey(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1)));
-        Assert.assertEquals("collision1", this.map.removeKey(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst()));
+        assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst(), "collision1"));
+        assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1), "collision2"));
+        assertEquals("collision2", this.map.removeKey(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1)));
+        assertEquals("collision1", this.map.removeKey(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst()));
 
         Mutable<name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
-        Assert.assertEquals("zero", map1.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map1);
-        Assert.assertEquals("one", map1.removeKey(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map1);
+        assertEquals("zero", map1.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map1);
+        assertEquals("one", map1.removeKey(<(literal.(type))("1")>));
+        assertEquals(<name>ObjectHashMap.newMap(), map1);
     }
 
     @Test
     public void remove()
     {
-        Assert.assertNull(this.map.remove(<(literal.(type))("5")>));
-        Assert.assertNull(this.map.remove(<(literal.(type))("50")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("zero", this.map.remove(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("thirtyOne", this.map.remove(<(literal.(type))("31")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map);
-        Assert.assertEquals("thirtyTwo", this.map.remove(<(literal.(type))("32")>));
-        Assert.assertEquals(new <name>ObjectHashMap\<String>(), this.map);
-        Assert.assertNull(this.map.remove(<(literal.(type))("0")>));
-        Assert.assertNull(this.map.remove(<(literal.(type))("1")>));
-        Assert.assertNull(this.map.remove(<(literal.(type))("31")>));
-        Assert.assertNull(this.map.remove(<(literal.(type))("32")>));
-        Assert.assertEquals(new <name>ObjectHashMap\<String>(), this.map);
-        Assert.assertTrue(this.map.isEmpty());
+        assertNull(this.map.remove(<(literal.(type))("5")>));
+        assertNull(this.map.remove(<(literal.(type))("50")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("zero", this.map.remove(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("thirtyOne", this.map.remove(<(literal.(type))("31")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map);
+        assertEquals("thirtyTwo", this.map.remove(<(literal.(type))("32")>));
+        assertEquals(new <name>ObjectHashMap\<String>(), this.map);
+        assertNull(this.map.remove(<(literal.(type))("0")>));
+        assertNull(this.map.remove(<(literal.(type))("1")>));
+        assertNull(this.map.remove(<(literal.(type))("31")>));
+        assertNull(this.map.remove(<(literal.(type))("32")>));
+        assertEquals(new <name>ObjectHashMap\<String>(), this.map);
+        assertTrue(this.map.isEmpty());
 
-        Assert.assertNull(this.map.put(<(literal.(type))("1")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.remove(<(literal.(type))("1")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("1")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.remove(<(literal.(type))("1")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("0")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.remove(<(literal.(type))("0")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("0")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.remove(<(literal.(type))("0")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
-        Assert.assertNull(this.map.remove(<(literal.(type))("35")>));
-        Assert.assertFalse(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("35")>, null));
+        assertTrue(this.map.containsValue(null));
+        assertNull(this.map.remove(<(literal.(type))("35")>));
+        assertFalse(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst(), "collision1"));
-        Assert.assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1), "collision2"));
-        Assert.assertEquals("collision2", this.map.remove(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1)));
-        Assert.assertEquals("collision1", this.map.remove(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst()));
+        assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst(), "collision1"));
+        assertNull(this.map.put(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1), "collision2"));
+        assertEquals("collision2", this.map.remove(AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(1)));
+        assertEquals("collision1", this.map.remove(AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst()));
 
         Mutable<name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
-        Assert.assertEquals("zero", map1.remove(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map1);
-        Assert.assertEquals("one", map1.remove(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map1);
+        assertEquals("zero", map1.remove(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), map1);
+        assertEquals("one", map1.remove(<(literal.(type))("1")>));
+        assertEquals(<name>ObjectHashMap.newMap(), map1);
     }
 
     @Test
     public void put()
     {
-        Assert.assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
-        Assert.assertEquals("thirtyOne", this.map.put(<(literal.(type))("31")>, "thirtyTwo"));
-        Assert.assertEquals("thirtyTwo", this.map.put(<(literal.(type))("32")>, "thirtyThree"));
+        assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
+        assertEquals("thirtyOne", this.map.put(<(literal.(type))("31")>, "thirtyTwo"));
+        assertEquals("thirtyTwo", this.map.put(<(literal.(type))("32")>, "thirtyThree"));
         <name>ObjectHashMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "one", <(literal.(type))("31")>, "thirtyTwo", <(literal.(type))("32")>, "thirtyThree");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.put(<(literal.(type))("1")>, "two"));
-        Assert.assertEquals("two", this.map.put(<(literal.(type))("1")>, "two"));
+        assertNull(this.map.put(<(literal.(type))("1")>, "two"));
+        assertEquals("two", this.map.put(<(literal.(type))("1")>, "two"));
         expected.put(<(literal.(type))("1")>, "two");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.put(<(literal.(type))("33")>, "thirtyFour"));
+        assertNull(this.map.put(<(literal.(type))("33")>, "thirtyFour"));
         expected.put(<(literal.(type))("33")>, "thirtyFour");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.put(<(literal.(type))("30")>, "thirtyOne"));
+        assertNull(this.map.put(<(literal.(type))("30")>, "thirtyOne"));
         expected.put(<(literal.(type))("30")>, "thirtyOne");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.put(<(literal.(type))("5")>, null));
+        assertNull(this.map.put(<(literal.(type))("5")>, null));
         expected.put(<(literal.(type))("5")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.put(<(literal.(type))("50")>, null));
+        assertNull(this.map.put(<(literal.(type))("50")>, null));
         expected.put(<(literal.(type))("50")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertNull(emptyMap.put(<(literal.(type))("0")>, "zero"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), emptyMap);
+        assertNull(emptyMap.put(<(literal.(type))("0")>, "zero"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), emptyMap);
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertNull(emptyMap1.put(<(literal.(type))("1")>, "one"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), emptyMap1);
-        Assert.assertNull(emptyMap1.put(<(literal.(type))("0")>, "zero"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), emptyMap1);
+        assertNull(emptyMap1.put(<(literal.(type))("1")>, "one"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), emptyMap1);
+        assertNull(emptyMap1.put(<(literal.(type))("0")>, "zero"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), emptyMap1);
     }
 
     @Test
     public void putPair()
     {
-        Assert.assertEquals("zero", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one")));
-        Assert.assertEquals("thirtyOne", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("31")>, "thirtyTwo")));
-        Assert.assertEquals("thirtyTwo", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("32")>, "thirtyThree")));
+        assertEquals("zero", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one")));
+        assertEquals("thirtyOne", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("31")>, "thirtyTwo")));
+        assertEquals("thirtyTwo", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("32")>, "thirtyThree")));
         <name>ObjectHashMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "one", <(literal.(type))("31")>, "thirtyTwo", <(literal.(type))("32")>, "thirtyThree");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "two")));
-        Assert.assertEquals("two", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "two")));
+        assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "two")));
+        assertEquals("two", this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "two")));
         expected.put(<(literal.(type))("1")>, "two");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("33")>, "thirtyFour")));
+        assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("33")>, "thirtyFour")));
         expected.put(<(literal.(type))("33")>, "thirtyFour");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("30")>, "thirtyOne")));
+        assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("30")>, "thirtyOne")));
         expected.put(<(literal.(type))("30")>, "thirtyOne");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("5")>, null)));
+        assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("5")>, null)));
         expected.put(<(literal.(type))("5")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("50")>, null)));
+        assertNull(this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("50")>, null)));
         expected.put(<(literal.(type))("50")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertNull(emptyMap.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "zero")));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), emptyMap);
+        assertNull(emptyMap.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "zero")));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero"), emptyMap);
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertNull(emptyMap1.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "one")));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), emptyMap1);
-        Assert.assertNull(emptyMap1.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "zero")));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), emptyMap1);
+        assertNull(emptyMap1.putPair(PrimitiveTuples.pair(<(literal.(type))("1")>, "one")));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), emptyMap1);
+        assertNull(emptyMap1.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "zero")));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one"), emptyMap1);
     }
 
 <if(primitive.floatingPoint)>
@@ -282,28 +288,28 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         <type> collision4 = AbstractMutable<name>ObjectMapTestCase.generateCollisions().get(3);
 
         Mutable<name>ObjectMap\<String> hashMap = <name>ObjectHashMap.newMap();
-        Assert.assertNull(hashMap.put(collision1, "collision1"));
-        Assert.assertNull(hashMap.put(collision2, "collision2"));
-        Assert.assertNull(hashMap.put(collision3, "collision3"));
-        Assert.assertEquals("collision2", hashMap.removeKey(collision2));
-        Assert.assertNull(hashMap.put(collision4, "collision4"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(collision1, "collision1", collision3, "collision3", collision4, "collision4"), hashMap);
+        assertNull(hashMap.put(collision1, "collision1"));
+        assertNull(hashMap.put(collision2, "collision2"));
+        assertNull(hashMap.put(collision3, "collision3"));
+        assertEquals("collision2", hashMap.removeKey(collision2));
+        assertNull(hashMap.put(collision4, "collision4"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(collision1, "collision1", collision3, "collision3", collision4, "collision4"), hashMap);
 
         Mutable<name>ObjectMap\<String> hashMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertNull(hashMap1.put(collision1, "collision1"));
-        Assert.assertNull(hashMap1.put(collision2, "collision2"));
-        Assert.assertNull(hashMap1.put(collision3, "collision3"));
-        Assert.assertEquals("collision1", hashMap1.removeKey(collision1));
-        Assert.assertNull(hashMap1.put(collision4, "collision4"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(collision2, "collision2", collision3, "collision3", collision4, "collision4"), hashMap1);
+        assertNull(hashMap1.put(collision1, "collision1"));
+        assertNull(hashMap1.put(collision2, "collision2"));
+        assertNull(hashMap1.put(collision3, "collision3"));
+        assertEquals("collision1", hashMap1.removeKey(collision1));
+        assertNull(hashMap1.put(collision4, "collision4"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(collision2, "collision2", collision3, "collision3", collision4, "collision4"), hashMap1);
 
         Mutable<name>ObjectMap\<String> hashMap2 = <name>ObjectHashMap.newMap();
-        Assert.assertNull(hashMap2.put(collision1, "collision1"));
-        Assert.assertNull(hashMap2.put(collision2, "collision2"));
-        Assert.assertNull(hashMap2.put(collision3, "collision3"));
-        Assert.assertEquals("collision3", hashMap2.removeKey(collision3));
-        Assert.assertNull(hashMap2.put(collision4, "collision4"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(collision1, "collision1", collision2, "collision2", collision4, "collision4"), hashMap2);
+        assertNull(hashMap2.put(collision1, "collision1"));
+        assertNull(hashMap2.put(collision2, "collision2"));
+        assertNull(hashMap2.put(collision3, "collision3"));
+        assertEquals("collision3", hashMap2.removeKey(collision3));
+        assertNull(hashMap2.put(collision4, "collision4"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(collision1, "collision1", collision2, "collision2", collision4, "collision4"), hashMap2);
     }
 
     @Test
@@ -314,160 +320,160 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
 
         for (<type> i = <(literal.(type))("1")>; i \< <(literal.(type))("10")>; i++)
         {
-            Assert.assertFalse(copyMap.containsKey(i));
+            assertFalse(copyMap.containsKey(i));
             copyMap.put(i, String.valueOf(i));
         }
 
-        Assert.assertEquals(9, copyMap.size());
-        Assert.assertEquals(0, hashMap.size());
+        assertEquals(9, copyMap.size());
+        assertEquals(0, hashMap.size());
 
         hashMap.putAll(copyMap);
-        Assert.assertEquals(9, hashMap.size());
+        assertEquals(9, hashMap.size());
 
         for (<type> i = <(literal.(type))("1")>; i \< <(literal.(type))("10")>; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(i));
+            assertTrue(hashMap.containsKey(i));
         }
 
-        Assert.assertEquals(hashMap, copyMap);
+        assertEquals(hashMap, copyMap);
     }
 
     @Test
     public void getIfAbsentPut_Value()
     {
-        Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
         Mutable<name>ObjectMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("oneValue", this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
+        assertEquals("oneValue", this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
         expected.put(<(literal.(type))("1")>, "oneValue");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPut(<(literal.(type))("2")>, () -> null));
+        assertNull(this.map.getIfAbsentPut(<(literal.(type))("2")>, () -> null));
         expected.put(<(literal.(type))("2")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyTwo", this.map.getIfAbsentPut(<(literal.(type))("32")>, "thirtyTwoValue"));
-        Assert.assertEquals(expected, this.map);
+        assertEquals("thirtyTwo", this.map.getIfAbsentPut(<(literal.(type))("32")>, "thirtyTwoValue"));
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyThreeValue", this.map.getIfAbsentPut(<(literal.(type))("33")>, "thirtyThreeValue"));
+        assertEquals("thirtyThreeValue", this.map.getIfAbsentPut(<(literal.(type))("33")>, "thirtyThreeValue"));
         expected.put(<(literal.(type))("33")>, "thirtyThreeValue");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPut(<(literal.(type))("34")>, () -> null));
+        assertNull(this.map.getIfAbsentPut(<(literal.(type))("34")>, () -> null));
         expected.put(<(literal.(type))("34")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue"), emptyMap);
 
-        Assert.assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
 
-        Assert.assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, "twoValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
-        Assert.assertEquals("zeroValue", emptyMap.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap);
-        Assert.assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, "twoValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
 
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("oneValue", emptyMap1.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap1);
+        assertEquals("oneValue", emptyMap1.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap1);
     }
 
     @Test
     public void getIfAbsentPut_Function()
     {
-        Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
         Mutable<name>ObjectMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("oneValue", this.map.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
+        assertEquals("oneValue", this.map.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
         expected.put(<(literal.(type))("1")>, "oneValue");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPut(<(literal.(type))("2")>, () -> null));
+        assertNull(this.map.getIfAbsentPut(<(literal.(type))("2")>, () -> null));
         expected.put(<(literal.(type))("2")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyTwo", this.map.getIfAbsentPut(<(literal.(type))("32")>, () -> "thirtyTwoValue"));
-        Assert.assertEquals(expected, this.map);
+        assertEquals("thirtyTwo", this.map.getIfAbsentPut(<(literal.(type))("32")>, () -> "thirtyTwoValue"));
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyThreeValue", this.map.getIfAbsentPut(<(literal.(type))("33")>, () -> "thirtyThreeValue"));
+        assertEquals("thirtyThreeValue", this.map.getIfAbsentPut(<(literal.(type))("33")>, () -> "thirtyThreeValue"));
         expected.put(<(literal.(type))("33")>, "thirtyThreeValue");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPut(<(literal.(type))("34")>, () -> null));
+        assertNull(this.map.getIfAbsentPut(<(literal.(type))("34")>, () -> null));
         expected.put(<(literal.(type))("34")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue"), emptyMap);
 
-        Assert.assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
 
-        Assert.assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, () -> "twoValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
-        Assert.assertEquals("zeroValue", emptyMap.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap);
-        Assert.assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("oneValue", emptyMap.getIfAbsentPut(<(literal.(type))("1")>, () -> "twoValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap);
+        assertEquals("zeroValue", emptyMap.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zeroValue", <(literal.(type))("1")>, "oneValue"), emptyMap);
 
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("oneValue", emptyMap1.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap1);
+        assertEquals("oneValue", emptyMap1.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "oneValue"), emptyMap1);
     }
 
     @Test
     public void getIfAbsentPutWith()
     {
         Function\<String, String> toUpperCase = StringFunctions.toUpperCase();
-        Assert.assertEquals("zero", this.map.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
         <name>ObjectHashMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("ONEVALUE", this.map.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
+        assertEquals("ONEVALUE", this.map.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
         expected.put(<(literal.(type))("1")>, "ONEVALUE");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPutWith(<(literal.(type))("2")>, string -> null, ""));
+        assertNull(this.map.getIfAbsentPutWith(<(literal.(type))("2")>, string -> null, ""));
         expected.put(<(literal.(type))("2")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyTwo", this.map.getIfAbsentPutWith(<(literal.(type))("32")>, toUpperCase, "thirtyTwoValue"));
-        Assert.assertEquals(expected, this.map);
+        assertEquals("thirtyTwo", this.map.getIfAbsentPutWith(<(literal.(type))("32")>, toUpperCase, "thirtyTwoValue"));
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("THIRTYTHREEVALUE", this.map.getIfAbsentPutWith(<(literal.(type))("33")>, toUpperCase, "thirtyThreeValue"));
+        assertEquals("THIRTYTHREEVALUE", this.map.getIfAbsentPutWith(<(literal.(type))("33")>, toUpperCase, "thirtyThreeValue"));
         expected.put(<(literal.(type))("33")>, "THIRTYTHREEVALUE");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPutWith(<(literal.(type))("34")>, string -> null, ""));
+        assertNull(this.map.getIfAbsentPutWith(<(literal.(type))("34")>, string -> null, ""));
         expected.put(<(literal.(type))("34")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("ZEROVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE"), emptyMap);
+        assertEquals("ZEROVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE"), emptyMap);
 
-        Assert.assertEquals("ONEVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
+        assertEquals("ONEVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
 
-        Assert.assertEquals("ONEVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "twoValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
+        assertEquals("ONEVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "twoValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
 
-        Assert.assertEquals("ZEROVALUE", emptyMap.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "ONEVALUE"), emptyMap);
+        assertEquals("ZEROVALUE", emptyMap.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "ONEVALUE"), emptyMap);
 
-        Assert.assertEquals("ZEROVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
+        assertEquals("ZEROVALUE", emptyMap.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "ZEROVALUE", <(literal.(type))("1")>, "ONEVALUE"), emptyMap);
 
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("ONEVALUE", emptyMap1.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "ONEVALUE"), emptyMap1);
+        assertEquals("ONEVALUE", emptyMap1.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "oneValue"));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "ONEVALUE"), emptyMap1);
     }
 
     @Test
@@ -475,64 +481,64 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
 
-        Assert.assertEquals("zero", this.map.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
+        assertEquals("zero", this.map.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
         <name>ObjectHashMap\<String> expected = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
         expected.put(<(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPutWithKey(<(literal.(type))("2")>, (<type> <type>Parameter) -> null));
+        assertNull(this.map.getIfAbsentPutWithKey(<(literal.(type))("2")>, (<type> <type>Parameter) -> null));
         expected.put(<(literal.(type))("2")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("thirtyTwo", this.map.getIfAbsentPutWithKey(<(literal.(type))("32")>, toString));
-        Assert.assertEquals(expected, this.map);
+        assertEquals("thirtyTwo", this.map.getIfAbsentPutWithKey(<(literal.(type))("32")>, toString));
+        assertEquals(expected, this.map);
 
-        Assert.assertEquals("<(toStringLiteral.(type))("33")>", this.map.getIfAbsentPutWithKey(<(literal.(type))("33")>, toString));
+        assertEquals("<(toStringLiteral.(type))("33")>", this.map.getIfAbsentPutWithKey(<(literal.(type))("33")>, toString));
         expected.put(<(literal.(type))("33")>, "<(toStringLiteral.(type))("33")>");
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
-        Assert.assertNull(this.map.getIfAbsentPutWithKey(<(literal.(type))("34")>, (<type> <type>Parameter) -> null));
+        assertNull(this.map.getIfAbsentPutWithKey(<(literal.(type))("34")>, (<type> <type>Parameter) -> null));
         expected.put(<(literal.(type))("34")>, null);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         Mutable<name>ObjectMap\<String> emptyMap = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>"), emptyMap);
+        assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>"), emptyMap);
 
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
+        assertEquals("<(toStringLiteral.(type))("1")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
 
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
+        assertEquals("<(toStringLiteral.(type))("1")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
 
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.removeKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
-        Assert.assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
+        assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.removeKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
+        assertEquals("<(toStringLiteral.(type))("0")>", emptyMap.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "<(toStringLiteral.(type))("0")>", <(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap);
 
         Mutable<name>ObjectMap\<String> emptyMap1 = <name>ObjectHashMap.newMap();
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", emptyMap1.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap1);
+        assertEquals("<(toStringLiteral.(type))("1")>", emptyMap1.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "<(toStringLiteral.(type))("1")>"), emptyMap1);
     }
 
     @Test
     public void removeIf()
     {
         this.map.removeIf((k, v) -> true);
-        Assert.assertTrue(this.map.isEmpty());
+        assertTrue(this.map.isEmpty());
 
         Mutable<name>ObjectMap\<String> testMap = this.classUnderTest();
         testMap.put(<(literal.(type))("1")>, "one");
         testMap.removeIf((k, v) -> true);
-        Assert.assertTrue(testMap.isEmpty());
+        assertTrue(testMap.isEmpty());
 
         testMap = this.classUnderTest();
         testMap.put(<(literal.(type))("1")>, "one");
         testMap.removeIf((k, v) -> k % 2 == 0);
-        Assert.assertEquals(2, testMap.size());
+        assertEquals(2, testMap.size());
     }
 
     @Test
@@ -542,30 +548,30 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
         Mutable<name>ObjectMap\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map1.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1), map1);
-        Assert.assertEquals(Integer.valueOf(2), map1.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2), map1);
-        Assert.assertEquals(Integer.valueOf(1), map1.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 1), map1);
-        Assert.assertEquals(Integer.valueOf(2), map1.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map1);
+        assertEquals(Integer.valueOf(1), map1.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1), map1);
+        assertEquals(Integer.valueOf(2), map1.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2), map1);
+        assertEquals(Integer.valueOf(1), map1.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 1), map1);
+        assertEquals(Integer.valueOf(2), map1.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map1);
 
         Mutable<name>ObjectMap\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map2.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1), map2);
-        Assert.assertEquals(Integer.valueOf(2), map2.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 2), map2);
-        Assert.assertEquals(Integer.valueOf(1), map2.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2), map2);
-        Assert.assertEquals(Integer.valueOf(2), map2.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(1), map2.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1), map2);
+        assertEquals(Integer.valueOf(2), map2.updateValue(<(literal.(type))("1")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(1), map2.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(2), map2.updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map2);
 
         Mutable<name>ObjectMap\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map3.updateValue(<(literal.(type))("33")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 1), map3);
-        Assert.assertEquals(Integer.valueOf(2), map3.updateValue(<(literal.(type))("33")>, zeroFactory, incrementFunction));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 2), map3);
+        assertEquals(Integer.valueOf(1), map3.updateValue(<(literal.(type))("33")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 1), map3);
+        assertEquals(Integer.valueOf(2), map3.updateValue(<(literal.(type))("33")>, zeroFactory, incrementFunction));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 2), map3);
     }
 
     @Test
@@ -575,30 +581,30 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
         Mutable<name>ObjectMap\<Integer> map1 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map1.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1), map1);
-        Assert.assertEquals(Integer.valueOf(2), map1.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2), map1);
-        Assert.assertEquals(Integer.valueOf(1), map1.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 1), map1);
-        Assert.assertEquals(Integer.valueOf(2), map1.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map1);
+        assertEquals(Integer.valueOf(1), map1.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1), map1);
+        assertEquals(Integer.valueOf(2), map1.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2), map1);
+        assertEquals(Integer.valueOf(1), map1.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 1), map1);
+        assertEquals(Integer.valueOf(2), map1.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map1);
 
         Mutable<name>ObjectMap\<Integer> map2 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map2.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1), map2);
-        Assert.assertEquals(Integer.valueOf(2), map2.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 2), map2);
-        Assert.assertEquals(Integer.valueOf(1), map2.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2), map2);
-        Assert.assertEquals(Integer.valueOf(2), map2.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(1), map2.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1), map2);
+        assertEquals(Integer.valueOf(2), map2.updateValueWith(<(literal.(type))("1")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(1), map2.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 1, <(literal.(type))("1")>, 2), map2);
+        assertEquals(Integer.valueOf(2), map2.updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, 2, <(literal.(type))("1")>, 2), map2);
 
         Mutable<name>ObjectMap\<Integer> map3 = this.getEmptyMap();
-        Assert.assertEquals(Integer.valueOf(1), map3.updateValueWith(<(literal.(type))("33")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 1), map3);
-        Assert.assertEquals(Integer.valueOf(2), map3.updateValueWith(<(literal.(type))("33")>, zeroFactory, incrementFunction, 1));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 2), map3);
+        assertEquals(Integer.valueOf(1), map3.updateValueWith(<(literal.(type))("33")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 1), map3);
+        assertEquals(Integer.valueOf(2), map3.updateValueWith(<(literal.(type))("33")>, zeroFactory, incrementFunction, 1));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("33")>, 2), map3);
     }
 
     @Test
@@ -607,52 +613,52 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         Mutable<name>ObjectMap\<String> mutable<name>ObjectMap = this.classUnderTest();
         <name>Set frozenSet = mutable<name>ObjectMap.keySet().freeze();
         <name>Set frozenSetCopy = <name>HashSet.newSetWith(mutable<name>ObjectMap.keySet().toArray());
-        Assert.assertEquals(frozenSet, frozenSetCopy);
-        Assert.assertEquals(frozenSetCopy, mutable<name>ObjectMap.keySet().freeze());
+        assertEquals(frozenSet, frozenSetCopy);
+        assertEquals(frozenSetCopy, mutable<name>ObjectMap.keySet().freeze());
         for (int i = 0; i \< 32; i++)
         {
             mutable<name>ObjectMap.put((<type>) i, "!");
-            Assert.assertEquals(frozenSet, frozenSetCopy);
+            assertEquals(frozenSet, frozenSetCopy);
         }
 
         <name>Set frozenSetForRemove = mutable<name>ObjectMap.keySet().freeze();
         <name>Set frozenSetCopyForRemove = <name>HashSet.newSetWith(mutable<name>ObjectMap.keySet().toArray());
-        Assert.assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
-        Assert.assertEquals(frozenSetCopyForRemove, mutable<name>ObjectMap.keySet().freeze());
+        assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
+        assertEquals(frozenSetCopyForRemove, mutable<name>ObjectMap.keySet().freeze());
         for (int i = 0; i \< 32; i++)
         {
             mutable<name>ObjectMap.remove((<type>) i);
-            Assert.assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
+            assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
         }
 
         Mutable<name>ObjectMap\<String> mutable<name>ObjectMapForClear = this.classUnderTest();
         <name>Set frozenSetForClear = mutable<name>ObjectMapForClear.keySet().freeze();
         <name>Set frozenSetCopyForClear = <name>HashSet.newSetWith(mutable<name>ObjectMapForClear.keySet().toArray());
         mutable<name>ObjectMapForClear.clear();
-        Assert.assertEquals(frozenSetForClear, frozenSetCopyForClear);
+        assertEquals(frozenSetForClear, frozenSetCopyForClear);
     }
 
     @Test
     public void withoutKey()
     {
         Mutable<name>ObjectMap\<String> actual = this.map.withoutKey(<(literal.(type))("55")>);
-        Assert.assertSame(this.map, actual);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), actual);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map.withoutKey(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map.withoutKey(<(literal.(type))("31")>));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutKey(<(literal.(type))("32")>));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutKey(<(literal.(type))("1")>));
+        assertSame(this.map, actual);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), actual);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), this.map.withoutKey(<(literal.(type))("0")>));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map.withoutKey(<(literal.(type))("31")>));
+        assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutKey(<(literal.(type))("32")>));
+        assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutKey(<(literal.(type))("1")>));
     }
 
     @Test
     public void withoutAllKeys()
     {
         Mutable<name>ObjectMap\<String> actual = this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("55")>, <(literal.(type))("1")>));
-        Assert.assertSame(this.map, actual);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), actual);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("31")>)));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("31")>, <(literal.(type))("32")>)));
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertSame(this.map, actual);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo"), actual);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo"), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("31")>)));
+        assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("31")>, <(literal.(type))("32")>)));
+        assertEquals(<name>ObjectHashMap.newMap(), this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
     }
 
     @Test
@@ -664,15 +670,15 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         Iterable\<<name>ObjectPair\<String>\> emptyIterable = Iterables.iList();
         Iterable\<<name>ObjectPair\<String>\> partialIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, "one"), PrimitiveTuples.pair(<(literal.(type))("3")>, "three"));
         Iterable\<<name>ObjectPair\<String>\> completeIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, "one"), PrimitiveTuples.pair(<(literal.(type))("2")>, "two"), PrimitiveTuples.pair(<(literal.(type))("3")>, "three"));
-        Assert.assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
+        assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
     }
 
     @Override
@@ -681,20 +687,20 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     {
         super.get();
 
-        Assert.assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
-        Assert.assertEquals("one", this.map.get(<(literal.(type))("0")>));
+        assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
+        assertEquals("one", this.map.get(<(literal.(type))("0")>));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("5")>, "five"));
-        Assert.assertEquals("five", this.map.get(<(literal.(type))("5")>));
+        assertNull(this.map.put(<(literal.(type))("5")>, "five"));
+        assertEquals("five", this.map.get(<(literal.(type))("5")>));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, "thirtyFive"));
-        Assert.assertEquals("thirtyFive", this.map.get(<(literal.(type))("35")>));
+        assertNull(this.map.put(<(literal.(type))("35")>, "thirtyFive"));
+        assertEquals("thirtyFive", this.map.get(<(literal.(type))("35")>));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("6")>, null));
-        Assert.assertNull(this.map.get(<(literal.(type))("6")>));
+        assertNull(this.map.put(<(literal.(type))("6")>, null));
+        assertNull(this.map.get(<(literal.(type))("6")>));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("36")>, null));
-        Assert.assertNull(this.map.get(<(literal.(type))("36")>));
+        assertNull(this.map.put(<(literal.(type))("36")>, null));
+        assertNull(this.map.get(<(literal.(type))("36")>));
     }
 
     @Override
@@ -705,20 +711,20 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
 
         Function0\<String> ifAbsent = () -> "ifAbsent";
 
-        Assert.assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
-        Assert.assertEquals("one", this.map.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("zero", this.map.put(<(literal.(type))("0")>, "one"));
+        assertEquals("one", this.map.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("5")>, "five"));
-        Assert.assertEquals("five", this.map.getIfAbsent(<(literal.(type))("5")>, ifAbsent));
+        assertNull(this.map.put(<(literal.(type))("5")>, "five"));
+        assertEquals("five", this.map.getIfAbsent(<(literal.(type))("5")>, ifAbsent));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, "thirtyFive"));
-        Assert.assertEquals("thirtyFive", this.map.getIfAbsent(<(literal.(type))("35")>, ifAbsent));
+        assertNull(this.map.put(<(literal.(type))("35")>, "thirtyFive"));
+        assertEquals("thirtyFive", this.map.getIfAbsent(<(literal.(type))("35")>, ifAbsent));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("6")>, null));
-        Assert.assertNull(this.map.getIfAbsent(<(literal.(type))("6")>, ifAbsent));
+        assertNull(this.map.put(<(literal.(type))("6")>, null));
+        assertNull(this.map.getIfAbsent(<(literal.(type))("6")>, ifAbsent));
 
-        Assert.assertNull(this.map.put(<(literal.(type))("36")>, null));
-        Assert.assertNull(this.map.getIfAbsent(<(literal.(type))("36")>, ifAbsent));
+        assertNull(this.map.put(<(literal.(type))("36")>, null));
+        assertNull(this.map.getIfAbsent(<(literal.(type))("36")>, ifAbsent));
     }
 
     @Override
@@ -727,12 +733,12 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     {
         super.containsKey();
 
-        Assert.assertEquals("zero", this.map.removeKey(<(literal.(type))("0")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("0")>));
-        Assert.assertEquals("thirtyOne", this.map.removeKey(<(literal.(type))("31")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("31")>));
-        Assert.assertEquals("thirtyTwo", this.map.removeKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("32")>));
+        assertEquals("zero", this.map.removeKey(<(literal.(type))("0")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("0")>));
+        assertEquals("thirtyOne", this.map.removeKey(<(literal.(type))("31")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("31")>));
+        assertEquals("thirtyTwo", this.map.removeKey(<(literal.(type))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("32")>));
     }
 
     @Override
@@ -741,12 +747,12 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     {
         super.containsValue();
 
-        Assert.assertNull(this.map.put(<(literal.(type))("5")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
+        assertNull(this.map.put(<(literal.(type))("5")>, null));
+        assertTrue(this.map.containsValue(null));
 
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("5")>));
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, null));
-        Assert.assertTrue(this.map.containsValue(null));
+        assertNull(this.map.removeKey(<(literal.(type))("5")>));
+        assertNull(this.map.put(<(literal.(type))("35")>, null));
+        assertTrue(this.map.containsValue(null));
     }
 
     @Override
@@ -754,20 +760,20 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     public void size()
     {
         super.size();
-        Assert.assertEquals(0, this.getEmptyMap().size());
-        Assert.assertEquals(1, this.getEmptyMap().withKeyValue(<(literal.(type))("0")>, "zero").size());
-        Assert.assertEquals(1, this.getEmptyMap().withKeyValue(<(literal.(type))("1")>, "one").size());
+        assertEquals(0, this.getEmptyMap().size());
+        assertEquals(1, this.getEmptyMap().withKeyValue(<(literal.(type))("0")>, "zero").size());
+        assertEquals(1, this.getEmptyMap().withKeyValue(<(literal.(type))("1")>, "one").size());
 
         Mutable<name>ObjectMap\<String> hashMap1 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("0")>, "zero");
-        Assert.assertEquals(2, hashMap1.size());
+        assertEquals(2, hashMap1.size());
         hashMap1.removeKey(<(literal.(type))("1")>);
-        Assert.assertEquals(1, hashMap1.size());
+        assertEquals(1, hashMap1.size());
         hashMap1.removeKey(<(literal.(type))("0")>);
-        Assert.assertEquals(0, hashMap1.size());
+        assertEquals(0, hashMap1.size());
 
         Mutable<name>ObjectMap\<String> hashMap = this.newWithKeysValues(<(literal.(type))("6")>, "six", <(literal.(type))("5")>, "five");
         hashMap.removeKey(<(literal.(type))("5")>);
-        Assert.assertEquals(1, hashMap.size());
+        assertEquals(1, hashMap.size());
     }
 
     @Override
@@ -775,12 +781,12 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     public void contains()
     {
         super.contains();
-        Assert.assertNull(this.map.put(<(literal.(type))("1")>, null));
-        Assert.assertTrue(this.map.contains(null));
+        assertNull(this.map.put(<(literal.(type))("1")>, null));
+        assertTrue(this.map.contains(null));
 
-        Assert.assertNull(this.map.removeKey(<(literal.(type))("5")>));
-        Assert.assertNull(this.map.put(<(literal.(type))("35")>, null));
-        Assert.assertTrue(this.map.contains(null));
+        assertNull(this.map.removeKey(<(literal.(type))("5")>));
+        assertNull(this.map.put(<(literal.(type))("35")>, null));
+        assertTrue(this.map.contains(null));
     }
 
     @Test
@@ -788,8 +794,8 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
     {
         Mutable<name>ObjectMap\<String> emptyMap = this.getEmptyMap();
         Mutable<name>ObjectMap\<String> hashMap = emptyMap.withKeyValue(<(literal.(type))("1")>, "one");
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), hashMap);
-        Assert.assertSame(emptyMap, hashMap);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), hashMap);
+        assertSame(emptyMap, hashMap);
     }
 
     @Override
@@ -800,61 +806,61 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
 
         Mutable<name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Iterator\<String> iterator1 = map1.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        Assert.assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one").equals(map1));
         iterator1.next();
         iterator1.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map1);
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertEquals(<name>ObjectHashMap.newMap(), map1);
+        assertThrows(IllegalStateException.class, iterator1::remove);
 
         Mutable<name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("9")>, "nine");
         Iterator\<String> iterator2 = map2.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator2::remove);
+        assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        Assert.assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map2)
+        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map2)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
         iterator2.next();
         iterator2.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map2);
+        assertEquals(<name>ObjectHashMap.newMap(), map2);
 
         Mutable<name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("8")>, "eight", <(literal.(type))("9")>, "nine");
         Iterator\<String> iterator3 = map3.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator3::remove);
+        assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        Assert.assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map3));
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map3);
+        assertEquals(<name>ObjectHashMap.newMap(), map3);
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(Unmodifiable<name>ObjectMap.class, this.map.asUnmodifiable());
-        Assert.assertEquals(new Unmodifiable<name>ObjectMap\<>(this.map), this.map.asUnmodifiable());
+        assertEquals(new Unmodifiable<name>ObjectMap\<>(this.map), this.map.asUnmodifiable());
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(Synchronized<name>ObjectMap.class, this.map.asSynchronized());
-        Assert.assertEquals(new Synchronized<name>ObjectMap\<>(this.map), this.map.asSynchronized());
+        assertEquals(new Synchronized<name>ObjectMap\<>(this.map), this.map.asSynchronized());
     }
 
     @Test
     public void flipUniqueValues()
     {
         Mutable<name>ObjectMap\<String> map = this.newWithKeysValues(<(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3");
-        Assert.assertEquals(
+        assertEquals(
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("2")>),
                 map.flipUniqueValues());
-        Assert.assertThrows(
+        assertThrows(
                 IllegalStateException.class,
                 () -> this.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "1").flipUniqueValues());
     }
@@ -870,14 +876,14 @@ public void put_<key>()
     Map\<<wrapperName>, String> hashmap = new HashMap\<>();
     hashmap.put(<wrapperName>.<key>, "one");
 
-    Assert.assertTrue(hashmap.containsKey(<wrapperName>.<key>));
-    Assert.assertTrue(map.containsKey(<wrapperName>.<key>));
+    assertTrue(hashmap.containsKey(<wrapperName>.<key>));
+    assertTrue(map.containsKey(<wrapperName>.<key>));
 
-    Assert.assertEquals("one", hashmap.get(<wrapperName>.<key>));
-    Assert.assertEquals("one", map.get(<wrapperName>.<key>));
+    assertEquals("one", hashmap.get(<wrapperName>.<key>));
+    assertEquals("one", map.get(<wrapperName>.<key>));
 
-    Assert.assertEquals("one", hashmap.put(<wrapperName>.<key>, "two"));
-    Assert.assertEquals("one", map.put(<wrapperName>.<key>, "two"));
+    assertEquals("one", hashmap.put(<wrapperName>.<key>, "two"));
+    assertEquals("one", map.put(<wrapperName>.<key>, "two"));
     Verify.assertIterableSize(hashmap.size(), map);
 }
 
@@ -891,20 +897,20 @@ public void put_zero()
     Map\<<wrapperName>, String> hashmap = new HashMap\<>();
     hashmap.put(<(literal.(type))("0")>, "one");
 
-    Assert.assertTrue(hashmap.containsKey(<(literal.(type))("0")>));
-    Assert.assertFalse(hashmap.containsKey(-<(literal.(type))("0")>));
-    Assert.assertTrue(map.containsKey(<(literal.(type))("0")>));
-    Assert.assertFalse(map.containsKey(-<(literal.(type))("0")>));
+    assertTrue(hashmap.containsKey(<(literal.(type))("0")>));
+    assertFalse(hashmap.containsKey(-<(literal.(type))("0")>));
+    assertTrue(map.containsKey(<(literal.(type))("0")>));
+    assertFalse(map.containsKey(-<(literal.(type))("0")>));
 
-    Assert.assertEquals("one", hashmap.get(<(literal.(type))("0")>));
-    Assert.assertNull(hashmap.get(-<(literal.(type))("0")>));
-    Assert.assertEquals("one", map.get(<(literal.(type))("0")>));
-    Assert.assertNull(map.get(-<(literal.(type))("0")>));
+    assertEquals("one", hashmap.get(<(literal.(type))("0")>));
+    assertNull(hashmap.get(-<(literal.(type))("0")>));
+    assertEquals("one", map.get(<(literal.(type))("0")>));
+    assertNull(map.get(-<(literal.(type))("0")>));
 
-    Assert.assertEquals("one", hashmap.put(<(literal.(type))("0")>, "two"));
-    Assert.assertNull(hashmap.put(-<(literal.(type))("0")>, "two"));
-    Assert.assertEquals("one", map.put(<(literal.(type))("0")>, "two"));
-    Assert.assertNull(map.put(-<(literal.(type))("0")>, "two"));
+    assertEquals("one", hashmap.put(<(literal.(type))("0")>, "two"));
+    assertNull(hashmap.put(-<(literal.(type))("0")>, "two"));
+    assertEquals("one", map.put(<(literal.(type))("0")>, "two"));
+    assertNull(map.put(-<(literal.(type))("0")>, "two"));
     Verify.assertIterableSize(hashmap.size(), map);
 }
 
@@ -919,14 +925,14 @@ public void put_different_NaNs()
     Map\<<wrapperName>, String> hashMap = new HashMap\<<wrapperName>, String>();
     hashMap.put(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1), "one");
     <bitsType.(type)> nan2 = <NaNBits2.(type)>;
-    Assert.assertTrue(hashMap.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
-    Assert.assertTrue(map.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
+    assertTrue(hashMap.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
+    assertTrue(map.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
 
-    Assert.assertEquals("one", hashMap.put(nan2, "two"));
-    Assert.assertEquals("one", map.put(nan2, "two"));
+    assertEquals("one", hashMap.put(nan2, "two"));
+    assertEquals("one", map.put(nan2, "two"));
 
-    Assert.assertTrue(hashMap.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1)));
-    Assert.assertTrue(map.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1)));
+    assertTrue(hashMap.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1)));
+    assertTrue(map.containsKey(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1)));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
@@ -41,8 +41,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitivePrimitiveMapTestCase.stg.
@@ -74,16 +79,16 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         super.get();
         Mutable<name1><name2>Map map1 = this.classUnderTest();
         map1.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
 
         map1.put(<["0"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
 
         map1.put(<["5"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("5")>, map1.get(<(literal.(type1))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("5")>, map1.get(<(literal.(type1))("5")>)<wideDelta.(type2)>);
 
         map1.put(<["35"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("35")>, map1.get(<(literal.(type1))("35")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("35")>, map1.get(<(literal.(type1))("35")>)<wideDelta.(type2)>);
     }
 
     @Override
@@ -93,18 +98,18 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         super.getOrThrow();
         Mutable<name1><name2>Map map1 = this.classUnderTest();
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertThrows(IllegalStateException.class, () -> map1.getOrThrow(<(literal.(type1))("0")>));
+        assertThrows(IllegalStateException.class, () -> map1.getOrThrow(<(literal.(type1))("0")>));
         map1.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map1.getOrThrow(<(literal.(type1))("0")>)<wideDelta.(type2)>);
 
         map1.put(<["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.getOrThrow(<(literal.(type1))("1")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map1.getOrThrow(<(literal.(type1))("1")>)<wideDelta.(type2)>);
 
         map1.put(<["5"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("5")>, map1.getOrThrow(<(literal.(type1))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("5")>, map1.getOrThrow(<(literal.(type1))("5")>)<wideDelta.(type2)>);
 
         map1.put(<["35"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("35")>, map1.getOrThrow(<(literal.(type1))("35")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("35")>, map1.getOrThrow(<(literal.(type1))("35")>)<wideDelta.(type2)>);
     }
 
     @Override
@@ -114,22 +119,22 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         super.getIfAbsent();
         Mutable<name1><name2>Map map1 = this.classUnderTest();
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertEquals(<(literal.(type2))("5")>, map1.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("5")>, map1.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
 
-        Assert.assertEquals(<(literal.(type2))("6")>, map1.getIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("6")>, map1.getIfAbsent(<(literal.(type1))("33")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("6")>, map1.getIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("6")>, map1.getIfAbsent(<(literal.(type1))("33")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
 
         map1.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map1.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
 
         map1.put(<["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.getIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map1.getIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
 
         map1.put(<["5"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("5")>, map1.getIfAbsent(<(literal.(type1))("5")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("5")>, map1.getIfAbsent(<(literal.(type1))("5")>, <(literal.(type2))("6")>)<wideDelta.(type2)>);
 
         map1.put(<["35"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("35")>, map1.getIfAbsent(<(literal.(type1))("35")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("35")>, map1.getIfAbsent(<(literal.(type1))("35")>, <(literal.(type2))("5")>)<wideDelta.(type2)>);
     }
 
     @Override
@@ -139,23 +144,23 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         super.containsKey();
         Mutable<name1><name2>Map map1 = this.classUnderTest();
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertFalse(map1.containsKey(<(literal.(type1))("0")>));
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertFalse(map1.containsKey(<(literal.(type1))("0")>));
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertFalse(map1.containsKey(<(literal.(type1))("0")>));
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
+        assertFalse(map1.containsKey(<(literal.(type1))("0")>));
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("0")>)<wideDelta.(type2)>);
 
         map1.removeKey(<(literal.(type1))("1")>);
-        Assert.assertFalse(map1.containsKey(<(literal.(type1))("1")>));
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("1")>)<wideDelta.(type2)>);
+        assertFalse(map1.containsKey(<(literal.(type1))("1")>));
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("1")>)<wideDelta.(type2)>);
 
         map1.removeKey(<(literal.(type1))("31")>);
-        Assert.assertFalse(map1.containsKey(<(literal.(type1))("31")>));
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
+        assertFalse(map1.containsKey(<(literal.(type1))("31")>));
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("31")>)<wideDelta.(type2)>);
 
         map1.removeKey(<(literal.(type1))("32")>);
-        Assert.assertFalse(map1.containsKey(<(literal.(type1))("32")>));
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
+        assertFalse(map1.containsKey(<(literal.(type1))("32")>));
+        assertEquals(<(literal.(type2))("0")>, map1.get(<(literal.(type1))("32")>)<wideDelta.(type2)>);
     }
 
     @Override
@@ -166,10 +171,10 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Mutable<name1><name2>Map map1 = this.classUnderTest();
 
         map1.put(<["35"]:keyValue(); separator=", ">);
-        Assert.assertTrue(map1.containsValue(<(literal.(type2))("35")>));
+        assertTrue(map1.containsValue(<(literal.(type2))("35")>));
 
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertFalse(map1.containsValue(<(literal.(type2))("0")>));
+        assertFalse(map1.containsValue(<(literal.(type2))("0")>));
     }
 
     @Override
@@ -180,10 +185,10 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Mutable<name1><name2>Map map1 = this.classUnderTest();
 
         map1.put(<["35"]:keyValue(); separator=", ">);
-        Assert.assertTrue(map1.contains(<(literal.(type2))("35")>));
+        assertTrue(map1.contains(<(literal.(type2))("35")>));
 
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertFalse(map1.contains(<(literal.(type2))("0")>));
+        assertFalse(map1.contains(<(literal.(type2))("0")>));
     }
 
     @Override
@@ -192,15 +197,15 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         super.size();
         Mutable<name1><name2>Map hashMap1 = this.newWithKeysValues(<["1", "0"]:keyValue(); separator=", ">);
-        Assert.assertEquals(2, hashMap1.size());
+        assertEquals(2, hashMap1.size());
         hashMap1.removeKey(<(literal.(type1))("1")>);
-        Assert.assertEquals(1, hashMap1.size());
+        assertEquals(1, hashMap1.size());
         hashMap1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertEquals(0, hashMap1.size());
+        assertEquals(0, hashMap1.size());
 
         Mutable<name1><name2>Map hashMap = this.newWithKeysValues(<["6", "5"]:keyValue(); separator=", ">);
         hashMap.removeKey(<(literal.(type1))("5")>);
-        Assert.assertEquals(1, hashMap.size());
+        assertEquals(1, hashMap.size());
     }
 
     protected static <name1>ArrayList generateCollisions()
@@ -222,17 +227,17 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map1 = this.classUnderTest();
         map1.clear();
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(new <name1><name2>HashMap(), map1);
 
         map1.put(<(literal.(type1))("1")>, <(literal.(type2))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("0")>), map1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("0")>), map1);
         map1.clear();
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(new <name1><name2>HashMap(), map1);
 
         map1.put(<(literal.(type1))("33")>, <(literal.(type2))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("0")>), map1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("0")>), map1);
         map1.clear();
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(new <name1><name2>HashMap(), map1);
     }
 
     @Test
@@ -240,42 +245,42 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
         map0.removeKey(<(literal.(type1))("1")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
         map0.removeKey(<(literal.(type1))("0")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map0);
+        assertEquals(new <name1><name2>HashMap(), map0);
 
         Mutable<name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
         map1.removeKey(<(literal.(type1))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
         map1.removeKey(<(literal.(type1))("1")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(new <name1><name2>HashMap(), map1);
 
         Mutable<name1><name2>Map map2 = this.classUnderTest();
         map2.removeKey(<(literal.(type1))("5")>);
         map2.removeKey(<(literal.(type1))("50")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.removeKey(<(literal.(type1))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.removeKey(<(literal.(type1))("31")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.removeKey(<(literal.(type1))("32")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(new <name1><name2>HashMap(), map2);
         map2.removeKey(<(literal.(type1))("0")>);
         map2.removeKey(<(literal.(type1))("31")>);
         map2.removeKey(<(literal.(type1))("32")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(new <name1><name2>HashMap(), map2);
         Verify.assertEmpty(map2);
 
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0), <(literal.(type2))("1")>);
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1), <(literal.(type2))("2")>);
 
-        Assert.assertEquals(<(literal.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
         map2.removeKey(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0));
-        Assert.assertEquals(<(literal.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
 
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
         map2.removeKey(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1));
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
     }
 
     @Test
@@ -283,89 +288,89 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
         map0.remove(<(literal.(type1))("1")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
         map0.remove(<(literal.(type1))("0")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map0);
+        assertEquals(new <name1><name2>HashMap(), map0);
 
         Mutable<name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
         map1.remove(<(literal.(type1))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
         map1.remove(<(literal.(type1))("1")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(new <name1><name2>HashMap(), map1);
 
         Mutable<name1><name2>Map map2 = this.classUnderTest();
         map2.remove(<(literal.(type1))("5")>);
         map2.remove(<(literal.(type1))("50")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.remove(<(literal.(type1))("0")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.remove(<(literal.(type1))("31")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
         map2.remove(<(literal.(type1))("32")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(new <name1><name2>HashMap(), map2);
         map2.remove(<(literal.(type1))("0")>);
         map2.remove(<(literal.(type1))("31")>);
         map2.remove(<(literal.(type1))("32")>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(new <name1><name2>HashMap(), map2);
         Verify.assertEmpty(map2);
 
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0), <(literal.(type2))("1")>);
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1), <(literal.(type2))("2")>);
 
-        Assert.assertEquals(<(literal.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
         map2.remove(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0));
-        Assert.assertEquals(<(literal.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<wideDelta.(type2)>);
 
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
         map2.remove(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1));
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<wideDelta.(type2)>);
     }
 
     @Test
     public void removeKeyIfAbsent()
     {
         Mutable<name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("1")>, map0.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
-        Assert.assertEquals(<(literal.(type2))("0")>, map0.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map0);
-        Assert.assertEquals(<(literal.(type2))("100")>, map0.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("100")>, map0.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("1")>, map0.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>), map0);
+        assertEquals(<(literal.(type2))("0")>, map0.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(new <name1><name2>HashMap(), map0);
+        assertEquals(<(literal.(type2))("100")>, map0.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("100")>, map0.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
 
         Mutable<name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <["1"]:keyValue(); separator=", ">);
-        Assert.assertEquals(<(literal.(type2))("0")>, map1.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
-        Assert.assertEquals(<(literal.(type2))("1")>, map1.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map1);
-        Assert.assertEquals(<(literal.(type2))("100")>, map1.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("100")>, map1.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("0")>, map1.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["1"]:keyValue(); separator=", ">), map1);
+        assertEquals(<(literal.(type2))("1")>, map1.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(new <name1><name2>HashMap(), map1);
+        assertEquals(<(literal.(type2))("100")>, map1.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("100")>, map1.removeKeyIfAbsent(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
 
         Mutable<name1><name2>Map map2 = this.classUnderTest();
-        Assert.assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("5")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("50")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
-        Assert.assertEquals(<(literal.(type2))("0")>, map2.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
-        Assert.assertEquals(<(literal.(type2))("31")>, map2.removeKeyIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
-        Assert.assertEquals(<(literal.(type2))("32")>, map2.removeKeyIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
-        Assert.assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("5")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("50")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("0")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<(literal.(type2))("0")>, map2.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("31")>, <(literal.(type2))("31")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<(literal.(type2))("31")>, map2.removeKeyIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map2);
+        assertEquals(<(literal.(type2))("32")>, map2.removeKeyIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(new <name1><name2>HashMap(), map2);
+        assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("100")>, map2.removeKeyIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(new <name1><name2>HashMap(), map2);
         Verify.assertEmpty(map2);
 
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0), <(literal.(type2))("1")>);
         map2.put(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1), <(literal.(type2))("2")>);
 
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("1")>, map2.removeKeyIfAbsent(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0), <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("1")>, map2.removeKeyIfAbsent(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0), <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(0))<(wideDelta.(type2))>);
 
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<(wideDelta.(type2))>);
-        Assert.assertEquals(<(literal.(type2))("2")>, map2.removeKeyIfAbsent(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1), <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("2")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("2")>, map2.removeKeyIfAbsent(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1), <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.get(AbstractMutable<name1><name2>MapTestCase.generateCollisions().get(1))<(wideDelta.(type2))>);
     }
 
     @Test
@@ -376,33 +381,33 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         map1.put(<(literal.(type1))("31")>, <(literal.(type2))("32")>);
         map1.put(<(literal.(type1))("32")>, <(literal.(type2))("33")>);
         <name1><name2>HashMap expected = <name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("31")>, <(literal.(type2))("32")>, <(literal.(type1))("32")>, <(literal.(type2))("33")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.put(<(literal.(type1))("1")>, <(literal.(type2))("2")>);
         expected.put(<(literal.(type1))("1")>, <(literal.(type2))("2")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.put(<(literal.(type1))("33")>, <(literal.(type2))("34")>);
         expected.put(<(literal.(type1))("33")>, <(literal.(type2))("34")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.put(<(literal.(type1))("30")>, <(literal.(type2))("31")>);
         expected.put(<(literal.(type1))("30")>, <(literal.(type2))("31")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
     }
 
     @Test
     public void getAndPut()
     {
         Mutable<name1><name2>Map map1 = this.classUnderTest();
-        Assert.assertEquals(0, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("25")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(25, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("35")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(35, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("45")>, <(literal.(type2))("55")>)<wideDelta.(type2)>);
-        Assert.assertEquals(100, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
-        Assert.assertEquals(25, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("30")>)<wideDelta.(type2)>);
+        assertEquals(0, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("25")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(25, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("35")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(35, map1.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("45")>, <(literal.(type2))("55")>)<wideDelta.(type2)>);
+        assertEquals(100, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("100")>)<wideDelta.(type2)>);
+        assertEquals(25, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("30")>)<wideDelta.(type2)>);
         map1.removeKey(<(literal.(type1))("10")>);
-        Assert.assertEquals(101, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("101")>)<wideDelta.(type2)>);
-        Assert.assertEquals(25, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("27")>, <(literal.(type2))("105")>)<wideDelta.(type2)>);
+        assertEquals(101, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("25")>, <(literal.(type2))("101")>)<wideDelta.(type2)>);
+        assertEquals(25, map1.getAndPut(<(literal.(type1))("10")>, <(literal.(type2))("27")>, <(literal.(type2))("105")>)<wideDelta.(type2)>);
     }
 
     @Test
@@ -413,19 +418,19 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         map1.putPair(PrimitiveTuples.pair(<(literal.(type1))("31")>, <(literal.(type2))("32")>));
         map1.putPair(PrimitiveTuples.pair(<(literal.(type1))("32")>, <(literal.(type2))("33")>));
         <name1><name2>HashMap expected = <name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("31")>, <(literal.(type2))("32")>, <(literal.(type1))("32")>, <(literal.(type2))("33")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.putPair(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
         expected.put(<(literal.(type1))("1")>, <(literal.(type2))("2")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.putPair(PrimitiveTuples.pair(<(literal.(type1))("33")>, <(literal.(type2))("34")>));
         expected.put(<(literal.(type1))("33")>, <(literal.(type2))("34")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.putPair(PrimitiveTuples.pair(<(literal.(type1))("30")>, <(literal.(type2))("31")>));
         expected.put(<(literal.(type1))("30")>, <(literal.(type2))("31")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
     }
 
     @Test
@@ -434,45 +439,45 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Mutable<name1><name2>Map map1 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("11")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("2")>, <(literal.(type2))("13")>);
         map1.updateValues((k, v) -> v);
         Mutable<name1><name2>Map expected1 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("11")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("2")>, <(literal.(type2))("13")>);
-        Assert.assertEquals(expected1, map1);
+        assertEquals(expected1, map1);
 
         Mutable<name1><name2>Map map2 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("11")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("2")>, <(literal.(type2))("13")>);
         map2.updateValues((k, v) -> <(castIntToNarrowTypeWithParens.(type2))({v + <(literal.(type2))("1")>})>);
         Mutable<name1><name2>Map expected2 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("12")>, <(literal.(type1))("1")>, <(literal.(type2))("13")>, <(literal.(type1))("2")>, <(literal.(type2))("14")>);
-        Assert.assertEquals(expected2, map2);
+        assertEquals(expected2, map2);
 
         Mutable<name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("11")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("2")>, <(literal.(type2))("13")>);
         map3.updateValues((k, v) -> k == <(literal.(type1))("0")> ? <(literal.(type2))("10")> : v);
         Mutable<name1><name2>Map expected3 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("10")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("2")>, <(literal.(type2))("13")>);
-        Assert.assertEquals(expected3, map3);
+        assertEquals(expected3, map3);
     }
 
     @Test
     public void addToValue()
     {
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("32")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("3")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("11")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("10")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("12")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("9")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("37")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("33")>, map1.addToValue(<(literal.(type1))("32")>, <(literal.(type2))("33")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("32")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("32")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("3")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("3")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("11")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("10")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("12")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("9")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("37")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("33")>, map1.addToValue(<(literal.(type1))("32")>, <(literal.(type2))("33")>)<(wideDelta.(type2))>);
         <name1><name2>HashMap expected = <name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("11")>, <(literal.(type1))("1")>, <(literal.(type2))("12")>, <(literal.(type1))("31")>, <(literal.(type2))("37")>, <(literal.(type1))("32")>, <(literal.(type2))("33")>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(expected, map1);
 
         map1.removeKey(<(literal.(type1))("0")>);
         map1.removeKey(<(literal.(type1))("1")>);
         map1.removeKey(<(literal.(type1))("31")>);
         map1.removeKey(<(literal.(type1))("32")>);
-        Assert.assertEquals(<(wideLiteral.(type2))("5")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("37")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("32")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("33")>, map1.addToValue(<(literal.(type1))("32")>, <(literal.(type2))("33")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("3")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("12")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("9")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("11")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("10")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(expected, map1);
+        assertEquals(<(wideLiteral.(type2))("5")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("37")>, map1.addToValue(<(literal.(type1))("31")>, <(literal.(type2))("32")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("33")>, map1.addToValue(<(literal.(type1))("32")>, <(literal.(type2))("33")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("3")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("3")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("12")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("9")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("11")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("10")>)<(wideDelta.(type2))>);
+        assertEquals(expected, map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
         MutableLongList list = LongLists.mutable.with(
@@ -490,7 +495,7 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         {
             <type1> k = <(castLongToNarrowType.(type1))("each")>;
             <type2> v = <(castLongToNarrowTypeWithParens.(type2))("each + index")>;
-            Assert.assertEquals("Key:" + k, v, map2.addToValue(k, v)<(wideDelta.(type2))>);
+            assertEquals("Key:" + k, v, map2.addToValue(k, v)<(wideDelta.(type2))>);
         });
     }
 
@@ -500,11 +505,11 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
         for (int i = 2; i \< 100; i++)
         {
-            Assert.assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
+            assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
             hashMap.put(<(castFromInt.(type1))("i")>, <(castFromInt.(type2))("i")>);
-            Assert.assertEquals(<(castFromInt.(type2))("i")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
+            assertEquals(<(castFromInt.(type2))("i")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
             hashMap.remove(<(castFromInt.(type1))("i")>);
-            Assert.assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
+            assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
         }
     }
 
@@ -520,58 +525,58 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         hashMap.put(collision1, <(literal.(type2))("1")>);
         hashMap.put(collision2, <(literal.(type2))("2")>);
         hashMap.put(collision3, <(literal.(type2))("3")>);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, hashMap.get(collision2)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("2")>, hashMap.get(collision2)<(wideDelta.(type2))>);
         hashMap.removeKey(collision2);
         hashMap.put(collision4, <(literal.(type2))("4")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(collision1, <(literal.(type2))("1")>, collision3, <(literal.(type2))("3")>, collision4, <(literal.(type2))("4")>), hashMap);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(collision1, <(literal.(type2))("1")>, collision3, <(literal.(type2))("3")>, collision4, <(literal.(type2))("4")>), hashMap);
 
         Mutable<name1><name2>Map hashMap1 = this.getEmptyMap();
         hashMap1.put(collision1, <(literal.(type2))("1")>);
         hashMap1.put(collision2, <(literal.(type2))("2")>);
         hashMap1.put(collision3, <(literal.(type2))("3")>);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, hashMap1.get(collision1)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, hashMap1.get(collision1)<(wideDelta.(type2))>);
         hashMap1.removeKey(collision1);
         hashMap1.put(collision4, <(literal.(type2))("4")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(collision2, <(literal.(type2))("2")>, collision3, <(literal.(type2))("3")>, collision4, <(literal.(type2))("4")>), hashMap1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(collision2, <(literal.(type2))("2")>, collision3, <(literal.(type2))("3")>, collision4, <(literal.(type2))("4")>), hashMap1);
 
         Mutable<name1><name2>Map hashMap2 = this.getEmptyMap();
         hashMap2.put(collision1, <(literal.(type2))("1")>);
         hashMap2.put(collision2, <(literal.(type2))("2")>);
         hashMap2.put(collision3, <(literal.(type2))("3")>);
-        Assert.assertEquals(<(wideLiteral.(type2))("3")>, hashMap2.get(collision3)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("3")>, hashMap2.get(collision3)<(wideDelta.(type2))>);
         hashMap2.removeKey(collision3);
         hashMap2.put(collision4, <(literal.(type2))("4")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(collision1, <(literal.(type2))("1")>, collision2, <(literal.(type2))("2")>, collision4, <(literal.(type2))("4")>), hashMap2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(collision1, <(literal.(type2))("1")>, collision2, <(literal.(type2))("2")>, collision4, <(literal.(type2))("4")>), hashMap2);
     }
 
     @Test
     public void getIfAbsentPut()
     {
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>, <(literal.(type1))("1")>, <(literal.(type2))("50")>), map1);
+        assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>), map1);
+        assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>, <(literal.(type1))("1")>, <(literal.(type2))("50")>), map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("50")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>, <(literal.(type1))("1")>, <(literal.(type2))("50")>), map2);
+        assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("50")>), map2);
+        assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("50")>, <(literal.(type1))("1")>, <(literal.(type2))("50")>), map2);
 
         Mutable<name1><name2>Map map3 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("50")>), map3);
+        assertEquals(<(wideLiteral.(type2))("50")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("50")>), map3);
 
         Mutable<name1><name2>Map map4 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("50")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("50")>), map4);
+        assertEquals(<(wideLiteral.(type2))("50")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("50")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("50")>), map4);
     }
 
     @Test
@@ -584,30 +589,30 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         };
 
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>, <(literal.(type1))("1")>, <(literal.(type2))("100")>), map1);
+        assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("0")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>), map1);
+        assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map1.getIfAbsentPut(<(literal.(type1))("1")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>, <(literal.(type1))("1")>, <(literal.(type2))("100")>), map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("100")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>, <(literal.(type1))("1")>, <(literal.(type2))("100")>), map2);
+        assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("1")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("100")>), map2);
+        assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map2.getIfAbsentPut(<(literal.(type1))("0")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("100")>, <(literal.(type1))("1")>, <(literal.(type2))("100")>), map2);
 
         Mutable<name1><name2>Map map3 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("100")>), map3);
+        assertEquals(<(wideLiteral.(type2))("100")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map3.getIfAbsentPut(<(literal.(type1))("32")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("100")>), map3);
 
         Mutable<name1><name2>Map map4 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, factory)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("100")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, factoryThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("100")>), map4);
+        assertEquals(<(wideLiteral.(type2))("100")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("100")>, map4.getIfAbsentPut(<(literal.(type1))("33")>, factoryThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("100")>), map4);
     }
 
     @Test
@@ -620,30 +625,30 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         };
 
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("0")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>), map1);
-        Assert.assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("1")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("1")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>, <(literal.(type1))("1")>, <(literal.(type2))("9")>), map1);
+        assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("0")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>), map1);
+        assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("1")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map1.getIfAbsentPutWith(<(literal.(type1))("1")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>, <(literal.(type1))("1")>, <(literal.(type2))("9")>), map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("1")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("1")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("9")>), map2);
-        Assert.assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("0")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>, <(literal.(type1))("1")>, <(literal.(type2))("9")>), map2);
+        assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("1")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("1")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("9")>), map2);
+        assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map2.getIfAbsentPutWith(<(literal.(type1))("0")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("9")>, <(literal.(type1))("1")>, <(literal.(type2))("9")>), map2);
 
         Mutable<name1><name2>Map map3 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type2))("9")>, map3.getIfAbsentPutWith(<(literal.(type1))("32")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map3.getIfAbsentPutWith(<(literal.(type1))("32")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("9")>), map3);
+        assertEquals(<(literal.(type2))("9")>, map3.getIfAbsentPutWith(<(literal.(type1))("32")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map3.getIfAbsentPutWith(<(literal.(type1))("32")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("9")>), map3);
 
         Mutable<name1><name2>Map map4 = this.getEmptyMap();
-        Assert.assertEquals(<(literal.(type2))("9")>, map4.getIfAbsentPutWith(<(literal.(type1))("33")>, functionLength, "123456789")<wideDelta.(type2)>);
-        Assert.assertEquals(<(literal.(type2))("9")>, map4.getIfAbsentPutWith(<(literal.(type1))("33")>, functionThrows, "unused")<wideDelta.(type2)>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("9")>), map4);
+        assertEquals(<(literal.(type2))("9")>, map4.getIfAbsentPutWith(<(literal.(type1))("33")>, functionLength, "123456789")<wideDelta.(type2)>);
+        assertEquals(<(literal.(type2))("9")>, map4.getIfAbsentPutWith(<(literal.(type1))("33")>, functionThrows, "unused")<wideDelta.(type2)>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("9")>), map4);
     }
 
     @Test
@@ -656,30 +661,30 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         };
 
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("0")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("1")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("1")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">), map1);
+        assertEquals(<(wideLiteral.(type2))("0")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("0")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<keyValue("0")>), map1);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("1")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.getIfAbsentPutWithKey(<(literal.(type1))("1")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">), map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("1")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("1")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("0")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">), map2);
+        assertEquals(<(wideLiteral.(type2))("1")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("1")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("1")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("1")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), map2);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, map2.getIfAbsentPutWithKey(<(literal.(type1))("0")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">), map2);
 
         Mutable<name1><name2>Map map3 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, map3.getIfAbsentPutWithKey(<(literal.(type1))("32")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, map3.getIfAbsentPutWithKey(<(literal.(type1))("32")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map3);
+        assertEquals(<(wideLiteral.(type2))("32")>, map3.getIfAbsentPutWithKey(<(literal.(type1))("32")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("32")>, map3.getIfAbsentPutWithKey(<(literal.(type1))("32")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>), map3);
 
         Mutable<name1><name2>Map map4 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("33")>, map4.getIfAbsentPutWithKey(<(literal.(type1))("33")>, function)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("33")>, map4.getIfAbsentPutWithKey(<(literal.(type1))("33")>, functionThrows)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("33")>), map4);
+        assertEquals(<(wideLiteral.(type2))("33")>, map4.getIfAbsentPutWithKey(<(literal.(type1))("33")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("33")>, map4.getIfAbsentPutWithKey(<(literal.(type1))("33")>, functionThrows)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("33")>), map4);
     }
 
     @Test
@@ -688,30 +693,30 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         <name2>To<name2>Function incrementFunction = (<type2> value) -> <(castIntToNarrowTypeWithParens.(type2))({value + <(literal.(type2))("1")>})>;
 
         Mutable<name1><name2>Map map1 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map1.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map1.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("1")>), map1);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map1.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map1);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>), map1);
+        assertEquals(<(wideLiteral.(type2))("2")>, map1.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>), map1);
+        assertEquals(<(wideLiteral.(type2))("1")>, map1.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("1")>), map1);
+        assertEquals(<(wideLiteral.(type2))("2")>, map1.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map1);
 
         Mutable<name1><name2>Map map2 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map2.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map2.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map2.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map2.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
+        assertEquals(<(wideLiteral.(type2))("1")>, map2.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), map2);
+        assertEquals(<(wideLiteral.(type2))("2")>, map2.updateValue(<(literal.(type1))("1")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
+        assertEquals(<(wideLiteral.(type2))("1")>, map2.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
+        assertEquals(<(wideLiteral.(type2))("2")>, map2.updateValue(<keyValue("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("2")>), map2);
 
         Mutable<name1><name2>Map map3 = this.getEmptyMap();
-        Assert.assertEquals(<(wideLiteral.(type2))("1")>, map3.updateValue(<(literal.(type1))("33")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("1")>), map3);
-        Assert.assertEquals(<(wideLiteral.(type2))("2")>, map3.updateValue(<(literal.(type1))("33")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("2")>), map3);
+        assertEquals(<(wideLiteral.(type2))("1")>, map3.updateValue(<(literal.(type1))("33")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("1")>), map3);
+        assertEquals(<(wideLiteral.(type2))("2")>, map3.updateValue(<(literal.(type1))("33")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("33")>, <(literal.(type2))("2")>), map3);
     }
 
     @Test
@@ -720,29 +725,29 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Mutable<name1><name2>Map mutable<name1><name2>Map = this.classUnderTest();
         <name1>Set frozenSet = mutable<name1><name2>Map.keySet().freeze();
         <name1>Set frozenSetCopy = <name1>HashSet.newSetWith(mutable<name1><name2>Map.keySet().toArray());
-        Assert.assertEquals(frozenSet, frozenSetCopy);
-        Assert.assertEquals(frozenSetCopy, mutable<name1><name2>Map.keySet().freeze());
+        assertEquals(frozenSet, frozenSetCopy);
+        assertEquals(frozenSetCopy, mutable<name1><name2>Map.keySet().freeze());
         for (int i = 0; i \< 32; i++)
         {
             mutable<name1><name2>Map.put((<type1>) i, (<type2>) i);
-            Assert.assertEquals(frozenSet, frozenSetCopy);
+            assertEquals(frozenSet, frozenSetCopy);
         }
 
         <name1>Set frozenSetForRemove = mutable<name1><name2>Map.keySet().freeze();
         <name1>Set frozenSetCopyForRemove = <name1>HashSet.newSetWith(mutable<name1><name2>Map.keySet().toArray());
-        Assert.assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
-        Assert.assertEquals(frozenSetCopyForRemove, mutable<name1><name2>Map.keySet().freeze());
+        assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
+        assertEquals(frozenSetCopyForRemove, mutable<name1><name2>Map.keySet().freeze());
         for (int i = 0; i \< 32; i++)
         {
             mutable<name1><name2>Map.remove((<type1>) i);
-            Assert.assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
+            assertEquals(frozenSetForRemove, frozenSetCopyForRemove);
         }
 
         Mutable<name1><name2>Map mutable<name1><name2>MapForClear = this.classUnderTest();
         <name1>Set frozenSetForClear = mutable<name1><name2>MapForClear.keySet().freeze();
         <name1>Set frozenSetCopyForClear = <name1>HashSet.newSetWith(mutable<name1><name2>MapForClear.keySet().toArray());
         mutable<name1><name2>MapForClear.clear();
-        Assert.assertEquals(frozenSetForClear, frozenSetCopyForClear);
+        assertEquals(frozenSetForClear, frozenSetCopyForClear);
     }
 
     @Test
@@ -750,8 +755,8 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map = this.newWithKeysValues(<["0", "1", "31", "32"]:keyValue(); separator=", ">);
         Mutable<name1><name2>Map mapWithout = map.withoutKey(<(literal.(type1))("32")>);
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1", "31"]:keyValue(); separator=", ">), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<["0", "1", "31"]:keyValue(); separator=", ">), mapWithout);
     }
 
     @Test
@@ -759,16 +764,16 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map = this.newWithKeysValues(<["0", "1", "31", "32"]:keyValue(); separator=", ">);
         Mutable<name1><name2>Map mapWithout = map.withoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>));
-        Assert.assertSame(map, mapWithout);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>), mapWithout);
+        assertSame(map, mapWithout);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("31")>, <(literal.(type2))("31")>), mapWithout);
     }
 
     @Test
     public void withKeysValues()
     {
         Mutable<name1><name2>Map hashMap = this.getEmptyMap();
-        Assert.assertSame(hashMap.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>), hashMap);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), hashMap);
+        assertSame(hashMap.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>), hashMap);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>), hashMap);
     }
 
     @Test
@@ -780,29 +785,29 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Iterable\<<name1><name2>Pair> emptyIterable = Iterables.iList();
         Iterable\<<name1><name2>Pair> partialIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("1")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("3")>));
         Iterable\<<name1><name2>Pair> completeIterable = Iterables.iList(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("1")>), PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("3")>, <(literal.(type2))("3")>), PrimitiveTuples.pair(<(literal.(type1))("4")>, <(literal.(type2))("4")>));
-        Assert.assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
+        assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(Synchronized<name1><name2>Map.class, this.classUnderTest().asSynchronized());
-        Assert.assertEquals(new Synchronized<name1><name2>Map(this.classUnderTest()), this.classUnderTest().asSynchronized());
+        assertEquals(new Synchronized<name1><name2>Map(this.classUnderTest()), this.classUnderTest().asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(Unmodifiable<name1><name2>Map.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(new Unmodifiable<name1><name2>Map(this.classUnderTest()), this.classUnderTest().asUnmodifiable());
+        assertEquals(new Unmodifiable<name1><name2>Map(this.classUnderTest()), this.classUnderTest().asUnmodifiable());
     }
 
     @Test
@@ -816,37 +821,37 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
             iterator.next();
             iterator.remove();
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         Verify.assertEmpty(mutableMap);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         Mutable<name2>Iterator iterator = this.classUnderTest().<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
     public void iterator_throws_on_consecutive_invocation_of_remove()
     {
         Mutable<name2>Iterator iterator = this.classUnderTest().<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
         iterator.remove();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
     public void flipUniqueValues()
     {
         Mutable<name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
-        Assert.assertEquals(
+        assertEquals(
                 <name2><name1>HashMap.newWithKeysValues(<(literal.(type2))("2")>, <(literal.(type1))("1")>, <(literal.(type2))("3")>, <(literal.(type1))("2")>, <(literal.(type2))("4")>, <(literal.(type1))("3")>, <(literal.(type2))("5")>, <(literal.(type1))("4")>),
                 map.flipUniqueValues());
-        Assert.assertThrows(
+        assertThrows(
                 IllegalStateException.class,
                 () -> this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("1")>).flipUniqueValues());
     }
@@ -856,7 +861,7 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         Mutable<name1><name2>Map map2 = SerializeTestHelper.serializeDeserialize(map);
-        Assert.assertEquals(map, map2);
+        assertEquals(map, map2);
     }
 
     @Test
@@ -864,7 +869,7 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
     {
         Mutable<name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <name1>Set set = SerializeTestHelper.serializeDeserialize(map.keySet());
-        Assert.assertEquals(map.keySet(), set);
+        assertEquals(map.keySet(), set);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 public abstract class Object<name>HashMapKeySetTestCase
 {
@@ -47,14 +52,14 @@ public abstract class Object<name>HashMapKeySetTestCase
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().addAll(FastList.newListWith("Four")));
     }
 
@@ -63,15 +68,15 @@ public abstract class Object<name>HashMapKeySetTestCase
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.contains("One"));
-        Assert.assertTrue(keySet.contains("Two"));
-        Assert.assertTrue(keySet.contains("Three"));
-        Assert.assertFalse(keySet.contains("Four"));
-        Assert.assertTrue(keySet.contains(null));
+        assertTrue(keySet.contains("One"));
+        assertTrue(keySet.contains("Two"));
+        assertTrue(keySet.contains("Three"));
+        assertFalse(keySet.contains("Four"));
+        assertTrue(keySet.contains(null));
         keySet.remove(null);
-        Assert.assertFalse(keySet.contains(null));
+        assertFalse(keySet.contains(null));
         map.removeKey("One");
-        Assert.assertFalse(keySet.contains("One"));
+        assertFalse(keySet.contains("One"));
     }
 
     @Test
@@ -79,17 +84,17 @@ public abstract class Object<name>HashMapKeySetTestCase
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
+        assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
         keySet.remove(null);
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
         map.removeKey("One");
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
     }
 
     @Test
@@ -97,12 +102,12 @@ public abstract class Object<name>HashMapKeySetTestCase
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         MutableObject<name>Map\<String> map1 = this.newEmptyMap();
         Set\<String> keySet1 = map1.keySet();
-        Assert.assertTrue(keySet1.isEmpty());
+        assertTrue(keySet1.isEmpty());
         map1.put("One", <(literal.(type))("1")>);
-        Assert.assertFalse(keySet1.isEmpty());
+        assertFalse(keySet1.isEmpty());
     }
 
     @Test
@@ -132,28 +137,28 @@ public abstract class Object<name>HashMapKeySetTestCase
 
         HashBag\<String> expected = HashBag.newBagWith("One", "Two", "Three", null);
         HashBag\<String> actual = HashBag.newBag();
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertThrows(IllegalStateException.class, iterator1::remove);
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator1.hasNext());
+            assertTrue(iterator1.hasNext());
             actual.add(iterator1.next());
         }
-        Assert.assertFalse(iterator1.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator1::next);
-        Assert.assertEquals(expected, actual);
+        assertFalse(iterator1.hasNext());
+        assertThrows(NoSuchElementException.class, iterator1::next);
+        assertEquals(expected, actual);
 
         Iterator\<String> iterator2 = keySet.iterator();
         for (int i = 4; i > 0; i--)
         {
-            Assert.assertTrue(iterator2.hasNext());
+            assertTrue(iterator2.hasNext());
             iterator2.next();
             iterator2.remove();
-            Assert.assertThrows(IllegalStateException.class, iterator2::remove);
+            assertThrows(IllegalStateException.class, iterator2::remove);
             Verify.assertSize(i - 1, keySet);
             Verify.assertSize(i - 1, map1);
         }
 
-        Assert.assertFalse(iterator2.hasNext());
+        assertFalse(iterator2.hasNext());
         Verify.assertEmpty(map1);
         Verify.assertEmpty(keySet);
 
@@ -168,57 +173,57 @@ public abstract class Object<name>HashMapKeySetTestCase
             iterator3.next();
             iterator3.remove();
         }
-        Assert.assertTrue(map3.isEmpty());
+        assertTrue(map3.isEmpty());
     }
 
     @Test
     public void removeFromKeySet()
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().remove("Four"));
+        assertFalse(map.keySet().remove("Four"));
 
-        Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().remove("Two"));
+        assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void removeNullFromKeySet()
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().remove(null));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().remove(null));
+        assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         map.put(null, <(literal.(type))("4")>);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertTrue(map.keySet().remove(null));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
+        assertTrue(map.keySet().remove(null));
+        assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
     }
 
     @Test
     public void removeAllFromKeySet()
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
+        assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void retainAllFromKeySet()
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
+        assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
@@ -235,8 +240,8 @@ public abstract class Object<name>HashMapKeySetTestCase
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("0")>);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
-        Assert.assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
     }
 
     @Test
@@ -245,11 +250,11 @@ public abstract class Object<name>HashMapKeySetTestCase
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
         HashBag\<String> expected = HashBag.newBagWith("One", "Two", "Three");
         Set\<String> keySet = map.keySet();
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
@@ -29,8 +29,12 @@ import org.eclipse.collections.api.block.function.primitive.<name>To<name>Functi
 import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<name>MapTestCase
 {
@@ -51,8 +55,8 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         values.setAccessible(true);
 
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
     }
 
     @Test
@@ -64,18 +68,18 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         values.setAccessible(true);
 
         MutableObject<name>Map\<String> hashMap = this.newMapWithInitialCapacity(3);
-        Assert.assertEquals(8L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(8L, ((<type>[]) values.get(hashMap)).length);
+        assertEquals(8L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(8L, ((<type>[]) values.get(hashMap)).length);
 
         MutableObject<name>Map\<String> hashMap2 = this.newMapWithInitialCapacity(15);
-        Assert.assertEquals(32L, ((Object[]) keys.get(hashMap2)).length);
-        Assert.assertEquals(32L, ((<type>[]) values.get(hashMap2)).length);
+        assertEquals(32L, ((Object[]) keys.get(hashMap2)).length);
+        assertEquals(32L, ((<type>[]) values.get(hashMap2)).length);
     }
 
     @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 this.newMapWithInitialCapacity(-1));
     }
 
@@ -88,9 +92,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         values.setAccessible(true);
 
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
-        Assert.assertEquals(this.getEmptyMap(), hashMap);
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
+        assertEquals(this.getEmptyMap(), hashMap);
     }
 
     @Test
@@ -102,16 +106,16 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         occupiedWithSentinels.setAccessible(true);
         MutableObject<name>Map\<Float> hashMap = this.newWithKeysValues(2.0f, <(literal.(type))("2")>, 3.0f, <(literal.(type))("3")>);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(1, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(1, occupiedWithData.get(hashMap));
 
         hashMap.clear();
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -123,24 +127,24 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         occupiedWithSentinels.setAccessible(true);
         MutableObject<name>Map\<Float> hashMap = this.newWithKeysValues(2.0f, <(literal.(type))("2")>, 3.0f, <(literal.(type))("3")>, 4.0f, <(literal.(type))("4")>);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(5.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(5.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(1.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -152,26 +156,26 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         occupiedWithSentinels.setAccessible(true);
         MutableObject<name>Map\<Float> hashMap = this.newWithKeysValues(2.0f, <(literal.(type))("2")>, 3.0f, <(literal.(type))("3")>, 4.0f, <(literal.(type))("4")>);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         <name>To<name>Function function = (<type> parameter) -> parameter;
 
         hashMap.updateValue(2.0f, <(literal.(type))("0")>, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(5.0f, <(literal.(type))("0")>, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(2.0f, <(literal.(type))("0")>, function); // putting in a slot marked REMOVED
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -182,23 +186,23 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         MutableObject<name>Map\<Float> hashMap = this.getEmptyMap();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 2; i \< 10; i++)
         {
             hashMap.put((float) i, <(castFromInt.(type))("i")>);
         }
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.put(2.0f, <(literal.(type))("9")>); // putting in a slot marked REMOVED
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -211,20 +215,20 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         MutableObject<name>Map\<Float> hashMap = this.newWithKeysValues(2.0f, <(literal.(type))("2")>, 3.0f, <(literal.(type))("3")>, 4.0f, <(literal.(type))("4")>);
 
         hashMap.getIfAbsentPut(2.0f, <(literal.(type))("5")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(5.0f, <(literal.(type))("5")>);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(2.0f, <(literal.(type))("5")>); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -239,20 +243,20 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         <name>Function0 function = () -> <(literal.(type))("5")>;
 
         hashMap.getIfAbsentPut(2.0f, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(5.0f, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(2.0f, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -267,20 +271,20 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         <name>Function\<Integer> function = (Integer object) -> (<type>) object.intValue();
 
         hashMap.getIfAbsentPutWith(2.0f, function, Integer.valueOf(5));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(5.0f, function, Integer.valueOf(5));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(2.0f, function, Integer.valueOf(5)); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -295,20 +299,20 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         <name>Function\<Float> function = (Float floatParameter) -> (<type>) floatParameter.floatValue();
 
         hashMap.getIfAbsentPutWithKey(2.0f, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(5.0f, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(2.0f, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -319,8 +323,8 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         MutableObject<name>Map\<Float> hashMap = this.getEmptyMap();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 2; i \< 10; i++)
         {
@@ -328,65 +332,65 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         }
 
         hashMap.remove(2.0f);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
 
         hashMap.put(2.0f, <(literal.(type))("3")>); //putting in a slot marked as REMOVED
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
     }
 
     @Test
     public void removeKeyIfAbsent()
     {
         MutableObject<name>Map\<String> map0 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("1")>, map0.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.newWithKeysValues("0", <(literal.(type))("0")>), map0);
-        Assert.assertEquals(<(literal.(type))("0")>, map0.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.getEmptyMap(), map0);
-        Assert.assertEquals(<(literal.(type))("100")>, map0.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map0.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, map0.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.newWithKeysValues("0", <(literal.(type))("0")>), map0);
+        assertEquals(<(literal.(type))("0")>, map0.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.getEmptyMap(), map0);
+        assertEquals(<(literal.(type))("100")>, map0.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map0.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
 
         MutableObject<name>Map\<String> map1 = this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("0")>, map1.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.newWithKeysValues("1", <(literal.(type))("1")>), map1);
-        Assert.assertEquals(<(literal.(type))("1")>, map1.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.getEmptyMap(), map1);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, map1.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, map1.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.newWithKeysValues("1", <(literal.(type))("1")>), map1);
+        assertEquals(<(literal.(type))("1")>, map1.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.getEmptyMap(), map1);
+        assertEquals(<(literal.(type))("100")>, map1.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, map1.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("5", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("50", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.removeKeyIfAbsent("2", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.getEmptyMap(), this.map);
-        Assert.assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("2", <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(this.getEmptyMap(), this.map);
+        assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("5", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("50", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(<(literal.(type))("0")>, this.map.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.newWithKeysValues("1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>), this.map);
+        assertEquals(<(literal.(type))("1")>, this.map.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.newWithKeysValues("2", <(literal.(type))("2")>), this.map);
+        assertEquals(<(literal.(type))("2")>, this.map.removeKeyIfAbsent("2", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.getEmptyMap(), this.map);
+        assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("1", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("100")>, this.map.removeKeyIfAbsent("2", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(this.getEmptyMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0), <(literal.(type))("1")>);
         this.map.put(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1), <(literal.(type))("2")>);
 
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0))<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.map.removeKeyIfAbsent(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0), <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0))<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.map.removeKeyIfAbsent(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0), <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(0))<delta.(type)>);
 
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1))<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.map.removeKeyIfAbsent(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1), <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1))<delta.(type)>);
+        assertEquals(<(literal.(type))("2")>, this.map.removeKeyIfAbsent(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1), <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(AbstractMutableObject<name>MapTestCase.generateCollisions().get(1))<delta.(type)>);
 
         this.map.put(null, <(literal.(type))("3")>);
 
-        Assert.assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.map.removeKeyIfAbsent(null, <(literal.(type))("100")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.map.get(null)<delta.(type)>);
+        assertEquals(<(literal.(type))("3")>, this.map.removeKeyIfAbsent(null, <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.map.get(null)<delta.(type)>);
     }
 
     @Test
@@ -395,7 +399,7 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         MutableObject<name>Map\<<wrapperName>\> hashMap = this.getEmptyMap();
         for (<type> each = 2; each \< 10; each++)
         {
-            Assert.assertFalse(hashMap.containsKey(each));
+            assertFalse(hashMap.containsKey(each));
             hashMap.put(each, each);
         }
 
@@ -403,17 +407,17 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Field values = targetClass.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type>[]) values.get(hashMap)).length);
         Verify.assertSize(8, hashMap);
         for (<type> each = 2; each \< 10; each++)
         {
-            Assert.assertTrue(hashMap.containsKey(each));
-            Assert.assertTrue(hashMap.containsValue(each));
+            assertTrue(hashMap.containsKey(each));
+            assertTrue(hashMap.containsValue(each));
         }
         hashMap.put(<(literal.(type))("10")>, <(literal.(type))("10")>);
-        Assert.assertEquals(32L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(32L, ((<type>[]) values.get(hashMap)).length);
+        assertEquals(32L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(32L, ((<type>[]) values.get(hashMap)).length);
     }
 
     @Test
@@ -424,7 +428,7 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = 1; each \< 11; each++)
         {
-            Assert.assertFalse(hashMap.containsKey(each));
+            assertFalse(hashMap.containsKey(each));
             copyMap.put(each, each);
         }
 
@@ -435,10 +439,10 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = 1; each \< 11; each++)
         {
-            Assert.assertTrue(hashMap.containsKey(each));
+            assertTrue(hashMap.containsKey(each));
         }
 
-        Assert.assertEquals(hashMap, copyMap);
+        assertEquals(hashMap, copyMap);
     }
 
     @Test
@@ -446,7 +450,7 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
     {
         MutableObject<name>Map\<Integer> hashMap = this.newWithKeysValues(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>, 4, <(literal.(type))("5")>);
         <wrapperName> sum = hashMap.injectInto(<wrapperName>.valueOf(<(literal.(type))("1")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("15")>), sum);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("15")>), sum);
     }
 
     @Test
@@ -455,11 +459,11 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
             hashMap.put(String.valueOf(each), each);
-            Assert.assertEquals(each, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(each, hashMap.get(String.valueOf(each))<delta.(type)>);
             hashMap.remove(String.valueOf(each));
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 
@@ -469,13 +473,13 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
             hashMap.put(String.valueOf(each), each);
             Iterator\<String> iterator = hashMap.keySet().iterator();
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(String.valueOf(each), iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(String.valueOf(each), iterator.next());
             iterator.remove();
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 
@@ -485,9 +489,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         MutableObject<name>Map\<String> hashMap = this.getEmptyMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
             hashMap.getIfAbsentPut(String.valueOf(each), each);
-            Assert.assertEquals(each, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(each, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 
@@ -500,9 +504,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
-            Assert.assertEquals(<(literal.(type))("9")>, hashMap.getIfAbsentPutWith(String.valueOf(each), functionLength, "123456789")<delta.(type)>);
-            Assert.assertEquals(<(literal.(type))("9")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("9")>, hashMap.getIfAbsentPutWith(String.valueOf(each), functionLength, "123456789")<delta.(type)>);
+            assertEquals(<(literal.(type))("9")>, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 
@@ -515,9 +519,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(each)<delta.(type)>);
-            Assert.assertEquals(each, hashMap.getIfAbsentPutWithKey(each, function)<delta.(type)>);
-            Assert.assertEquals(each, hashMap.get(each)<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(each)<delta.(type)>);
+            assertEquals(each, hashMap.getIfAbsentPutWithKey(each, function)<delta.(type)>);
+            assertEquals(each, hashMap.get(each)<delta.(type)>);
         }
     }
 
@@ -530,9 +534,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
-            Assert.assertEquals(<(literal.(type))("100")>, hashMap.getIfAbsentPut(String.valueOf(each), factory)<delta.(type)>);
-            Assert.assertEquals(<(literal.(type))("100")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("100")>, hashMap.getIfAbsentPut(String.valueOf(each), factory)<delta.(type)>);
+            assertEquals(<(literal.(type))("100")>, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 
@@ -545,9 +549,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
-            Assert.assertEquals(each + 1, hashMap.updateValue(String.valueOf(each), each, incrementFunction)<delta.(type)>);
-            Assert.assertEquals(each + 1, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(<(literal.(type))("0")>, hashMap.get(String.valueOf(each))<delta.(type)>);
+            assertEquals(each + 1, hashMap.updateValue(String.valueOf(each), each, incrementFunction)<delta.(type)>);
+            assertEquals(each + 1, hashMap.get(String.valueOf(each))<delta.(type)>);
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
@@ -39,8 +39,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<na
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This file was automatically generated from template file objectPrimitiveHashMapValuesTestCase.stg.
@@ -95,13 +99,13 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
         <name>Iterator iterator1 = bag.<type>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator1.hasNext());
-            Assert.assertTrue(list.remove(iterator1.next()));
+            assertTrue(iterator1.hasNext());
+            assertTrue(list.remove(iterator1.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator1::next);
+        assertThrows(NoSuchElementException.class, iterator1::next);
 
         MutableObject<name>Map\<String> map2 = new Object<name>HashMap\<>();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
@@ -114,14 +118,14 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
             iterator2.next();
             iterator2.remove();
         }
-        Assert.assertTrue(map2.isEmpty());
+        assertTrue(map2.isEmpty());
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                  this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
@@ -129,7 +133,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -137,7 +141,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
@@ -145,21 +149,21 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
@@ -167,7 +171,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -177,13 +181,13 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertTrue(collection.remove(<(literal.(type))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(collection.remove(<(literal.(type))("3")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
     }
 
     @Override
@@ -192,134 +196,134 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     {
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
+        assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
 
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.removeAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new <name>ArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertFalse(this.newWith().removeAll(new <name>ArrayList()));
+        assertFalse(this.newWith().removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
 
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(<(literal.(type))("1")>));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(<(literal.(type))("1")>));
 
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.retainAll(<(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("5")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("0")>, <(literal.(type))("4")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("0")>, <(literal.(type))("4")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new <name>ArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertFalse(this.newWith().retainAll(new <name>ArrayList()));
+        assertFalse(this.newWith().retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
 
         MutableObject<name>Map\<String> map = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>)));
+        assertFalse(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>)));
 
-        Assert.assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("2")>, <(literal.(type))("3")>, <(literal.(type))("5")>)));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("0")>, <(literal.(type))("4")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("0")>, <(literal.(type))("4")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
@@ -336,19 +340,19 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(collection.contains(<(literal.(type))("0")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         collection1.clear();
         Verify.assertEmpty(collection1);
         Verify.assertSize(0, collection1);
-        Assert.assertFalse(collection1.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("31")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("32")>));
+        assertFalse(collection1.contains(<(literal.(type))("0")>));
+        assertFalse(collection1.contains(<(literal.(type))("1")>));
+        assertFalse(collection1.contains(<(literal.(type))("31")>));
+        assertFalse(collection1.contains(<(literal.(type))("32")>));
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
         collection2.clear();
@@ -360,19 +364,19 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     public void contains()
     {
         Mutable<name>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
-            Assert.assertTrue(collection.remove(number));
-            Assert.assertFalse(collection.contains(number));
+            assertTrue(collection.contains(number));
+            assertTrue(collection.remove(number));
+            assertFalse(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
     }
 
     @Override
@@ -398,60 +402,60 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = (<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
@@ -463,63 +467,63 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -529,7 +533,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Synchronized<name>Collection.class, this.classUnderTest().asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -538,7 +542,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name>Collection.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -570,7 +574,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     public void chunk()
     {
         <name>Iterable iterable = this.newMapWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -578,7 +582,7 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -589,16 +593,16 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
                         <name>Bags.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyKeySetTest.stg
@@ -27,8 +27,11 @@ import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link Object<name>HashMapWithHashingStrategy#keySet()}.
@@ -112,7 +115,7 @@ public class Object<name>HashMapWithHashingStrategyKeySetTest extends Object<nam
         MutableObject<name>Map\<Person> map = Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, <allPeople()>);
         Set\<Person> people = map.keySet();
         people.remove(JOHNDOE);
-        Assert.assertEquals(map, Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, <(literal.(type))("4")>));
+        assertEquals(map, Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, <(literal.(type))("4")>));
     }
 
     @Override
@@ -124,7 +127,7 @@ public class Object<name>HashMapWithHashingStrategyKeySetTest extends Object<nam
         Set\<Person> people1 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNDOE, <(literal.(type))("1")>, JOHNSMITH, <(literal.(type))("3")>).keySet();
         Set\<Person> people2 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JANEDOE, <(literal.(type))("2")>, JANESMITH, <(literal.(type))("4")>).keySet();
 
-        Assert.assertTrue(people1.hashCode() == people2.hashCode());
+        assertTrue(people1.hashCode() == people2.hashCode());
     }
 
     @Override
@@ -135,9 +138,9 @@ public class Object<name>HashMapWithHashingStrategyKeySetTest extends Object<nam
 
         Set\<Person> people = Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, <allPeople()>).keySet();
         Object[] keys1 = {JOHNDOE, JOHNSMITH};
-        Assert.assertArrayEquals(people.toArray(), keys1);
+        assertArrayEquals(people.toArray(), keys1);
         Person[] keys2 = new Person[2];
-        Assert.assertArrayEquals(people.toArray(keys2), keys1);
+        assertArrayEquals(people.toArray(keys2), keys1);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyTest.stg
@@ -30,8 +30,12 @@ import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Object<name>HashMapWithHashingStrategy}.
@@ -146,7 +150,7 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>HashMapWithHashingStrategy\<Person> map = Object<name>HashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY,
                 <allPeople()>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(JOHNDOE, <(literal.(type))("2")>), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
+        assertEquals(Object<name>HashMap.newWithKeysValues(JOHNDOE, <(literal.(type))("2")>), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
     }
 
     @Override
@@ -158,7 +162,7 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>HashMapWithHashingStrategy\<Person> map = Object<name>HashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY,
                 <allPeople()>);
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues(JOHNDOE, <(literal.(type))("2")>), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
+        assertEquals(Object<name>HashMap.newWithKeysValues(JOHNDOE, <(literal.(type))("2")>), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
     }
 
     @Override
@@ -171,7 +175,7 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
                 LAST_NAME_HASHING_STRATEGY,
                 <allPeople()>);
         <name>ToObjectFunction f = argument1 -> (int) argument1 * 2;
-        Assert.assertEquals(FastList.newListWith(4, 8), map.collect(f));
+        assertEquals(FastList.newListWith(4, 8), map.collect(f));
     }
 
     @Test
@@ -180,15 +184,15 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>HashMapWithHashingStrategy\<Person> map = Object<name>HashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY,
                 <allPeople()>);
-        Assert.assertTrue(map.containsKey(JOHNDOE));
-        Assert.assertTrue(map.containsValue(<(literal.(type))("2")>));
-        Assert.assertTrue(map.containsKey(JOHNSMITH));
-        Assert.assertTrue(map.containsValue(<(literal.(type))("4")>));
-        Assert.assertTrue(map.containsKey(JANEDOE));
-        Assert.assertTrue(map.containsKey(JANESMITH));
+        assertTrue(map.containsKey(JOHNDOE));
+        assertTrue(map.containsValue(<(literal.(type))("2")>));
+        assertTrue(map.containsKey(JOHNSMITH));
+        assertTrue(map.containsValue(<(literal.(type))("4")>));
+        assertTrue(map.containsKey(JANEDOE));
+        assertTrue(map.containsKey(JANESMITH));
 
-        Assert.assertFalse(map.containsValue(<(literal.(type))("1")>));
-        Assert.assertFalse(map.containsValue(<(literal.(type))("3")>));
+        assertFalse(map.containsValue(<(literal.(type))("1")>));
+        assertFalse(map.containsValue(<(literal.(type))("3")>));
     }
 
     @Test
@@ -199,7 +203,7 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
                 <allPeople()>);
 
         map.remove(JANEDOE);
-        Assert.assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, <(literal.(type))("4")>), map);
+        assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, <(literal.(type))("4")>), map);
         map.remove(JOHNSMITH);
 
         Verify.assertEmpty(map);
@@ -208,14 +212,14 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>HashMapWithHashingStrategy\<String> map2 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(
                 STRING_HASHING_STRATEGY, collidingKeys.get(0), <(literal.(type))("0")>, collidingKeys.get(1), <(literal.(type))("1")>, collidingKeys.get(2), <(literal.(type))("2")>, collidingKeys.get(3), <(literal.(type))("3")>);
         map2.remove(collidingKeys.get(3));
-        Assert.assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(0), <(literal.(type))("0")>, collidingKeys.get(1), <(literal.(type))("1")>, collidingKeys.get(2), <(literal.(type))("2")>), map2);
+        assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(0), <(literal.(type))("0")>, collidingKeys.get(1), <(literal.(type))("1")>, collidingKeys.get(2), <(literal.(type))("2")>), map2);
         map2.remove(collidingKeys.get(0));
-        Assert.assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(1), <(literal.(type))("1")>, collidingKeys.get(2), <(literal.(type))("2")>), map2);
+        assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(1), <(literal.(type))("1")>, collidingKeys.get(2), <(literal.(type))("2")>), map2);
         Verify.assertSize(2, map2);
 
         Object<name>HashMapWithHashingStrategy\<Integer> map3 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, <(literal.(type))("1")>, null, <(literal.(type))("2")>, 3, <(literal.(type))("3")>);
         map3.remove(null);
-        Assert.assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, <(literal.(type))("1")>, 3, <(literal.(type))("3")>), map3);
+        assertEquals(Object<name>HashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, <(literal.(type))("1")>, 3, <(literal.(type))("3")>), map3);
     }
 
     @Test
@@ -225,13 +229,13 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>HashMapWithHashingStrategy\<Person> map2 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(FIRST_NAME_HASHING_STRATEGY, JOHNDOE, <(literal.(type))("1")>, JANEDOE, <(literal.(type))("1")>, JOHNSMITH, <(literal.(type))("1")>, JANESMITH, <(literal.(type))("1")>);
         Object<name>HashMapWithHashingStrategy\<Person> mapWithConstantHashCodeStrategy = Object<name>HashMapWithHashingStrategy.newWithKeysValues(CONSTANT_HASHCODE_STRATEGY, JOHNDOE, <(literal.(type))("1")>, JANEDOE, <(literal.(type))("1")>, JOHNSMITH, <(literal.(type))("1")>, JANESMITH, <(literal.(type))("1")>);
 
-        Assert.assertEquals(map1, map2);
-        Assert.assertEquals(map2, map1);
-        Assert.assertEquals(mapWithConstantHashCodeStrategy, map2);
-        Assert.assertEquals(map2, mapWithConstantHashCodeStrategy);
-        Assert.assertNotEquals(map1.hashCode(), map2.hashCode());
-        Assert.assertNotEquals(map1.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
-        Assert.assertNotEquals(map2.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
+        assertEquals(map1, map2);
+        assertEquals(map2, map1);
+        assertEquals(mapWithConstantHashCodeStrategy, map2);
+        assertEquals(map2, mapWithConstantHashCodeStrategy);
+        assertNotEquals(map1.hashCode(), map2.hashCode());
+        assertNotEquals(map1.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
+        assertNotEquals(map2.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
 
         Object<name>HashMapWithHashingStrategy\<Person> map3 = Object<name>HashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY,
@@ -241,12 +245,12 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         Object<name>Map hashMap = Object<name>Maps.mutable.withAll(map3);
 
         Verify.assertEqualsAndHashCode(map3, map4);
-        Assert.assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
+        assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
 
         Object<name>HashMap\<Person> objectMap = Object<name>HashMap.newWithKeysValues(
                 <allPeople()>);
         Object<name>HashMapWithHashingStrategy\<Person> map5 = Object<name>HashMapWithHashingStrategy.newMap(LAST_NAME_HASHING_STRATEGY, objectMap);
-        Assert.assertNotEquals(map5, objectMap);
+        assertNotEquals(map5, objectMap);
     }
 
     @Test
@@ -256,15 +260,15 @@ public class Object<name>HashMapWithHashingStrategyTest extends Object<name>Hash
         map.put(null, <(literal.(type))("5")>);
 
         //Testing getting values from no chains
-        Assert.assertEquals(<(literal.(type))("1")>, map.get("1")<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("2")>, map.get("2")<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("5")>, map.get(null)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, map.get("1")<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, map.get("2")<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("5")>, map.get(null)<(wideDelta.(type))>);
 
         Object<name>HashMapWithHashingStrategy\<Person> map2 = Object<name>HashMapWithHashingStrategy.newMap(LAST_NAME_HASHING_STRATEGY);
         map2.put(JOHNSMITH, <(literal.(type))("1")>);
-        Assert.assertEquals(<(literal.(type))("1")>, map2.get(JOHNSMITH)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, map2.get(JOHNSMITH)<(wideDelta.(type))>);
         map2.put(JANESMITH, <(literal.(type))("2")>);
-        Assert.assertEquals(<(literal.(type))("2")>, map2.get(JOHNSMITH)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, map2.get(JOHNSMITH)<(wideDelta.(type))>);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#keySet()}.
@@ -60,14 +65,14 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -75,7 +80,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
@@ -83,34 +88,34 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Test
     public void freeze()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
@@ -126,7 +131,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -134,7 +139,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -142,7 +147,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -151,8 +156,8 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -160,7 +165,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -168,7 +173,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -179,16 +184,16 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -199,14 +204,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -214,7 +219,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
@@ -32,8 +32,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#keysView}.
@@ -74,60 +79,60 @@ public class <name>BooleanHashMapKeysViewTest
     @Test
     public void empty()
     {
-        Assert.assertTrue(new <name>BooleanHashMap().keysView().isEmpty());
-        Assert.assertFalse(new <name>BooleanHashMap().keysView().notEmpty());
-        Assert.assertFalse(this.iterable.isEmpty());
-        Assert.assertTrue(this.iterable.notEmpty());
-        Assert.assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView().isEmpty());
-        Assert.assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView().notEmpty());
-        Assert.assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView().isEmpty());
-        Assert.assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView().notEmpty());
-        Assert.assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView().isEmpty());
-        Assert.assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView().notEmpty());
+        assertTrue(new <name>BooleanHashMap().keysView().isEmpty());
+        assertFalse(new <name>BooleanHashMap().keysView().notEmpty());
+        assertFalse(this.iterable.isEmpty());
+        assertTrue(this.iterable.notEmpty());
+        assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView().isEmpty());
+        assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView().notEmpty());
+        assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView().isEmpty());
+        assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView().notEmpty());
+        assertFalse(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView().isEmpty());
+        assertTrue(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView().notEmpty());
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.iterable.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(this.iterable.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(this.iterable.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(this.iterable.contains(<(literal.(type))("31")>));
-        Assert.assertTrue(this.iterable.contains(generateCollisions1().getFirst()));
-        Assert.assertTrue(this.iterable.contains(generateCollisions1().get(1)));
+        assertTrue(this.iterable.contains(<(literal.(type))("0")>));
+        assertTrue(this.iterable.contains(<(literal.(type))("1")>));
+        assertFalse(this.iterable.contains(<(literal.(type))("2")>));
+        assertTrue(this.iterable.contains(<(literal.(type))("31")>));
+        assertTrue(this.iterable.contains(generateCollisions1().getFirst()));
+        assertTrue(this.iterable.contains(generateCollisions1().get(1)));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.iterable.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
-        Assert.assertFalse(this.iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertFalse(this.iterable.containsAll(<(literal.(type))("2")>, <(literal.(type))("5")>));
-        Assert.assertFalse(this.iterable.containsAll(<(literal.(type))("31")>, <(literal.(type))("2")>));
+        assertTrue(this.iterable.containsAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
+        assertFalse(this.iterable.containsAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertFalse(this.iterable.containsAll(<(literal.(type))("2")>, <(literal.(type))("5")>));
+        assertFalse(this.iterable.containsAll(<(literal.(type))("31")>, <(literal.(type))("2")>));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>)));
-        Assert.assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("2")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("31")>, <(literal.(type))("2")>)));
+        assertTrue(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>)));
+        assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("2")>, <(literal.(type))("5")>)));
+        assertFalse(this.iterable.containsAll(<name>HashSet.newSetWith(<(literal.(type))("31")>, <(literal.(type))("2")>)));
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertTrue(Arrays.equals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>}, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().toArray())
+        assertTrue(Arrays.equals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>}, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().toArray())
                 || Arrays.equals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>}, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().toArray()));
-        Assert.assertArrayEquals(new <type>[]{}, new <name>BooleanHashMap().keysView().toArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{}, new <name>BooleanHashMap().keysView().toArray()<delta.(type)>);
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, generateCollisions1().getFirst(), generateCollisions1().get(1)}, this.iterable.toSortedArray()<delta.(type)>);
-        Assert.assertArrayEquals(new <type>[]{}, new <name>BooleanHashMap().keysView().toSortedArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, generateCollisions1().getFirst(), generateCollisions1().get(1)}, this.iterable.toSortedArray()<delta.(type)>);
+        assertArrayEquals(new <type>[]{}, new <name>BooleanHashMap().keysView().toSortedArray()<delta.(type)>);
     }
 
     @Test
@@ -136,19 +141,19 @@ public class <name>BooleanHashMapKeysViewTest
         Mutable<name>Set expected = <name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, generateCollisions1().getFirst(), generateCollisions1().get(1));
         Mutable<name>Set actual = <name>HashSet.newSetWith();
         <name>Iterator iterator = this.iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -160,7 +165,7 @@ public class <name>BooleanHashMapKeysViewTest
             iterator.next();
         }
 
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -168,42 +173,42 @@ public class <name>BooleanHashMapKeysViewTest
     {
         <type>[] sum = new <type>[1];
         this.iterable.forEach(each -> sum[0] += each);
-        Assert.assertEquals(32L + generateCollisions1().getFirst() + generateCollisions1().get(1), sum[0]<delta.(type)>);
+        assertEquals(32L + generateCollisions1().getFirst() + generateCollisions1().get(1), sum[0]<delta.(type)>);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(4L, this.iterable.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertEquals(3L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
-        Assert.assertEquals(1L, this.iterable.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
+        assertEquals(4L, this.iterable.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertEquals(3L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
+        assertEquals(1L, this.iterable.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertTrue(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("31")>)));
-        Assert.assertFalse(this.iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("2")>)));
+        assertTrue(this.iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertTrue(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertTrue(this.iterable.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("31")>)));
+        assertFalse(this.iterable.anySatisfy(<name>Predicates.equal(<(literal.(type))("2")>)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
-        Assert.assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(generateCollisions1().getFirst())));
-        Assert.assertTrue(this.iterable.allSatisfy(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("2")>))));
+        assertFalse(this.iterable.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("1")>)));
+        assertFalse(this.iterable.allSatisfy(<name>Predicates.lessThan(generateCollisions1().getFirst())));
+        assertTrue(this.iterable.allSatisfy(<name>Predicates.not(<name>Predicates.equal(<(literal.(type))("2")>))));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.iterable.noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertFalse(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("31")>)));
-        Assert.assertTrue(this.iterable.noneSatisfy(<name>Predicates.equal(<(literal.(type))("2")>)));
+        assertFalse(this.iterable.noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertFalse(this.iterable.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("31")>)));
+        assertTrue(this.iterable.noneSatisfy(<name>Predicates.equal(<(literal.(type))("2")>)));
     }
 
     @Test
@@ -223,16 +228,16 @@ public class <name>BooleanHashMapKeysViewTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("1")>), <(literal.(type))("9")>)<delta.(type)>);
-        Assert.assertEquals(generateCollisions1().get(1), this.iterable.detectIfNone(<name>Predicates.greaterThan(generateCollisions1().getFirst()), <(literal.(type))("9")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("9")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(generateCollisions1().get(1)), <(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("1")>), <(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(generateCollisions1().get(1), this.iterable.detectIfNone(<name>Predicates.greaterThan(generateCollisions1().getFirst()), <(literal.(type))("9")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("9")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(generateCollisions1().get(1)), <(literal.(type))("9")>)<delta.(type)>);
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(<(literal.(type))("-1")>, <(literal.(type))("0")>, <(literal.(type))("30")>, <(castIntToNarrowTypeWithParens.(type))("generateCollisions1().getFirst() - 1")>, <(castIntToNarrowTypeWithParens.(type))("generateCollisions1().get(1) - 1")>),
                 this.iterable.collect((<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>).toSet());
     }
@@ -240,103 +245,103 @@ public class <name>BooleanHashMapKeysViewTest
     @Test
     public void max()
     {
-        Assert.assertEquals(generateCollisions1().get(1), this.iterable.max()<delta.(type)>);
+        assertEquals(generateCollisions1().get(1), this.iterable.max()<delta.(type)>);
     }
 
     @Test
     public void max_throws_emptyList()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().max());
+        assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().max());
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, this.iterable.min()<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("31")>, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, false).keysView().min()<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.iterable.min()<delta.(type)>);
+        assertEquals(<(literal.(type))("31")>, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, false).keysView().min()<delta.(type)>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, new <name>BooleanHashMap().keysView().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, new <name>BooleanHashMap().keysView().minIfEmpty(<(literal.(type))("0")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.iterable.minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, new <name>BooleanHashMap().keysView().minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, new <name>BooleanHashMap().keysView().minIfEmpty(<(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, this.iterable.minIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, new <name>BooleanHashMap().keysView().maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
-        Assert.assertEquals(<(literal.(type))("0")>, new <name>BooleanHashMap().keysView().maxIfEmpty(<(literal.(type))("0")>)<delta.(type)>);
-        Assert.assertEquals(generateCollisions1().get(1), this.iterable.maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("5")>, new <name>BooleanHashMap().keysView().maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
+        assertEquals(<(literal.(type))("0")>, new <name>BooleanHashMap().keysView().maxIfEmpty(<(literal.(type))("0")>)<delta.(type)>);
+        assertEquals(generateCollisions1().get(1), this.iterable.maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
     }
 
     @Test
     public void min_throws_emptyList()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().min());
+        assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().min());
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("94")>, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("94")>, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().sum()<wideDelta.(type)>);
     }
 
     @Test
     public void average_throws_emptyList()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().average());
+        assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().average());
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(31.0, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).keysView().average(), 0.0);
+        assertEquals(31.0, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).keysView().average(), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(31.0, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).keysView().median(), 0.0);
-        Assert.assertEquals(30.5, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeyValue(<(literal.(type))("1")>, true).keysView().median(), 0.0);
+        assertEquals(31.0, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).keysView().median(), 0.0);
+        assertEquals(30.5, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeyValue(<(literal.(type))("1")>, true).keysView().median(), 0.0);
     }
 
     @Test
     public void median_throws_emptyList()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().median());
+        assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().median());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[]", new <name>BooleanHashMap().keysView().toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("0")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true).keysView().toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("1")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false).keysView().toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("5")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("5")>, false).keysView().toString());
+        assertEquals("[]", new <name>BooleanHashMap().keysView().toString());
+        assertEquals("[<(toStringLiteral.(type))("0")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true).keysView().toString());
+        assertEquals("[<(toStringLiteral.(type))("1")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false).keysView().toString());
+        assertEquals("[<(toStringLiteral.(type))("5")>]", <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("5")>, false).keysView().toString());
 
         Lazy<name>Iterable iterable1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.toString(),
                 iterable1.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable1.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.toString(),
                 iterable2.toString().equals("[<["1", "32"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable2.toString().equals("[<["32", "1"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable3 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.toString(),
                 iterable3.toString().equals("[<["0", "32"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable3.toString().equals("[<["32", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
 
         Lazy<name>Iterable iterable4 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable4.toString(),
                 iterable4.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
                         || iterable4.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
@@ -345,30 +350,30 @@ public class <name>BooleanHashMapKeysViewTest
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", new <name>BooleanHashMap().keysView().makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", new <name>BooleanHashMap().withKeyValue(<(literal.(type))("31")>, true).keysView().makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", new <name>BooleanHashMap().withKeyValue(<(literal.(type))("32")>, false).keysView().makeString());
+        assertEquals("", new <name>BooleanHashMap().keysView().makeString());
+        assertEquals("<(toStringLiteral.(type))("31")>", new <name>BooleanHashMap().withKeyValue(<(literal.(type))("31")>, true).keysView().makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", new <name>BooleanHashMap().withKeyValue(<(literal.(type))("32")>, false).keysView().makeString());
 
         Lazy<name>Iterable iterable0 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable0.makeString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("1")>".equals(iterable0.makeString())
                         || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(iterable0.makeString()));
 
         Lazy<name>Iterable iterable1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(iterable1.makeString())
                         || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(iterable1.makeString()));
 
         Lazy<name>Iterable iterable2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>]".equals(iterable2.makeString("[", "/", "]"))
                         || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>]".equals(iterable2.makeString("[", "/", "]")));
 
         Lazy<name>Iterable iterable3 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView();
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>".equals(iterable3.makeString("/"))
                         || "<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>".equals(iterable3.makeString("/")));
@@ -379,64 +384,64 @@ public class <name>BooleanHashMapKeysViewTest
     {
         StringBuilder appendable = new StringBuilder();
         new <name>BooleanHashMap().keysView().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         StringBuilder appendable0 = new StringBuilder();
         new <name>BooleanHashMap().withKeyValue(<(literal.(type))("31")>, true).keysView().appendString(appendable0);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable0.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable0.toString());
 
         StringBuilder appendable1 = new StringBuilder();
         new <name>BooleanHashMap().withKeyValue(<(literal.(type))("32")>, true).keysView().appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         Lazy<name>Iterable set1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView();
         set1.appendString(appendable2);
-        Assert.assertTrue(appendable2.toString(), "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(appendable2.toString())
+        assertTrue(appendable2.toString(), "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(appendable2.toString())
                 || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(appendable2.toString()));
 
         StringBuilder appendable3 = new StringBuilder();
         Lazy<name>Iterable set2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView();
         set2.appendString(appendable3, "/");
-        Assert.assertTrue(appendable3.toString(), "<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>".equals(appendable3.toString())
+        assertTrue(appendable3.toString(), "<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>".equals(appendable3.toString())
                 || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>".equals(appendable3.toString()));
 
         StringBuilder appendable4 = new StringBuilder();
         Lazy<name>Iterable set4 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView();
         set4.appendString(appendable4, "[", "/", "]");
-        Assert.assertTrue(appendable4.toString(), "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>]".equals(appendable4.toString())
+        assertTrue(appendable4.toString(), "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>]".equals(appendable4.toString())
                 || "[<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>]".equals(appendable4.toString()));
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true).keysView().toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true).keysView().toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true).keysView().toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true).keysView().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toSet());
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toBag());
+        assertEquals(<name>HashBag.newBagWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>), <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true).keysView().toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
+        assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, this.iterable.asLazy());
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.api.block.function.primitive.BooleanToBooleanFunc
 import org.eclipse.collections.api.block.function.primitive.<name>ToBooleanFunction;
 import org.eclipse.collections.api.map.primitive.Mutable<name>BooleanMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap}.
@@ -83,8 +88,8 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         values.setAccessible(true);
 
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap();
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test
@@ -96,18 +101,18 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         values.setAccessible(true);
 
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap(3);
-        Assert.assertEquals(8L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(8L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
 
         <name>BooleanHashMap hashMap2 = new <name>BooleanHashMap(15);
-        Assert.assertEquals(32L, ((<type>[]) keys.get(hashMap2)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(32L, ((<type>[]) keys.get(hashMap2)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>BooleanHashMap(-1));
+        assertThrows(IllegalArgumentException.class, () -> new <name>BooleanHashMap(-1));
     }
 
     @Test
@@ -119,9 +124,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         values.setAccessible(true);
 
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap();
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
-        Assert.assertEquals(new <name>BooleanHashMap(), hashMap);
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(new <name>BooleanHashMap(), hashMap);
     }
 
     @Test
@@ -130,7 +135,7 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap();
         for (<type> i = <(literal.(type))("2")>; i \< 10; i++)
         {
-            Assert.assertFalse(hashMap.containsKey(i));
+            assertFalse(hashMap.containsKey(i));
             hashMap.put(i, (<(castRealTypeToInt.(type))("i")> & 1) == <(literal.(type))("0")>);
         }
 
@@ -138,26 +143,26 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         Field values = <name>BooleanHashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
         Verify.assertSize(8, hashMap);
         for (<type> i = <(literal.(type))("2")>; i \< 10; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(i));
+            assertTrue(hashMap.containsKey(i));
         }
-        Assert.assertTrue(hashMap.containsValue(false));
-        Assert.assertTrue(hashMap.containsValue(true));
+        assertTrue(hashMap.containsValue(false));
+        assertTrue(hashMap.containsValue(true));
         hashMap.put(<(literal.(type))("10")>, true);
-        Assert.assertEquals(32L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(32L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
 
         for (<type> i = 11; i \< 75; i++)
         {
-            Assert.assertFalse(String.valueOf(i), hashMap.containsKey(i));
+            assertFalse(String.valueOf(i), hashMap.containsKey(i));
             hashMap.put(i, (<(castRealTypeToInt.(type))("i")> & 1) == <(literal.(type))("0")>);
         }
-        Assert.assertEquals(256L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(256L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(256L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(256L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test
@@ -168,8 +173,8 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> i = <(literal.(type))("1")>; i \< 11; i++)
         {
-            Assert.assertFalse(hashMap.containsKey(i));
-            Assert.assertFalse(copyMap.containsKey(i));
+            assertFalse(hashMap.containsKey(i));
+            assertFalse(copyMap.containsKey(i));
             copyMap.put(i, (<(castRealTypeToInt.(type))("i")> & 1) == <(literal.(type))("0")>);
         }
 
@@ -182,11 +187,11 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> i = <(literal.(type))("1")>; i \< 11; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(i));
-            Assert.assertTrue(copyMap.containsKey(i));
+            assertTrue(hashMap.containsKey(i));
+            assertTrue(copyMap.containsKey(i));
         }
 
-        Assert.assertEquals(hashMap, copyMap);
+        assertEquals(hashMap, copyMap);
     }
 
     @Override
@@ -195,12 +200,12 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
     {
         super.withKeysValues();
         <name>BooleanHashMap hashMap0 = new <name>BooleanHashMap();
-        Assert.assertSame(hashMap0.withKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true), hashMap0);
+        assertSame(hashMap0.withKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true), hashMap0);
         <name>BooleanHashMap hashMap1 = new <name>BooleanHashMap().withKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         <name>BooleanHashMap hashMap2 = new <name>BooleanHashMap().withKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false, <(literal.(type))("4")>, true);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true), hashMap0);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false), hashMap1);
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false, <(literal.(type))("4")>, true), hashMap2);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true), hashMap0);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false), hashMap1);
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false, <(literal.(type))("4")>, true), hashMap2);
     }
 
     @Test
@@ -210,7 +215,7 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         <wrapperName> total = hashMap0.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, boolean value) -> value ? result : <wrapperName>.valueOf((<type>) (result + <(literal.(type))("2")>)));
 
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("6")>), total);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("6")>), total);
     }
 
     @Test
@@ -219,11 +224,11 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
+            assertFalse(hashMap.get(each));
             hashMap.put(each, each % 2 == 0);
-            Assert.assertEquals(each % 2 == 0, hashMap.get(each));
+            assertEquals(each % 2 == 0, hashMap.get(each));
             hashMap.remove(each);
-            Assert.assertFalse(hashMap.get(each));
+            assertFalse(hashMap.get(each));
         }
     }
 
@@ -233,9 +238,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         <name>BooleanHashMap hashMap = new <name>BooleanHashMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
+            assertFalse(hashMap.get(each));
             hashMap.getIfAbsentPut(each, each % 2 == 0);
-            Assert.assertEquals(each % 2 == 0, hashMap.get(each));
+            assertEquals(each % 2 == 0, hashMap.get(each));
         }
     }
 
@@ -248,9 +253,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
-            Assert.assertTrue(hashMap.getIfAbsentPutWith(each, functionLength, ""));
-            Assert.assertTrue(hashMap.get(each));
+            assertFalse(hashMap.get(each));
+            assertTrue(hashMap.getIfAbsentPutWith(each, functionLength, ""));
+            assertTrue(hashMap.get(each));
         }
     }
 
@@ -263,9 +268,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
-            Assert.assertEquals(each % 2 == 0, hashMap.getIfAbsentPutWithKey(each, function));
-            Assert.assertEquals(each % 2 == 0, hashMap.get(each));
+            assertFalse(hashMap.get(each));
+            assertEquals(each % 2 == 0, hashMap.getIfAbsentPutWithKey(each, function));
+            assertEquals(each % 2 == 0, hashMap.get(each));
         }
     }
 
@@ -278,9 +283,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
-            Assert.assertTrue(hashMap.getIfAbsentPut(each, factory));
-            Assert.assertTrue(hashMap.get(each));
+            assertFalse(hashMap.get(each));
+            assertTrue(hashMap.getIfAbsentPut(each, factory));
+            assertTrue(hashMap.get(each));
         }
     }
 
@@ -293,9 +298,9 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
-            Assert.assertEquals(each % 2 != 0, hashMap.updateValue(each, each % 2 == 0, function));
-            Assert.assertEquals(each % 2 != 0, hashMap.get(each));
+            assertFalse(hashMap.get(each));
+            assertEquals(each % 2 != 0, hashMap.updateValue(each, each % 2 == 0, function));
+            assertEquals(each % 2 != 0, hashMap.get(each));
         }
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
@@ -36,8 +36,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBoo
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#values()}.
@@ -83,20 +87,20 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
         BooleanIterator iterator = collection.booleanIterator();
         for (int i = 0; i \< 6; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
@@ -104,35 +108,35 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
@@ -140,7 +144,7 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new BooleanArrayList()));
     }
 
@@ -150,11 +154,11 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     {
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.remove(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
     }
 
     @Override
@@ -162,15 +166,15 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     public void containsAllArray()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll());
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
+        assertTrue(emptyCollection.containsAll());
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll());
-        Assert.assertTrue(classUnderTest.containsAll(true));
-        Assert.assertTrue(classUnderTest.containsAll(false));
-        Assert.assertTrue(classUnderTest.containsAll(false, true));
+        assertTrue(classUnderTest.containsAll());
+        assertTrue(classUnderTest.containsAll(true));
+        assertTrue(classUnderTest.containsAll(false));
+        assertTrue(classUnderTest.containsAll(false, true));
     }
 
     @Override
@@ -179,7 +183,7 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(SynchronizedBooleanCollection.class, collection.asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -188,7 +192,7 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(UnmodifiableBooleanCollection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -196,161 +200,161 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     public void containsAllIterable()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(true));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(true));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.removeAll(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.removeAll(true));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.removeAll(false, true));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.removeAll(false, true));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new BooleanArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.newWith().removeAll(new BooleanArrayList()));
+        assertFalse(this.newWith().removeAll(BooleanArrayList.newListWith(true)));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.removeAll(BooleanArrayList.newListWith(false, true)));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.removeAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(true));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(true));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.retainAll(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.retainAll(true));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(false));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(false));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll());
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.retainAll());
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
 
         <name>BooleanHashMap sentinelMap = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("0")>, false);
         MutableBooleanCollection collection2 = sentinelMap.values();
-        Assert.assertTrue(collection2.retainAll(false));
-        Assert.assertTrue(collection2.contains(false));
-        Assert.assertFalse(collection2.contains(true));
-        Assert.assertTrue(sentinelMap.contains(false));
-        Assert.assertFalse(sentinelMap.contains(true));
-        Assert.assertTrue(collection2.retainAll(true));
-        Assert.assertFalse(collection2.contains(false));
-        Assert.assertFalse(collection2.contains(true));
-        Assert.assertFalse(sentinelMap.contains(false));
-        Assert.assertFalse(sentinelMap.contains(true));
+        assertTrue(collection2.retainAll(false));
+        assertTrue(collection2.contains(false));
+        assertFalse(collection2.contains(true));
+        assertTrue(sentinelMap.contains(false));
+        assertFalse(sentinelMap.contains(true));
+        assertTrue(collection2.retainAll(true));
+        assertFalse(collection2.contains(false));
+        assertFalse(collection2.contains(true));
+        assertFalse(sentinelMap.contains(false));
+        assertFalse(sentinelMap.contains(true));
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new BooleanArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.newWith().retainAll(new BooleanArrayList()));
+        assertFalse(this.newWith().retainAll(BooleanArrayList.newListWith(true)));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll(new BooleanArrayList()));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.retainAll(new BooleanArrayList()));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
 
         <name>BooleanHashMap sentinelMap = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("0")>, false);
         MutableBooleanCollection collection2 = sentinelMap.values();
-        Assert.assertTrue(collection2.retainAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection2.contains(false));
-        Assert.assertFalse(collection2.contains(true));
-        Assert.assertTrue(sentinelMap.contains(false));
-        Assert.assertFalse(sentinelMap.contains(true));
-        Assert.assertTrue(collection2.retainAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection2.contains(false));
-        Assert.assertFalse(collection2.contains(true));
-        Assert.assertFalse(sentinelMap.contains(false));
-        Assert.assertFalse(sentinelMap.contains(true));
+        assertTrue(collection2.retainAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection2.contains(false));
+        assertFalse(collection2.contains(true));
+        assertTrue(sentinelMap.contains(false));
+        assertFalse(sentinelMap.contains(true));
+        assertTrue(collection2.retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection2.contains(false));
+        assertFalse(collection2.contains(true));
+        assertFalse(sentinelMap.contains(false));
+        assertFalse(sentinelMap.contains(true));
     }
 
     @Override
@@ -367,10 +371,10 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
     }
 
     @Override
@@ -378,13 +382,13 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     public void contains()
     {
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.contains(true));
-        Assert.assertFalse(emptyCollection.contains(false));
+        assertFalse(emptyCollection.contains(true));
+        assertFalse(emptyCollection.contains(false));
         BooleanIterable booleanIterable = this.classUnderTest();
-        Assert.assertTrue(booleanIterable.contains(true));
-        Assert.assertTrue(booleanIterable.contains(false));
-        Assert.assertFalse(this.newWith(true, true, true).contains(false));
-        Assert.assertFalse(this.newWith(false, false, false).contains(true));
+        assertTrue(booleanIterable.contains(true));
+        assertTrue(booleanIterable.contains(false));
+        assertFalse(this.newWith(true, true, true).contains(false));
+        assertFalse(this.newWith(false, false, false).contains(true));
     }
 
     @Override
@@ -410,8 +414,8 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     public void collect()
     {
         BooleanToObjectFunction\<Integer> function = (boolean parameter) -> parameter ? 1 : 0;
-        Assert.assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
     }
 
     @Override
@@ -422,22 +426,22 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
 
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", "/", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true).appendString(appendable1);
-        Assert.assertEquals("true", appendable1.toString());
+        assertEquals("true", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
         BooleanIterable iterable = this.newWith(true, false);
         iterable.appendString(appendable2);
-        Assert.assertTrue("true, false".equals(appendable2.toString())
+        assertTrue("true, false".equals(appendable2.toString())
                 || "false, true".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("true/false".equals(appendable3.toString())
+        assertTrue("true/false".equals(appendable3.toString())
                 || "false/true".equals(appendable3.toString()));
 
         <name>BooleanHashMap map = new <name>BooleanHashMap();
@@ -446,7 +450,7 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
 
         StringBuilder stringBuilder = new StringBuilder();
         map.values().appendString(stringBuilder, "[", ", ", "]");
-        Assert.assertEquals("[true, false]", stringBuilder.toString());
+        assertEquals("[true, false]", stringBuilder.toString());
     }
 
     @Override
@@ -475,8 +479,8 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
                 Lists.mutable.with(BooleanBags.mutable.with(false, true)),
                 iterable3.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap#keySet()}.
@@ -60,14 +65,14 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -75,35 +80,35 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
@@ -119,7 +124,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -127,7 +132,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -135,7 +140,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -143,8 +148,8 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -152,7 +157,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -160,7 +165,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -171,16 +176,16 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -191,14 +196,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -206,7 +211,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
@@ -34,8 +34,13 @@ import org.eclipse.collections.impl.block.function.AddFunction;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap}.
@@ -82,8 +87,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         values.setAccessible(true);
 
         <name>ObjectHashMap\<Object> hashMap = new <name>ObjectHashMap\<>();
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
     }
 
     @Test
@@ -95,18 +100,18 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         values.setAccessible(true);
 
         <name>ObjectHashMap\<Object> hashMap = new <name>ObjectHashMap\<>(3);
-        Assert.assertEquals(8L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(8L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(8L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(8L, ((Object[]) values.get(hashMap)).length);
 
         <name>ObjectHashMap\<?> hashMap2 = new <name>ObjectHashMap\<>(15);
-        Assert.assertEquals(32L, ((<type>[]) keys.get(hashMap2)).length);
-        Assert.assertEquals(32L, ((Object[]) values.get(hashMap2)).length);
+        assertEquals(32L, ((<type>[]) keys.get(hashMap2)).length);
+        assertEquals(32L, ((Object[]) values.get(hashMap2)).length);
     }
 
     @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>ObjectHashMap\<>(-1));
+        assertThrows(IllegalArgumentException.class, () -> new <name>ObjectHashMap\<>(-1));
     }
 
     @Test
@@ -118,9 +123,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         values.setAccessible(true);
 
         <name>ObjectHashMap\<Object> hashMap = <name>ObjectHashMap.newMap();
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
-        Assert.assertEquals(new <name>ObjectHashMap\<>(), hashMap);
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(new <name>ObjectHashMap\<>(), hashMap);
     }
 
     @Test
@@ -134,15 +139,15 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         <name>ObjectHashMap\<Object> map = <name>ObjectHashMap.newMap();
 
         <name>ObjectHashMap\<Object> hashMap = <name>ObjectHashMap.newMap(map);
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
-        Assert.assertEquals(new <name>ObjectHashMap\<>(), hashMap);
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(new <name>ObjectHashMap\<>(), hashMap);
 
         map.put(<(literal.(type))("1")>, "one");
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectHashMap.newMap(map));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one"), <name>ObjectHashMap.newMap(map));
 
         map.put(<(literal.(type))("2")>, "two");
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), <name>ObjectHashMap.newMap(map));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), <name>ObjectHashMap.newMap(map));
     }
 
     @Test
@@ -151,30 +156,30 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         <name>ObjectHashMap\<String> hashMap = <name>ObjectHashMap.newMap();
         for (<type> i = <(literal.(type))("2")>; i \< <(literal.(type))("10")>; i++)
         {
-            Assert.assertNull(hashMap.put(i, String.valueOf(i)));
+            assertNull(hashMap.put(i, String.valueOf(i)));
         }
 
         Field keys = <name>ObjectHashMap.class.getDeclaredField("keys");
         Field values = <name>ObjectHashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
-        Assert.assertEquals(8, hashMap.size());
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(8, hashMap.size());
         for (<type> i = <(literal.(type))("2")>; i \< <(literal.(type))("10")>; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(i));
-            Assert.assertTrue(hashMap.containsValue(String.valueOf(i)));
+            assertTrue(hashMap.containsKey(i));
+            assertTrue(hashMap.containsValue(String.valueOf(i)));
         }
 
         Field occupiedWithData = <name>ObjectHashMap.class.getDeclaredField("occupiedWithData");
         occupiedWithData.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
 
-        Assert.assertNull(hashMap.put(<(literal.(type))("10")>, "10"));
-        Assert.assertEquals(32L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(32L, ((Object[]) values.get(hashMap)).length);
-        Assert.assertEquals(9, occupiedWithData.get(hashMap));
+        assertNull(hashMap.put(<(literal.(type))("10")>, "10"));
+        assertEquals(32L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(32L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(9, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -190,29 +195,29 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Field values = <name>ObjectHashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
 
         Field occupiedWithData = <name>ObjectHashMap.class.getDeclaredField("occupiedWithData");
         occupiedWithData.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
 
         Field occupiedWithSentinels = <name>ObjectHashMap.class.getDeclaredField("occupiedWithSentinels");
         occupiedWithSentinels.setAccessible(true);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 0; i \< 4; i++)
         {
             hashMap.remove(<(castIntToNarrowTypeWithParens.(type))("i + 2")>);
-            Assert.assertEquals(7 - i, occupiedWithData.get(hashMap));
-            Assert.assertEquals(i + 1, occupiedWithSentinels.get(hashMap));
+            assertEquals(7 - i, occupiedWithData.get(hashMap));
+            assertEquals(i + 1, occupiedWithSentinels.get(hashMap));
         }
 
         hashMap.remove(<(literal.(type))("6")>);
-        Assert.assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((Object[]) values.get(hashMap)).length);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(5, occupiedWithSentinels.get(hashMap));
+        assertEquals(16L, ((<type>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((Object[]) values.get(hashMap)).length);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(5, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -224,16 +229,16 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, 2.0f, <(literal.(type))("3")>, 3.0f);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(1, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(1, occupiedWithData.get(hashMap));
 
         hashMap.clear();
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -245,20 +250,20 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, 2.0f, <(literal.(type))("3")>, 3.0f, <(literal.(type))("4")>, 4.0f);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("5")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -270,28 +275,28 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, 2.0f, <(literal.(type))("3")>, 3.0f, <(literal.(type))("4")>, 4.0f);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         Function\<Float, Float> function = Functions.getPassThru();
 
         Function0\<Float> function0 = Functions0.value(0.0f);
 
         hashMap.updateValue(<(literal.(type))("2")>, function0, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(<(literal.(type))("5")>, function0, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(<(literal.(type))("2")>, function0, function); // putting in a slot marked REMOVED
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -303,28 +308,28 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, 2.0f, <(literal.(type))("3")>, 3.0f, <(literal.(type))("4")>, 4.0f);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         Function2\<Float, Float, Float> function = Functions2.fromFunction(Functions.\<Float>getPassThru());
 
         Function0\<Float> function0 = Functions0.value(0.0f);
 
         hashMap.updateValueWith(<(literal.(type))("2")>, function0, function, 0.0f);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValueWith(<(literal.(type))("5")>, function0, function, 0.0f);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValueWith(<(literal.(type))("2")>, function0, function, 0.0f); // putting in a slot marked REMOVED
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -335,23 +340,23 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = new <name>ObjectHashMap\<>();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (<type> i = 2; i \< 10; i++)
         {
             hashMap.put(<(castFromInt.(type))("i")>, (float) i);
         }
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.put(<(literal.(type))("2")>, 9.0f); // putting in a slot marked REMOVED
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -364,20 +369,20 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         <name>ObjectHashMap\<Float> hashMap = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("2")>, 2.0f, <(literal.(type))("3")>, 3.0f, <(literal.(type))("4")>, 4.0f);
 
         hashMap.getIfAbsentPut(<(literal.(type))("2")>, 5.0f);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type))("5")>, 5.0f);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type))("2")>, 5.0f); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -392,20 +397,20 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Function0\<Float> function = Functions0.value(5.0f);
 
         hashMap.getIfAbsentPut(<(literal.(type))("2")>, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type))("5")>, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type))("2")>, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -420,20 +425,20 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Function\<Float, Float> function = Functions.getPassThru();
 
         hashMap.getIfAbsentPutWith(<(literal.(type))("2")>, function, Float.valueOf(5.0f));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(<(literal.(type))("5")>, function, Float.valueOf(5.0f));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(<(literal.(type))("2")>, function, Float.valueOf(5.0f)); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -448,20 +453,20 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         <name>ToObjectFunction\<Float> function = (<type> <type>Parameter) -> (float) <type>Parameter;
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type))("2")>, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type))("5")>, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type))("2")>, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -472,8 +477,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         <name>ObjectHashMap\<Float> hashMap = new <name>ObjectHashMap\<>();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (<type> i = 2; i \< 10; i++)
         {
@@ -481,13 +486,13 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         }
 
         hashMap.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
 
         hashMap.put(<(literal.(type))("2")>, 3.0f); //putting in a slot marked as REMOVED
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
     }
 
     @Override
@@ -497,12 +502,12 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         super.withKeysValues();
 
         <name>ObjectHashMap\<String> hashMap0 = new <name>ObjectHashMap\<>();
-        Assert.assertSame(hashMap0.withKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), hashMap0);
+        assertSame(hashMap0.withKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), hashMap0);
         <name>ObjectHashMap\<String> hashMap1 = new <name>ObjectHashMap\<String>().withKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three");
         <name>ObjectHashMap\<String> hashMap2 = new <name>ObjectHashMap\<String>().withKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four");
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), hashMap0);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"), hashMap1);
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three").withKeyValue(<(literal.(type))("4")>, "four"), hashMap2);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two"), hashMap0);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"), hashMap1);
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three").withKeyValue(<(literal.(type))("4")>, "four"), hashMap2);
     }
 
     @Test
@@ -511,9 +516,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Mutable<name>ObjectMap\<String> hashMap = this.getEmptyMap();
         for (<type> i = <(literal.(type))("2")>; i \< <(literal.(type))("100")>; i++)
         {
-            Assert.assertNull(hashMap.get(i));
-            Assert.assertNull(hashMap.put(i, String.valueOf(i)));
-            Assert.assertEquals(String.valueOf(i), hashMap.remove(i));
+            assertNull(hashMap.get(i));
+            assertNull(hashMap.put(i, String.valueOf(i)));
+            assertEquals(String.valueOf(i), hashMap.remove(i));
         }
     }
 
@@ -523,8 +528,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Mutable<name>ObjectMap\<String> hashMap = this.getEmptyMap();
         for (<type> i = <(literal.(type))("2")>; i \< <(literal.(type))("100")>; i++)
         {
-            Assert.assertNull(hashMap.get(i));
-            Assert.assertEquals("value", hashMap.getIfAbsentPut(i, Functions0.value("value")));
+            assertNull(hashMap.get(i));
+            assertEquals("value", hashMap.getIfAbsentPut(i, Functions0.value("value")));
         }
     }
 
@@ -536,8 +541,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Mutable<name>ObjectMap\<String> hashMap = this.getEmptyMap();
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertNull(hashMap.get(each));
-            Assert.assertEquals("VALUE", hashMap.getIfAbsentPutWith(each, toUpperCase, "value"));
+            assertNull(hashMap.get(each));
+            assertEquals("VALUE", hashMap.getIfAbsentPutWith(each, toUpperCase, "value"));
         }
     }
 
@@ -548,8 +553,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertNull(hashMap.get(each));
-            Assert.assertEquals(<wrapperName>.valueOf(each), hashMap.getIfAbsentPutWithKey(each, <wrapperName>::valueOf));
+            assertNull(hashMap.get(each));
+            assertEquals(<wrapperName>.valueOf(each), hashMap.getIfAbsentPutWithKey(each, <wrapperName>::valueOf));
         }
     }
 
@@ -562,8 +567,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertNull(hashMap.get(each));
-            Assert.assertEquals(1L, hashMap.updateValue(each, Functions0.value(0), incrementFunction).intValue());
+            assertNull(hashMap.get(each));
+            assertEquals(1L, hashMap.updateValue(each, Functions0.value(0), incrementFunction).intValue());
         }
     }
 
@@ -576,8 +581,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
 
         for (<type> each = <(literal.(type))("2")>; each \< <(literal.(type))("100")>; each++)
         {
-            Assert.assertNull(hashMap.get(each));
-            Assert.assertEquals(1L, hashMap.updateValueWith(each, Functions0.value(0), incrementFunction, 1).longValue());
+            assertNull(hashMap.get(each));
+            assertEquals(1L, hashMap.updateValueWith(each, Functions0.value(0), incrementFunction, 1).longValue());
         }
     }
 
@@ -613,7 +618,7 @@ public void sumOfFloatConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type))()>,
             result,
             1.0e-15);
@@ -630,7 +635,7 @@ public void sumOfDoubleConsistentRounding()
     randomIntegers.each(i -> hashMap.put(<if(primitive.charPrimitive)>(char) i.intValue()<else>i.<type>Value()<endif>, i));
     double result = hashMap.sumOfDouble(i -> 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue()));
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type))()>,
             result,
             1.0e-15);
@@ -668,7 +673,7 @@ public void sumOfFloatConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             result,
             1.0e-15);
@@ -682,7 +687,7 @@ public void sumOfDoubleConsistentRounding()
     randomIntegers.each(i -> hashMap.put(i.<type>Value(), i));
     double result = hashMap.sumOfDouble(i -> 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue()));
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             result,
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
@@ -30,8 +30,12 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap#values()}.
@@ -58,14 +62,14 @@ public class <name>ObjectHashMapValuesTest
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
                     .values().addAll(FastList.newListWith(4)));
     }
@@ -84,14 +88,14 @@ public class <name>ObjectHashMapValuesTest
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.contains(1));
-        Assert.assertTrue(values.contains(2));
-        Assert.assertTrue(values.contains(null));
-        Assert.assertFalse(values.contains(4));
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(2));
+        assertTrue(values.contains(null));
+        assertFalse(values.contains(4));
         values.remove(null);
-        Assert.assertFalse(values.contains(null));
+        assertFalse(values.contains(null));
         map.removeKey(<(literal.(type))("1")>);
-        Assert.assertFalse(values.contains(1));
+        assertFalse(values.contains(1));
     }
 
     @Test
@@ -99,17 +103,17 @@ public class <name>ObjectHashMapValuesTest
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 4)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(5, 4)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(null, null)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 4)));
+        assertFalse(values.containsAll(FastList.newListWith(5, 4)));
         values.remove(null);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
         map.removeKey(<(literal.(type))("1")>);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(2)));
     }
 
     @Test
@@ -117,12 +121,12 @@ public class <name>ObjectHashMapValuesTest
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("1")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertFalse(values.isEmpty());
+        assertFalse(values.isEmpty());
         <name>ObjectHashMap\<Integer> map1 = <name>ObjectHashMap.newMap();
         Collection\<Integer> values1 = map1.values();
-        Assert.assertTrue(values1.isEmpty());
+        assertTrue(values1.isEmpty());
         map1.put(<(literal.(type))("1")>, 1);
-        Assert.assertFalse(values1.isEmpty());
+        assertFalse(values1.isEmpty());
     }
 
     @Test
@@ -150,50 +154,50 @@ public class <name>ObjectHashMapValuesTest
         MutableSet\<String> actual = UnifiedSet.newSet();
 
         Iterator\<String> iterator = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, null).iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
 
         Mutable<name>ObjectMap\<String> map1 = this.newMapWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, null);
         Iterator\<String> iterator1 = map1.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        Assert.assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1));
         iterator1.next();
         iterator1.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map1);
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertEquals(<name>ObjectHashMap.newMap(), map1);
+        assertThrows(IllegalStateException.class, iterator1::remove);
 
         Mutable<name>ObjectMap\<String> map2 = this.newMapWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("9")>, "nine");
         Iterator\<String> iterator2 = map2.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator2::remove);
+        assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        Assert.assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
+        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
         iterator2.next();
         iterator2.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map2);
+        assertEquals(<name>ObjectHashMap.newMap(), map2);
 
         Mutable<name>ObjectMap\<String> map3 = this.newMapWithKeysValues(<(literal.(type))("8")>, "eight", <(literal.(type))("9")>, null);
         Iterator\<String> iterator3 = map3.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator3::remove);
+        assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        Assert.assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3));
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map3);
+        assertEquals(<name>ObjectHashMap.newMap(), map3);
     }
 
     @Test
@@ -207,41 +211,41 @@ public class <name>ObjectHashMapValuesTest
     public void removeFromValues()
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().remove(4));
+        assertFalse(map.values().remove(4));
 
-        Assert.assertTrue(map.values().remove(2));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().remove(2));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void removeNullFromValues()
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().remove(null));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
+        assertFalse(map.values().remove(null));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
         map.put(<(literal.(type))("4")>, null);
-        Assert.assertTrue(map.values().remove(null));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().remove(null));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void removeAllFromValues()
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().removeAll(FastList.newListWith(4)));
+        assertFalse(map.values().removeAll(FastList.newListWith(4)));
 
-        Assert.assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void retainAllFromValues()
     {
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
+        assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
 
-        Assert.assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
@@ -250,11 +254,11 @@ public class <name>ObjectHashMapValuesTest
         <name>ObjectHashMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         HashBag\<Integer> expected = HashBag.newBagWith(1, 2, null);
         Collection\<Integer> values = map.values();
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray()));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
@@ -27,8 +27,12 @@ import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap#keySet()}.
@@ -58,14 +62,14 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
@@ -73,35 +77,35 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
     }
 
     @Override
@@ -117,7 +121,7 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -125,7 +129,7 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
     }
 
     @Override
@@ -133,7 +137,7 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     @Override
@@ -141,8 +145,8 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 }
 
@@ -157,14 +161,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
@@ -172,7 +176,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
@@ -31,8 +31,13 @@ import org.eclipse.collections.api.block.function.primitive.<name2>To<name2>Func
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.api.map.primitive.Mutable<name1><name2>Map;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap}.
@@ -90,10 +95,10 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <endif>
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
         <if(!sameTwoPrimitives)>
-        Assert.assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
         <else>
-        Assert.assertEquals(32L, ((<type1>[]) keysValues.get(hashMap)).length);
+        assertEquals(32L, ((<type1>[]) keysValues.get(hashMap)).length);
         <endif>
     }
 
@@ -107,27 +112,27 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         values.setAccessible(true);
 
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap(3);
-        Assert.assertEquals(8L, ((<type1>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(8L, ((<type2>[]) values.get(hashMap)).length);
+        assertEquals(8L, ((<type1>[]) keys.get(hashMap)).length);
+        assertEquals(8L, ((<type2>[]) values.get(hashMap)).length);
 
         <name1><name2>HashMap hashMap2 = new <name1><name2>HashMap(15);
-        Assert.assertEquals(32L, ((<type1>[]) keys.get(hashMap2)).length);
-        Assert.assertEquals(32L, ((<type2>[]) values.get(hashMap2)).length);
+        assertEquals(32L, ((<type1>[]) keys.get(hashMap2)).length);
+        assertEquals(32L, ((<type2>[]) values.get(hashMap2)).length);
         <else>
         Field keysValues = <name1><name2>HashMap.class.getDeclaredField("keysValues");
         keysValues.setAccessible(true);
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap(3);
-        Assert.assertEquals(16L, ((<type1>[]) keysValues.get(hashMap)).length);
+        assertEquals(16L, ((<type1>[]) keysValues.get(hashMap)).length);
 
         <name1><name2>HashMap hashMap2 = new <name1><name2>HashMap(15);
-        Assert.assertEquals(64L, ((<type1>[]) keysValues.get(hashMap2)).length);
+        assertEquals(64L, ((<type1>[]) keysValues.get(hashMap2)).length);
         <endif>
     }
 
     @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new <name1><name2>HashMap(-1));
+        assertThrows(IllegalArgumentException.class, () -> new <name1><name2>HashMap(-1));
     }
 
     @Test
@@ -140,16 +145,16 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         values.setAccessible(true);
 
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
-        Assert.assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
         <else>
         Field keysValues = <name1><name2>HashMap.class.getDeclaredField("keysValues");
         keysValues.setAccessible(true);
 
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
-        Assert.assertEquals(32L, ((<type1>[]) keysValues.get(hashMap)).length);
+        assertEquals(32L, ((<type1>[]) keysValues.get(hashMap)).length);
         <endif>
-        Assert.assertEquals(new <name1><name2>HashMap(), hashMap);
+        assertEquals(new <name1><name2>HashMap(), hashMap);
     }
 
     @Test
@@ -158,7 +163,7 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
         for (int i = 2; i \< 10; i++)
         {
-            Assert.assertFalse(hashMap.containsKey(<(castFromInt.(type1))("i")>));
+            assertFalse(hashMap.containsKey(<(castFromInt.(type1))("i")>));
             hashMap.put(<(castFromInt.(type1))("i")>, <(castFromInt.(type2))("i")>);
         }
 
@@ -167,30 +172,30 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Field values = <name1><name2>HashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
         <endif>
         Verify.assertSize(8, hashMap);
         for (int i = 2; i \< 10; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(<(castFromInt.(type1))("i")>));
-            Assert.assertTrue(hashMap.containsValue(<(castFromInt.(type2))("i")>));
+            assertTrue(hashMap.containsKey(<(castFromInt.(type1))("i")>));
+            assertTrue(hashMap.containsValue(<(castFromInt.(type2))("i")>));
         }
 
         Field occupiedWithData = <name1><name2>HashMap.class.getDeclaredField("occupiedWithData");
         Field occupiedWithSentinels = <name1><name2>HashMap.class.getDeclaredField("occupiedWithSentinels");
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
         hashMap.put(<(literal.(type1))("10")>, <(literal.(type2))("10")>);
         hashMap.put(<(literal.(type1))("11")>, <(literal.(type2))("11")>);
-        Assert.assertEquals(9, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(9, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -207,28 +212,28 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Field values = <name1><name2>HashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
-        Assert.assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
+        assertEquals(16L, ((<type1>[]) keys.get(hashMap)).length);
+        assertEquals(16L, ((<type2>[]) values.get(hashMap)).length);
         <endif>
 
         Field occupiedWithData = <name1><name2>HashMap.class.getDeclaredField("occupiedWithData");
         occupiedWithData.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
 
         Field occupiedWithSentinels = <name1><name2>HashMap.class.getDeclaredField("occupiedWithSentinels");
         occupiedWithSentinels.setAccessible(true);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 0; i \< 4; i++)
         {
             hashMap.remove(<(castIntToNarrowTypeWithParens.(type1))("i + 2")>);
-            Assert.assertEquals(7 - i, occupiedWithData.get(hashMap));
-            Assert.assertEquals(i + 1, occupiedWithSentinels.get(hashMap));
+            assertEquals(7 - i, occupiedWithData.get(hashMap));
+            assertEquals(i + 1, occupiedWithSentinels.get(hashMap));
         }
 
         hashMap.remove(<(literal.(type1))("6")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(5, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(5, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -240,16 +245,16 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = <name1><name2>HashMap.newWithKeysValues(<["2", "3"]:keyValue(); separator=", ">);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(1, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(1, occupiedWithData.get(hashMap));
 
         hashMap.clear();
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -261,20 +266,20 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = <name1><name2>HashMap.newWithKeysValues(<["2", "3", "4"]:keyValue(); separator=", ">);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("5")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -286,26 +291,26 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = <name1><name2>HashMap.newWithKeysValues(<["2", "3", "4"]:keyValue(); separator=", ">);
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         <name2>To<name2>Function function = (<type2> <type2>Parameter) -> <type2>Parameter;
 
         hashMap.updateValue(<(literal.(type1))("2")>, <(literal.(type2))("0")>, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(<(literal.(type1))("5")>, <(literal.(type2))("0")>, function);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
 
         hashMap.updateValue(<(literal.(type1))("2")>, <(literal.(type2))("0")>, function); // putting in a slot marked REMOVED
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -316,24 +321,24 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 2; i \< 10; i++)
         {
             hashMap.put(<(castFromInt.(type1))("i")>, <(castFromInt.(type2))("i")>);
-            Assert.assertEquals(i - 1, occupiedWithData.get(hashMap));
+            assertEquals(i - 1, occupiedWithData.get(hashMap));
         }
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("9")>); // putting in a slot marked REMOVED
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -346,20 +351,20 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <name1><name2>HashMap hashMap = <name1><name2>HashMap.newWithKeysValues(<["2", "3", "4"]:keyValue(); separator=", ">);
 
         hashMap.getIfAbsentPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type1))("5")>, <(literal.(type2))("5")>);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -374,20 +379,20 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <name2>Function0 function = () -> <(literal.(type2))("5")>;
 
         hashMap.getIfAbsentPut(<(literal.(type1))("2")>, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type1))("5")>, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPut(<(literal.(type1))("2")>, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -402,20 +407,20 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <name2>Function\<<wrapperName2>\> function = <wrapperName2>::<type2>Value;
 
         hashMap.getIfAbsentPutWith(<(literal.(type1))("2")>, function, <wrapperName2>.valueOf(<(literal.(type2))("5")>));
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(<(literal.(type1))("5")>, function, <wrapperName2>.valueOf(<(literal.(type2))("5")>));
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWith(<(literal.(type1))("2")>, function, <wrapperName2>.valueOf(<(literal.(type2))("5")>)); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -427,32 +432,32 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = <name1><name2>HashMap.newWithKeysValues(<["2", "3", "4"]:keyValue(); separator=", ">);
 
-        Assert.assertEquals(2, hashMap.getAndPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, hashMap.getAndPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
-        Assert.assertEquals(50, hashMap.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(5, hashMap.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("5")>, <(literal.(type2))("70")>)<wideDelta.(type2)>);
+        assertEquals(50, hashMap.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(5, hashMap.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("5")>, <(literal.(type2))("70")>)<wideDelta.(type2)>);
 
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
-        Assert.assertEquals(50, hashMap.getAndPut(<(literal.(type1))("1")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(50, hashMap.getAndPut(<(literal.(type1))("1")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
-        Assert.assertEquals(5, hashMap.getAndPut(<(literal.(type1))("1")>, <(literal.(type2))("11")>, <(literal.(type2))("60")>)<wideDelta.(type2)>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(5, hashMap.getAndPut(<(literal.(type1))("1")>, <(literal.(type2))("11")>, <(literal.(type2))("60")>)<wideDelta.(type2)>);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.removeKey(<(literal.(type1))("2")>);
-        Assert.assertEquals(2, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(50, hashMap.getAndPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(2, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(50, hashMap.getAndPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>, <(literal.(type2))("50")>)<wideDelta.(type2)>);
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -467,20 +472,20 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <name1>To<name2>Function function = (<type1> <type1>Parameter) -> (<type2>) <type1>Parameter;
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type1))("2")>, function);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type1))("5")>, function);
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(3, occupiedWithData.get(hashMap));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(3, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
 
         hashMap.getIfAbsentPutWithKey(<(literal.(type1))("2")>, function); //putting in a slot marked REMOVED
-        Assert.assertEquals(4, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(4, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
 
     @Test
@@ -491,24 +496,24 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap();
-        Assert.assertEquals(0, occupiedWithData.get(hashMap));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(0, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
 
         for (int i = 2; i \< 10; i++)
         {
-            Assert.assertFalse(hashMap.containsKey(<(castFromInt.(type1))("i")>));
+            assertFalse(hashMap.containsKey(<(castFromInt.(type1))("i")>));
             hashMap.put(<(castFromInt.(type1))("i")>, <(castFromInt.(type2))("i")>);
-            Assert.assertEquals(i - 1, occupiedWithData.get(hashMap));
+            assertEquals(i - 1, occupiedWithData.get(hashMap));
         }
 
         hashMap.remove(<(literal.(type1))("2")>);
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(7, occupiedWithData.get(hashMap));
+        assertEquals(1, occupiedWithSentinels.get(hashMap));
+        assertEquals(7, occupiedWithData.get(hashMap));
 
         hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("3")>); //putting in a slot marked as REMOVED
 
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
-        Assert.assertEquals(8, occupiedWithData.get(hashMap));
+        assertEquals(0, occupiedWithSentinels.get(hashMap));
+        assertEquals(8, occupiedWithData.get(hashMap));
     }
 
     @Test
@@ -518,7 +523,7 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
 
         for (int i = 2; i \< 10; i++)
         {
-            Assert.assertFalse(copyMap.containsKey(<(castFromInt.(type1))("i")>));
+            assertFalse(copyMap.containsKey(<(castFromInt.(type1))("i")>));
             copyMap.put(<(castFromInt.(type1))("i")>, <(castFromInt.(type2))("i")>);
         }
 
@@ -530,11 +535,11 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
 
         for (int i = 2; i \< 10; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(<(castFromInt.(type1))("i")>));
-            Assert.assertTrue(hashMap.containsValue(<(castFromInt.(type2))("i")>));
+            assertTrue(hashMap.containsKey(<(castFromInt.(type1))("i")>));
+            assertTrue(hashMap.containsValue(<(castFromInt.(type2))("i")>));
         }
 
-        Assert.assertEquals(copyMap, hashMap);
+        assertEquals(copyMap, hashMap);
     }
 
     @Override
@@ -543,12 +548,12 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
     {
         super.withKeysValues();
         <name1><name2>HashMap hashMap0 = new <name1><name2>HashMap();
-        Assert.assertSame(hashMap0.withKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), hashMap0);
+        assertSame(hashMap0.withKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), hashMap0);
         <name1><name2>HashMap hashMap1 = new <name1><name2>HashMap().withKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>);
         <name1><name2>HashMap hashMap2 = new <name1><name2>HashMap().withKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>, <(literal.(type1))("4")>, <(literal.(type2))("4")>);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), hashMap0);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), hashMap1);
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>, <(literal.(type1))("4")>, <(literal.(type2))("4")>), hashMap2);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>), hashMap0);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>), hashMap1);
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("2")>, <(literal.(type1))("3")>, <(literal.(type2))("3")>, <(literal.(type1))("4")>, <(literal.(type2))("4")>), hashMap2);
     }
 
     @Test
@@ -556,7 +561,7 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
     {
         <name1><name2>HashMap hashMap = new <name1><name2>HashMap().withKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
         <wrapperName2> sum = hashMap.injectInto(<wrapperName2>.valueOf(<(literal.(type2))("1")>), (<wrapperName2> result, <type2> value) -> <wrapperName2>.valueOf((<type2>) (result + value)));
-        Assert.assertEquals(<wrapperName2>.valueOf(<(literal.(type2))("15")>), sum);
+        assertEquals(<wrapperName2>.valueOf(<(literal.(type2))("15")>), sum);
     }
 
     @Test
@@ -568,9 +573,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
 
         for (int i = 2; i \< 100; i++)
         {
-            Assert.assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
-            Assert.assertEquals(<(wideLiteral.(type2))("1")>, hashMap.updateValue(<(castFromInt.(type1))("i")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
-            Assert.assertEquals(<(literal.(type2))("1")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
+            assertEquals(<(literal.(type2))("0")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
+            assertEquals(<(wideLiteral.(type2))("1")>, hashMap.updateValue(<(castFromInt.(type1))("i")>, <(literal.(type2))("0")>, incrementFunction)<(wideDelta.(type2))>);
+            assertEquals(<(literal.(type2))("1")>, hashMap.get(<(castFromInt.(type1))("i")>)<(wideDelta.(type2))>);
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
@@ -40,8 +40,12 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 <if(primitive2.floatOrDoublePrimitive)><if(primitive1.byteOrShortOrCharPrimitive)>import org.eclipse.collections.impl.list.Interval;<endif><endif>
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap#values()}.
@@ -87,27 +91,27 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
         <name2>Iterator iterator = bag.<type2>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
     <if(primitive2.floatingPoint)><NaNTests()><endif>
@@ -115,35 +119,35 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type2))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type2))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name2>ArrayList()));
     }
 
     @Override
@@ -152,13 +156,13 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertTrue(collection.remove(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.remove(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
     }
 
     @Override
@@ -167,14 +171,14 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertTrue(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
+        assertTrue(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
     }
 
     <if(primitive2.floatPrimitive)><(sumMethodFloat.(type1))()>
@@ -186,7 +190,7 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         Mutable<name2>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Synchronized<name2>Collection.class, collection.asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -195,201 +199,201 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         Mutable<name2>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name2>Collection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(<(literal.(type2))("1")>));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(<(literal.(type2))("1")>));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.removeAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
 
         map = <name1><name2>HashMap.newWithKeysValues(<["0", "2", "3"]:keyValue(); separator=", ">);
         collection = map.values();
-        Assert.assertTrue(collection.removeAll(<(literal.(type2))("0")>, <(literal.(type2))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.removeAll(<(literal.(type2))("0")>, <(literal.(type2))("5")>));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new <name2>ArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
+        assertFalse(this.newWith().removeAll(new <name2>ArrayList()));
+        assertFalse(this.newWith().removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(<(literal.(type2))("1")>));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(<(literal.(type2))("1")>));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>));
+        assertTrue(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertTrue(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("3")>, <(literal.(type2))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<(literal.(type2))("3")>, <(literal.(type2))("5")>));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("0")>, <(literal.(type2))("1")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<(literal.(type2))("0")>, <(literal.(type2))("0")>, <(literal.(type2))("1")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new <name2>ArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
+        assertFalse(this.newWith().retainAll(new <name2>ArrayList()));
+        assertFalse(this.newWith().retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>)));
+        assertFalse(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>)));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>)));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>)));
+        assertTrue(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertTrue(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("2")>, <(literal.(type2))("3")>, <(literal.(type2))("5")>)));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("5")>)));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("0")>, <(literal.(type2))("1")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("5")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("5")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("0")>, <(literal.(type2))("1")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("5")>));
+        assertFalse(map.contains(<(literal.(type2))("0")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("5")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
@@ -406,19 +410,19 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
 
         Mutable<name2>Collection collection1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type2))(); separator=", ">);
         collection1.clear();
         Verify.assertEmpty(collection1);
         Verify.assertSize(0, collection1);
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("31")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("32")>));
+        assertFalse(collection1.contains(<(literal.(type2))("0")>));
+        assertFalse(collection1.contains(<(literal.(type2))("1")>));
+        assertFalse(collection1.contains(<(literal.(type2))("31")>));
+        assertFalse(collection1.contains(<(literal.(type2))("32")>));
 
         Mutable<name2>Collection collection2 = this.newWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">);
         collection2.clear();
@@ -430,19 +434,19 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     public void contains()
     {
         Mutable<name2>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
 
         <type2>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">};
         for (<type2> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
-            Assert.assertTrue(collection.remove(number));
-            Assert.assertFalse(collection.contains(number));
+            assertTrue(collection.contains(number));
+            assertTrue(collection.remove(number));
+            assertFalse(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
     }
 
     @Override
@@ -468,60 +472,60 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     public void collect()
     {
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
@@ -533,63 +537,63 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -623,7 +627,7 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -631,7 +635,7 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name2>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["3"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked)
@@ -642,16 +646,16 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -697,7 +701,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -717,7 +721,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map#keySet()}.
@@ -50,14 +55,14 @@ public class SynchronizedObject<name>MapKeySetTest
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>)
                     .keySet().addAll(FastList.newListWith("Four")));
     }
@@ -67,15 +72,15 @@ public class SynchronizedObject<name>MapKeySetTest
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.contains("One"));
-        Assert.assertTrue(keySet.contains("Two"));
-        Assert.assertTrue(keySet.contains("Three"));
-        Assert.assertFalse(keySet.contains("Four"));
-        Assert.assertTrue(keySet.contains(null));
+        assertTrue(keySet.contains("One"));
+        assertTrue(keySet.contains("Two"));
+        assertTrue(keySet.contains("Three"));
+        assertFalse(keySet.contains("Four"));
+        assertTrue(keySet.contains(null));
         keySet.remove(null);
-        Assert.assertFalse(keySet.contains(null));
+        assertFalse(keySet.contains(null));
         map.removeKey("One");
-        Assert.assertFalse(keySet.contains("One"));
+        assertFalse(keySet.contains("One"));
     }
 
     @Test
@@ -83,17 +88,17 @@ public class SynchronizedObject<name>MapKeySetTest
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
+        assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
         keySet.remove(null);
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
         map.removeKey("One");
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
     }
 
     @Test
@@ -101,12 +106,12 @@ public class SynchronizedObject<name>MapKeySetTest
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         Object<name>HashMap\<String> map1 = Object<name>HashMap.newMap();
         Set\<String> keySet1 = map1.keySet();
-        Assert.assertTrue(keySet1.isEmpty());
+        assertTrue(keySet1.isEmpty());
         map1.put("One", <(literal.(type))("1")>);
-        Assert.assertFalse(keySet1.isEmpty());
+        assertFalse(keySet1.isEmpty());
     }
 
     @Test
@@ -136,28 +141,28 @@ public class SynchronizedObject<name>MapKeySetTest
 
         HashBag\<String> expected = HashBag.newBagWith("One", "Two", "Three", null);
         HashBag\<String> actual = HashBag.newBag();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
 
         Iterator\<String> iterator1 = keySet.iterator();
         for (int i = 4; i > 0; i--)
         {
-            Assert.assertTrue(iterator1.hasNext());
+            assertTrue(iterator1.hasNext());
             iterator1.next();
             iterator1.remove();
-            Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+            assertThrows(IllegalStateException.class, iterator1::remove);
             Verify.assertSize(i - 1, keySet);
             Verify.assertSize(i - 1, map);
         }
 
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
         Verify.assertEmpty(map);
         Verify.assertEmpty(keySet);
     }
@@ -166,50 +171,50 @@ public class SynchronizedObject<name>MapKeySetTest
     public void removeFromKeySet()
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().remove("Four"));
+        assertFalse(map.keySet().remove("Four"));
 
-        Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().remove("Two"));
+        assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void removeNullFromKeySet()
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().remove(null));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().remove(null));
+        assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         map.put(null, <(literal.(type))("4")>);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertTrue(map.keySet().remove(null));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
+        assertTrue(map.keySet().remove(null));
+        assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
     }
 
     @Test
     public void removeAllFromKeySet()
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
+        assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void retainAllFromKeySet()
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
-        Assert.assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
+        assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
@@ -226,8 +231,8 @@ public class SynchronizedObject<name>MapKeySetTest
     {
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("0")>);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
-        Assert.assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
     }
 
     @Test
@@ -236,11 +241,11 @@ public class SynchronizedObject<name>MapKeySetTest
         SynchronizedObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
         HashBag\<String> expected = HashBag.newBagWith("One", "Two", "Three");
         Set\<String> keySet = map.keySet();
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapTest.stg
@@ -20,8 +20,8 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map}.
@@ -72,7 +72,7 @@ public class SynchronizedObject<name>MapTest extends AbstractMutableObject<name>
     public void asSynchronized()
     {
         super.asSynchronized();
-        Assert.assertSame(this.map, this.map.asSynchronized());
+        assertSame(this.map, this.map.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
@@ -37,8 +37,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map#values()}.
@@ -84,27 +89,27 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         <name>Iterator iterator = bag.<type>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -112,21 +117,21 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -135,10 +140,10 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Collection collection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Collection collectionWithout = collection.without(<(literal.(type))("2")>);
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         Mutable<name>Collection expectedCollection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -147,9 +152,9 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Collection collection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Collection collectionWithout = collection.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         Mutable<name>Collection expectedCollection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -158,13 +163,13 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertTrue(collection.remove(<(literal.(type))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(collection.remove(<(literal.(type))("3")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
     }
 
     @Override
@@ -173,134 +178,134 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
+        assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(<(literal.(type))("1")>));
 
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.removeAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new <name>ArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertFalse(this.newWith().removeAll(new <name>ArrayList()));
+        assertFalse(this.newWith().removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
 
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertTrue(collection.contains(<(literal.(type))("2")>));
+        assertTrue(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertTrue(map.contains(<(literal.(type))("2")>));
+        assertTrue(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(<(literal.(type))("1")>));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(<(literal.(type))("1")>));
 
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("5")>));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<(literal.(type))("3")>, <(literal.(type))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new <name>ArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
+        assertFalse(this.newWith().retainAll(new <name>ArrayList()));
+        assertFalse(this.newWith().retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>)));
 
         Object<name>HashMap\<Integer> map = Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
-        Assert.assertTrue(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("1")>, <(literal.(type))("5")>)));
+        assertTrue(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertTrue(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(map.contains(<(literal.(type))("1")>));
+        assertFalse(map.contains(<(literal.(type))("2")>));
+        assertFalse(map.contains(<(literal.(type))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
@@ -317,19 +322,19 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("3")>));
+        assertFalse(collection.contains(<(literal.(type))("0")>));
+        assertFalse(collection.contains(<(literal.(type))("1")>));
+        assertFalse(collection.contains(<(literal.(type))("2")>));
+        assertFalse(collection.contains(<(literal.(type))("3")>));
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         collection1.clear();
         Verify.assertEmpty(collection1);
         Verify.assertSize(0, collection1);
-        Assert.assertFalse(collection1.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("31")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type))("32")>));
+        assertFalse(collection1.contains(<(literal.(type))("0")>));
+        assertFalse(collection1.contains(<(literal.(type))("1")>));
+        assertFalse(collection1.contains(<(literal.(type))("31")>));
+        assertFalse(collection1.contains(<(literal.(type))("32")>));
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">);
         collection2.clear();
@@ -341,19 +346,19 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     public void contains()
     {
         Mutable<name>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
-            Assert.assertTrue(collection.remove(number));
-            Assert.assertFalse(collection.contains(number));
+            assertTrue(collection.contains(number));
+            assertTrue(collection.remove(number));
+            assertFalse(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
     }
 
     @Override
@@ -379,60 +384,60 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = (<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
@@ -444,63 +449,63 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -510,7 +515,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Synchronized<name>Collection.class, this.classUnderTest().asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -519,7 +524,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name>Collection.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -551,7 +556,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -559,7 +564,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -570,16 +575,16 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
                         <name>Bags.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
@@ -29,8 +29,14 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap#keySet()}.
@@ -60,14 +66,14 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -75,21 +81,21 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -98,10 +104,10 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Set setWithout = set.without(<(literal.(type))("2")>);
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -110,15 +116,15 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Set setWithout = set.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Test
     public void freeze()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
@@ -134,7 +140,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -142,7 +148,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -150,7 +156,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -159,8 +165,8 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -168,7 +174,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -176,7 +182,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -187,16 +193,16 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -207,14 +213,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -222,7 +228,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapTest.stg
@@ -20,8 +20,8 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap}.
@@ -71,7 +71,7 @@ public class Synchronized<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         super.asSynchronized();
         Synchronized<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertSame(map1, map1.asSynchronized());
+        assertSame(map1, map1.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
@@ -33,8 +33,13 @@ import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBoo
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap#values()}.
@@ -75,7 +80,7 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
@@ -83,28 +88,28 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
@@ -114,9 +119,9 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         MutableBooleanCollection collection = this.newWith(true, true, false);
         MutableBooleanCollection collectionWithout = collection.without(false);
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         MutableBooleanCollection expectedCollection = this.newWith(true, true);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -125,9 +130,9 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         MutableBooleanCollection collection = this.newWith(true, true, false);
         MutableBooleanCollection collectionWithout = collection.withoutAll(new BooleanArrayList(false));
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         MutableBooleanCollection expectedCollection = this.newWith(true, true);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -136,11 +141,11 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.remove(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
     }
 
     @Override
@@ -148,15 +153,15 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void containsAllArray()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll());
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
+        assertTrue(emptyCollection.containsAll());
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll());
-        Assert.assertTrue(classUnderTest.containsAll(true));
-        Assert.assertTrue(classUnderTest.containsAll(false));
-        Assert.assertTrue(classUnderTest.containsAll(false, true));
+        assertTrue(classUnderTest.containsAll());
+        assertTrue(classUnderTest.containsAll(true));
+        assertTrue(classUnderTest.containsAll(false));
+        assertTrue(classUnderTest.containsAll(false, true));
     }
 
     @Override
@@ -165,7 +170,7 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(SynchronizedBooleanCollection.class, collection.asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -174,7 +179,7 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(UnmodifiableBooleanCollection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -182,135 +187,135 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void containsAllIterable()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(true));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(true));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.removeAll(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.removeAll(true));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.removeAll(false, true));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.removeAll(false, true));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new BooleanArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.newWith().removeAll(new BooleanArrayList()));
+        assertFalse(this.newWith().removeAll(BooleanArrayList.newListWith(true)));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.removeAll(BooleanArrayList.newListWith(false, true)));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.removeAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(true));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(true));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.retainAll(false));
-        Assert.assertTrue(collection.contains(false));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertTrue(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(false));
+        assertTrue(collection.contains(false));
+        assertFalse(collection.contains(true));
+        assertTrue(map.contains(false));
+        assertFalse(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(true));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll());
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.retainAll());
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new BooleanArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.newWith().retainAll(new BooleanArrayList()));
+        assertFalse(this.newWith().retainAll(BooleanArrayList.newListWith(true)));
 
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.contains(false));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertTrue(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.contains(false));
+        assertFalse(collection.contains(true));
+        assertTrue(map.contains(false));
+        assertFalse(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertFalse(map.contains(true));
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertFalse(map.contains(true));
 
         <name>BooleanHashMap map1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll(BooleanArrayList.newListWith()));
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertFalse(map1.contains(true));
+        assertTrue(collection1.retainAll(BooleanArrayList.newListWith()));
+        assertFalse(collection1.contains(false));
+        assertFalse(collection1.contains(true));
+        assertFalse(map1.contains(false));
+        assertFalse(map1.contains(true));
     }
 
     @Override
@@ -327,10 +332,10 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
     }
 
     @Override
@@ -338,13 +343,13 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void contains()
     {
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.contains(true));
-        Assert.assertFalse(emptyCollection.contains(false));
+        assertFalse(emptyCollection.contains(true));
+        assertFalse(emptyCollection.contains(false));
         BooleanIterable booleanIterable = this.classUnderTest();
-        Assert.assertTrue(booleanIterable.contains(true));
-        Assert.assertTrue(booleanIterable.contains(false));
-        Assert.assertFalse(this.newWith(true, true, true).contains(false));
-        Assert.assertFalse(this.newWith(false, false, false).contains(true));
+        assertTrue(booleanIterable.contains(true));
+        assertTrue(booleanIterable.contains(false));
+        assertFalse(this.newWith(true, true, true).contains(false));
+        assertFalse(this.newWith(false, false, false).contains(true));
     }
 
     @Override
@@ -370,8 +375,8 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void collect()
     {
         BooleanToObjectFunction\<Integer> function = (boolean parameter) -> parameter ? 1 : 0;
-        Assert.assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
     }
 
     @Override
@@ -380,22 +385,22 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", "/", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true).appendString(appendable1);
-        Assert.assertEquals("true", appendable1.toString());
+        assertEquals("true", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
         BooleanIterable iterable = this.newWith(true, false);
         iterable.appendString(appendable2);
-        Assert.assertTrue("true, false".equals(appendable2.toString())
+        assertTrue("true, false".equals(appendable2.toString())
                 || "false, true".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("true/false".equals(appendable3.toString())
+        assertTrue("true/false".equals(appendable3.toString())
                 || "false/true".equals(appendable3.toString()));
     }
 
@@ -425,8 +430,8 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
                 Lists.mutable.with(BooleanBags.mutable.with(false, true)),
                 iterable3.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
@@ -25,8 +25,13 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap#keySet()}.
@@ -56,14 +61,14 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -71,7 +76,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
@@ -79,14 +84,14 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -95,10 +100,10 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Set setWithout = set.without(<(literal.(type))("2")>);
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -107,9 +112,9 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set = this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>, <(literal.(type))("3")>);
         Mutable<name>Set setWithout = set.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Override
@@ -125,7 +130,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -133,7 +138,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -141,7 +146,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -149,8 +154,8 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 }
 
@@ -161,14 +166,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -176,7 +181,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapTest.stg
@@ -19,8 +19,8 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap}.
@@ -65,7 +65,7 @@ public class Synchronized<name>ObjectMapTest extends AbstractMutable<name>Object
     public void asSynchronized()
     {
         super.asSynchronized();
-        Assert.assertSame(this.map, this.map.asSynchronized());
+        assertSame(this.map, this.map.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
@@ -30,8 +30,12 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap#values()}.
@@ -58,14 +62,14 @@ public class Synchronized<name>ObjectMapValuesTest
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
                     .values().addAll(FastList.newListWith(4)));
     }
@@ -84,14 +88,14 @@ public class Synchronized<name>ObjectMapValuesTest
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.contains(1));
-        Assert.assertTrue(values.contains(2));
-        Assert.assertTrue(values.contains(null));
-        Assert.assertFalse(values.contains(4));
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(2));
+        assertTrue(values.contains(null));
+        assertFalse(values.contains(4));
         values.remove(null);
-        Assert.assertFalse(values.contains(null));
+        assertFalse(values.contains(null));
         map.removeKey(<(literal.(type))("1")>);
-        Assert.assertFalse(values.contains(1));
+        assertFalse(values.contains(1));
     }
 
     @Test
@@ -99,17 +103,17 @@ public class Synchronized<name>ObjectMapValuesTest
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 4)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(5, 4)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(null, null)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 4)));
+        assertFalse(values.containsAll(FastList.newListWith(5, 4)));
         values.remove(null);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
         map.removeKey(<(literal.(type))("1")>);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(2)));
     }
 
     @Test
@@ -117,12 +121,12 @@ public class Synchronized<name>ObjectMapValuesTest
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("1")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertFalse(values.isEmpty());
+        assertFalse(values.isEmpty());
         <name>ObjectHashMap\<Integer> map1 = <name>ObjectHashMap.newMap();
         Collection\<Integer> values1 = map1.values();
-        Assert.assertTrue(values1.isEmpty());
+        assertTrue(values1.isEmpty());
         map1.put(<(literal.(type))("1")>, 1);
-        Assert.assertFalse(values1.isEmpty());
+        assertFalse(values1.isEmpty());
     }
 
     @Test
@@ -150,50 +154,50 @@ public class Synchronized<name>ObjectMapValuesTest
         MutableSet\<String> actual = UnifiedSet.newSet();
 
         Iterator\<String> iterator = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, null).iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
 
         Mutable<name>ObjectMap\<String> map1 = this.newMapWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, null);
         Iterator\<String> iterator1 = map1.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        Assert.assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1));
         iterator1.next();
         iterator1.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map1);
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertEquals(<name>ObjectHashMap.newMap(), map1);
+        assertThrows(IllegalStateException.class, iterator1::remove);
 
         Mutable<name>ObjectMap\<String> map2 = this.newMapWithKeysValues(<(literal.(type))("0")>, null, <(literal.(type))("9")>, "nine");
         Iterator\<String> iterator2 = map2.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator2::remove);
+        assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        Assert.assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
+        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
         iterator2.next();
         iterator2.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map2);
+        assertEquals(<name>ObjectHashMap.newMap(), map2);
 
         Mutable<name>ObjectMap\<String> map3 = this.newMapWithKeysValues(<(literal.(type))("8")>, "eight", <(literal.(type))("9")>, null);
         Iterator\<String> iterator3 = map3.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator3::remove);
+        assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        Assert.assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
                 || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3));
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(<name>ObjectHashMap.newMap(), map3);
+        assertEquals(<name>ObjectHashMap.newMap(), map3);
     }
 
     @Test
@@ -207,41 +211,41 @@ public class Synchronized<name>ObjectMapValuesTest
     public void removeFromValues()
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().remove(4));
+        assertFalse(map.values().remove(4));
 
-        Assert.assertTrue(map.values().remove(2));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().remove(2));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void removeNullFromValues()
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().remove(null));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
+        assertFalse(map.values().remove(null));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
         map.put(<(literal.(type))("4")>, null);
-        Assert.assertTrue(map.values().remove(null));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().remove(null));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void removeAllFromValues()
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().removeAll(FastList.newListWith(4)));
+        assertFalse(map.values().removeAll(FastList.newListWith(4)));
 
-        Assert.assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
     public void retainAllFromValues()
     {
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3);
-        Assert.assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
+        assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
 
-        Assert.assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
+        assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("3")>, 3), map);
     }
 
     @Test
@@ -250,11 +254,11 @@ public class Synchronized<name>ObjectMapValuesTest
         Synchronized<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         HashBag\<Integer> expected = HashBag.newBagWith(1, 2, null);
         Collection\<Integer> values = map.values();
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray()));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
@@ -27,8 +27,13 @@ import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#keySet()}.
@@ -58,14 +63,14 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
@@ -73,21 +78,21 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
@@ -96,10 +101,10 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     {
         Mutable<name1>Set set = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("2")>, <(literal.(type1))("3")>);
         Mutable<name1>Set setWithout = set.without(<(literal.(type1))("2")>);
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name1>Set expectedSet = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type1))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type1))("4")>).toList());
     }
 
     @Override
@@ -108,9 +113,9 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     {
         Mutable<name1>Set set = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("2")>, <(literal.(type1))("3")>);
         Mutable<name1>Set setWithout = set.withoutAll(new <name1>ArrayList(<(literal.(type1))("2")>, <(literal.(type1))("4")>));
-        Assert.assertSame(set, setWithout);
+        assertSame(set, setWithout);
         Mutable<name1>Set expectedSet = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Override
@@ -126,7 +131,7 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -134,7 +139,7 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
     }
 
     @Override
@@ -142,7 +147,7 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     @Override
@@ -150,8 +155,8 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 }
 
@@ -166,14 +171,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
@@ -181,7 +186,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapTest.stg
@@ -22,8 +22,8 @@ body(type1, type2, name1, name2) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map}.
@@ -74,7 +74,7 @@ public class Synchronized<name1><name2>MapTest extends AbstractMutable<name1><na
     public void asSynchronized()
     {
         super.asSynchronized();
-        Assert.assertSame(this.map, this.map.asSynchronized());
+        assertSame(this.map, this.map.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
@@ -40,8 +40,13 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 <if(primitive2.floatOrDoublePrimitive)><if(primitive1.byteOrShortOrCharPrimitive)>import org.eclipse.collections.impl.list.Interval;<endif><endif>
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#values()}.
@@ -87,27 +92,27 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
         <name2>Iterator iterator = bag.<type2>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
     <if(primitive2.floatingPoint)><NaNTests()><endif>
@@ -115,21 +120,21 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
     @Override
@@ -138,10 +143,10 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection collection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>);
         Mutable<name2>Collection collectionWithout = collection.without(<(literal.(type2))("2")>);
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         Mutable<name2>Collection expectedCollection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type2))("4")>).toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type2))("4")>).toList());
     }
 
     @Override
@@ -150,9 +155,9 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection collection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>);
         Mutable<name2>Collection collectionWithout = collection.withoutAll(new <name2>ArrayList(<(literal.(type2))("2")>, <(literal.(type2))("4")>));
-        Assert.assertSame(collection, collectionWithout);
+        assertSame(collection, collectionWithout);
         Mutable<name2>Collection expectedCollection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -161,13 +166,13 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertTrue(collection.remove(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.remove(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
     }
 
     @Override
@@ -176,14 +181,14 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertTrue(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
+        assertTrue(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.removeIf(<name2>Predicates.equal(<(literal.(type2))("3")>)));
     }
 
     <if(primitive2.floatPrimitive)><(sumMethodFloat.(type1))()>
@@ -195,7 +200,7 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Synchronized<name2>Collection.class, collection.asSynchronized());
-        Assert.assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
+        assertTrue(collection.asSynchronized().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -204,127 +209,127 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name2>Collection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
-        Assert.assertFalse(this.newWith().removeAll(<(literal.(type2))("1")>));
+        assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll(<(literal.(type2))("1")>));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.removeAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new <name2>ArrayList()));
-        Assert.assertFalse(this.newWith().removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
+        assertFalse(this.newWith().removeAll(new <name2>ArrayList()));
+        assertFalse(this.newWith().removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertTrue(collection.contains(<(literal.(type2))("2")>));
+        assertTrue(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertTrue(map.contains(<(literal.(type2))("2")>));
+        assertTrue(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
-        Assert.assertFalse(this.newWith().retainAll(<(literal.(type2))("1")>));
+        assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll(<(literal.(type2))("1")>));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("5")>));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<(literal.(type2))("3")>, <(literal.(type2))("2")>));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new <name2>ArrayList()));
-        Assert.assertFalse(this.newWith().retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
+        assertFalse(this.newWith().retainAll(new <name2>ArrayList()));
+        assertFalse(this.newWith().retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>)));
 
         <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
         Mutable<name2>Collection collection = map.values();
-        Assert.assertFalse(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
+        assertFalse(collection.retainAll(<(literal.(type2))("1")>, <(literal.(type2))("2")>, <(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("5")>)));
+        assertTrue(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertTrue(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
 
-        Assert.assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(<name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(map.contains(<(literal.(type2))("1")>));
+        assertFalse(map.contains(<(literal.(type2))("2")>));
+        assertFalse(map.contains(<(literal.(type2))("3")>));
+        assertTrue(map.isEmpty());
     }
 
     @Override
@@ -341,19 +346,19 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
+        assertFalse(collection.contains(<(literal.(type2))("0")>));
+        assertFalse(collection.contains(<(literal.(type2))("1")>));
+        assertFalse(collection.contains(<(literal.(type2))("2")>));
+        assertFalse(collection.contains(<(literal.(type2))("3")>));
 
         Mutable<name2>Collection collection1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type2))(); separator=", ">);
         collection1.clear();
         Verify.assertEmpty(collection1);
         Verify.assertSize(0, collection1);
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("0")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("1")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("31")>));
-        Assert.assertFalse(collection1.contains(<(literal.(type2))("32")>));
+        assertFalse(collection1.contains(<(literal.(type2))("0")>));
+        assertFalse(collection1.contains(<(literal.(type2))("1")>));
+        assertFalse(collection1.contains(<(literal.(type2))("31")>));
+        assertFalse(collection1.contains(<(literal.(type2))("32")>));
 
         Mutable<name2>Collection collection2 = this.newWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">);
         collection2.clear();
@@ -365,19 +370,19 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void contains()
     {
         Mutable<name2>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
 
         <type2>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">};
         for (<type2> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
-            Assert.assertTrue(collection.remove(number));
-            Assert.assertFalse(collection.contains(number));
+            assertTrue(collection.contains(number));
+            assertTrue(collection.remove(number));
+            assertFalse(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
     }
 
     @Override
@@ -403,60 +408,60 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void collect()
     {
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
@@ -468,63 +473,63 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -558,7 +563,7 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -567,7 +572,7 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         MutableSet\<<name2>Iterable> chunked = iterable.chunk(2).toSet();
 
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["3"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked)
@@ -578,16 +583,16 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -633,7 +638,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -653,7 +658,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map#keySet()}.
@@ -50,14 +55,14 @@ public class UnmodifiableObject<name>MapKeySetTest
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>)
                     .keySet().addAll(FastList.newListWith("Four")));
     }
@@ -67,11 +72,11 @@ public class UnmodifiableObject<name>MapKeySetTest
     {
         UnmodifiableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.contains("One"));
-        Assert.assertTrue(keySet.contains("Two"));
-        Assert.assertTrue(keySet.contains("Three"));
-        Assert.assertFalse(keySet.contains("Four"));
-        Assert.assertTrue(keySet.contains(null));
+        assertTrue(keySet.contains("One"));
+        assertTrue(keySet.contains("Two"));
+        assertTrue(keySet.contains("Three"));
+        assertFalse(keySet.contains("Four"));
+        assertTrue(keySet.contains(null));
     }
 
     @Test
@@ -79,11 +84,11 @@ public class UnmodifiableObject<name>MapKeySetTest
     {
         UnmodifiableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
+        assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
     }
 
     @Test
@@ -91,12 +96,12 @@ public class UnmodifiableObject<name>MapKeySetTest
     {
         UnmodifiableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("4")>);
         Set\<String> keySet = map.keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         Object<name>HashMap\<String> map1 = Object<name>HashMap.newMap();
         Set\<String> keySet1 = map1.keySet();
-        Assert.assertTrue(keySet1.isEmpty());
+        assertTrue(keySet1.isEmpty());
         map1.put("One", <(literal.(type))("1")>);
-        Assert.assertFalse(keySet1.isEmpty());
+        assertFalse(keySet1.isEmpty());
     }
 
     @Test
@@ -118,12 +123,12 @@ public class UnmodifiableObject<name>MapKeySetTest
         HashBag\<String> actual = HashBag.newBag();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -131,8 +136,8 @@ public class UnmodifiableObject<name>MapKeySetTest
     {
         UnmodifiableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>, null, <(literal.(type))("0")>);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
-        Assert.assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
     }
 
     @Test
@@ -141,11 +146,11 @@ public class UnmodifiableObject<name>MapKeySetTest
         UnmodifiableObject<name>Map\<String> map = this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>);
         HashBag\<String> expected = HashBag.newBagWith("One", "Two", "Three");
         Set\<String> keySet = map.keySet();
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.factory.Iterables;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map}.
@@ -80,70 +85,70 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.map, this.map.asUnmodifiable());
+        assertSame(this.map, this.map.asUnmodifiable());
     }
 
     @Override
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
     @Test
     public void removeKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey("0"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey("0"));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove("0"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.remove("0"));
     }
 
     @Override
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put("0", <(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.put("0", <(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void putPair()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair("0", <(literal.(type))("1")>)));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair("0", <(literal.(type))("1")>)));
     }
 
     @Override
     @Test
     public void updateValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
     }
 
     @Override
     @Test
     public void withKeysValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue("1", <(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue("1", <(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withoutKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey("0"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey("0"));
     }
 
     @Override
     @Test
     public void withoutAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.withoutAllKeys(FastList.newListWith("0", "1")));
     }
 
@@ -151,7 +156,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     @Test
     public void withAllKeyValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair("1", <(literal.(type))("1")>))));
     }
 
@@ -160,48 +165,48 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     public void putDuplicateWithRemovedSlot()
     {
         String collision1 = AbstractMutableObject<name>MapTestCase.generateCollisions().getFirst();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, <(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, <(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.get("0")<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.map.get("1")<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, this.map.get("2")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.get("0")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.map.get("1")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("2")>, this.map.get("2")<delta.(type)>);
 
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.get("5")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.get("5")<delta.(type)>);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.map.getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, this.map.getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, this.map.getIfAbsent("3", <(literal.(type))("4")>)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsent("0", <(literal.(type))("1")>)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.map.getIfAbsent("1", <(literal.(type))("2")>)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("2")>, this.map.getIfAbsent("2", <(literal.(type))("3")>)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("4")>, this.map.getIfAbsent("3", <(literal.(type))("4")>)<delta.(type)>);
     }
 
     @Override
     @Test
     public void getIfAbsentPut_Value()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", <(literal.(type))("100")>)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", <(literal.(type))("100")>)<delta.(type)>);
     }
 
     @Test
     public void getIfAbsentPut_ValueThrowsException()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", <(literal.(type))("100")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", <(literal.(type))("100")>));
     }
 
     @Override
     @Test
     public void getAndPut()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut("10", <(literal.(type))("200")>, <(literal.(type))("100")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut("10", <(literal.(type))("200")>, <(literal.(type))("100")>));
     }
 
     @Override
@@ -210,7 +215,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function0 factory = () -> <(literal.(type))("100")>;
 
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", factory)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", factory)<delta.(type)>);
     }
 
     @Test
@@ -218,7 +223,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function0 factory = () -> { throw new AssertionError(); };
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", factory));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", factory));
     }
 
     @Override
@@ -227,7 +232,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function\<String> functionLength = (String string) -> <(castIntToNarrowType.(type))("string.length()")>;
 
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPutWith("0", functionLength, "123456789")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPutWith("0", functionLength, "123456789")<delta.(type)>);
     }
 
     @Test
@@ -235,7 +240,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function\<String> functionLength = (String string) -> { throw new AssertionError(); };
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.getIfAbsentPutWith("10", functionLength, "123456789"));
     }
 
@@ -245,7 +250,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function\<Integer> function = (Integer anObject) -> anObject == null ? <(literal.(type))("32")> : <(castIntToNarrowType.(type))("anObject.intValue()")>;
 
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWithKeysValues(0, <(literal.(type))("0")>).getIfAbsentPutWithKey(0, function)<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWithKeysValues(0, <(literal.(type))("0")>).getIfAbsentPutWithKey(0, function)<delta.(type)>);
     }
 
     @Test
@@ -253,7 +258,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     {
         <name>Function\<Integer> function = (Integer anObject) -> { throw new AssertionError(); };
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.\<Integer>getEmptyMap().getIfAbsentPutWithKey(10, function));
     }
 
@@ -261,7 +266,7 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     @Test
     public void addToValue()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.\<Integer>getEmptyMap().addToValue(10, <(literal.(type))("2")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.\<Integer>getEmptyMap().addToValue(10, <(literal.(type))("2")>));
     }
 
     @Override
@@ -271,53 +276,53 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
         <name>To<name>Function incrementFunction = (<type> value) -> { throw new AssertionError(); };
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map1.updateValue(0, <(literal.(type))("0")>, incrementFunction));
+        assertThrows(UnsupportedOperationException.class, () -> map1.updateValue(0, <(literal.(type))("0")>, incrementFunction));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getOrThrow("0")<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.map.getOrThrow("1")<delta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, this.map.getOrThrow("2")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.map.getOrThrow("0")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.map.getOrThrow("1")<delta.(type)>);
+        assertEquals(<(wideLiteral.(type))("2")>, this.map.getOrThrow("2")<delta.(type)>);
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type))("2")>));
+        assertTrue(this.map.contains(<(literal.(type))("0")>));
+        assertTrue(this.map.contains(<(literal.(type))("1")>));
+        assertTrue(this.map.contains(<(literal.(type))("2")>));
 
-        Assert.assertFalse(this.getEmptyMap().contains(<(literal.(type))("0")>));
-        Assert.assertFalse(this.newWithKeysValues("0", <(literal.(type))("0")>).contains(<(literal.(type))("1")>));
+        assertFalse(this.getEmptyMap().contains(<(literal.(type))("0")>));
+        assertFalse(this.newWithKeysValues("0", <(literal.(type))("0")>).contains(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey("0"));
-        Assert.assertTrue(this.map.containsKey("1"));
-        Assert.assertTrue(this.map.containsKey("2"));
-        Assert.assertFalse(this.map.containsKey("3"));
-        Assert.assertFalse(this.map.containsKey(null));
+        assertTrue(this.map.containsKey("0"));
+        assertTrue(this.map.containsKey("1"));
+        assertTrue(this.map.containsKey("2"));
+        assertFalse(this.map.containsKey("3"));
+        assertFalse(this.map.containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("0")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("1")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type))("2")>));
-        Assert.assertFalse(this.getEmptyMap().contains(<(literal.(type))("2")>));
-        Assert.assertFalse(this.newWithKeysValues("0", <(literal.(type))("1")>).contains(<(literal.(type))("2")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("0")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("1")>));
+        assertTrue(this.map.containsValue(<(literal.(type))("2")>));
+        assertFalse(this.getEmptyMap().contains(<(literal.(type))("2")>));
+        assertFalse(this.newWithKeysValues("0", <(literal.(type))("1")>).contains(<(literal.(type))("2")>));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
@@ -38,8 +38,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<na
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map#values()}.
@@ -85,27 +89,27 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
         <name>Iterator iterator = bag.<type>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()>
@@ -114,21 +118,21 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
@@ -136,7 +140,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
@@ -144,7 +148,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -152,14 +156,14 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().remove(<(literal.(type))("3")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().remove(<(literal.(type))("3")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith().removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
     }
 
@@ -167,28 +171,28 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name>ArrayList()));
     }
 
     @Override
@@ -196,7 +200,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void clear()
     {
         Mutable<name>Collection emptyCollection = this.newWith();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
+        assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override
@@ -204,17 +208,17 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void contains()
     {
         Mutable<name>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
+            assertTrue(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type))("49")>));
+        assertFalse(collection.contains(<(literal.(type))("29")>));
+        assertFalse(collection.contains(<(literal.(type))("49")>));
     }
 
     @Override
@@ -240,60 +244,60 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = (<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
@@ -305,63 +309,63 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -371,7 +375,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name>Collection.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -410,17 +414,17 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void <type>Iterator_with_remove()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
     public void <type>Iterator_throws_for_remove_before_next()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -434,7 +438,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -442,7 +446,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -453,16 +457,16 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
                         <name>Bags.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
@@ -30,8 +30,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap#keySet()}.
@@ -61,7 +66,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
@@ -69,7 +74,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -77,42 +82,42 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Test
     public void freeze()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -120,56 +125,56 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -185,7 +190,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -193,7 +198,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -201,7 +206,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -210,8 +215,8 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -219,9 +224,9 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void <type>Iterator_with_remove()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -229,8 +234,8 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void <type>Iterator_throws_for_remove_before_next()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -245,7 +250,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -253,7 +258,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["3"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked)
@@ -264,16 +269,16 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -284,14 +289,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -299,7 +304,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
@@ -30,8 +30,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap}.
@@ -79,62 +83,62 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void removeKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKey(<(literal.(type))("5")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKey(<(literal.(type))("5")>));
     }
 
     @Override
     @Test
     public void removeKeyIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("10")>, true));
+        assertTrue(this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("10")>, true));
     }
 
     @Test
     public void removeKeyIfAbsentThrowsException()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("0")>, true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("0")>, true));
     }
 
     @Override
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().put(<(literal.(type))("0")>, true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().put(<(literal.(type))("0")>, true));
     }
 
     @Override
     @Test
     public void updateValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().updateValues((k, v) -> v));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().updateValues((k, v) -> v));
     }
 
     @Override
     @Test
     public void withKeysValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true));
     }
 
     @Override
     @Test
     public void withoutKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutKey(<(literal.(type))("32")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutKey(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void withoutAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
     }
 
@@ -142,7 +146,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     @Test
     public void withAllKeyValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, true))));
     }
 
@@ -153,55 +157,55 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         <type> collision1 = AbstractMutable<name>BooleanMapTestCase.generateCollisions().getFirst();
 
         Unmodifiable<name>BooleanMap hashMap = this.getEmptyMap();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, true));
+        assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, true));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().get(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().get(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().get(<(literal.(type))("32")>));
 
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().get(<(literal.(type))("33")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().get(<(literal.(type))("33")>));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("0")>, false));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("31")>, true));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("32")>, false));
 
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, false));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, true));
+        assertFalse(this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, false));
+        assertTrue(this.classUnderTest().getIfAbsent(<(literal.(type))("1")>, true));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
-        Assert.assertFalse(this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
+        assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("0")>));
+        assertFalse(this.classUnderTest().getOrThrow(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().getOrThrow(<(literal.(type))("32")>));
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("33")>));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(<(literal.(type))("33")>));
     }
 
     @Override
     @Test
     public void getIfAbsentPut()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, false));
+        assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, false));
     }
 
     @Test
     public void getIfAbsentPutThrowsException()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, true));
     }
 
     @Override
@@ -210,7 +214,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         BooleanFunction0 factory = () -> true;
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, factory));
+        assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, factory));
     }
 
     @Test
@@ -218,7 +222,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         BooleanFunction0 factory = () -> true;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, factory));
     }
 
@@ -228,7 +232,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         BooleanFunction\<String> functionLengthEven = (String string) -> (string.length() & 1) == <(literal.(type))("0")>;
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "12345678"));
+        assertTrue(this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "12345678"));
     }
 
     @Test
@@ -236,7 +240,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         BooleanFunction\<String> functionLengthEven = (String string) -> (string.length() & 1) == <(literal.(type))("0")>;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("10")>, functionLengthEven, "unused"));
     }
 
@@ -246,7 +250,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         <name>ToBooleanFunction keyIsEven = (<type> parameter) -> (<(castRealTypeToInt.(type))("parameter")> & 1) == <(literal.(type))("0")>;
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
+        assertTrue(this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
     }
 
     @Test
@@ -254,7 +258,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         <name>ToBooleanFunction keyIsEven = (<type> parameter) -> (<(castRealTypeToInt.(type))("parameter")> & 1) == <(literal.(type))("0")>;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("10")>, keyIsEven));
     }
 
@@ -264,7 +268,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         BooleanToBooleanFunction flip = (boolean value) -> !value;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().updateValue(<(literal.(type))("0")>, false, flip));
     }
 
@@ -272,50 +276,50 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(true));
-        Assert.assertTrue(this.classUnderTest().contains(false));
-        Assert.assertFalse(this.getEmptyMap().contains(false));
+        assertTrue(this.classUnderTest().contains(true));
+        assertTrue(this.classUnderTest().contains(false));
+        assertFalse(this.getEmptyMap().contains(false));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
-        Assert.assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("0")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("31")>));
+        assertTrue(this.classUnderTest().containsKey(<(literal.(type))("32")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("1")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("5")>));
+        assertFalse(this.classUnderTest().containsKey(<(literal.(type))("35")>));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
-        Assert.assertTrue(this.classUnderTest().containsValue(false));
-        Assert.assertFalse(this.getEmptyMap().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(true));
+        assertTrue(this.classUnderTest().containsValue(false));
+        assertFalse(this.getEmptyMap().containsValue(false));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(true, false));
-        Assert.assertTrue(this.classUnderTest().containsAll(true, true));
-        Assert.assertTrue(this.classUnderTest().containsAll(false, false));
-        Assert.assertFalse(this.getEmptyMap().containsAll(false, true));
+        assertTrue(this.classUnderTest().containsAll(true, false));
+        assertTrue(this.classUnderTest().containsAll(true, true));
+        assertTrue(this.classUnderTest().containsAll(false, false));
+        assertFalse(this.getEmptyMap().containsAll(false, true));
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.getEmptyMap().containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.getEmptyMap().containsAll(BooleanArrayList.newListWith(false, false)));
     }
 
     @Override
@@ -334,7 +338,7 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     {
         super.asUnmodifiable();
         Unmodifiable<name>BooleanMap map1 = this.classUnderTest();
-        Assert.assertSame(map1, map1.asUnmodifiable());
+        assertSame(map1, map1.asUnmodifiable());
     }
 
     @Override
@@ -342,8 +346,8 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -351,8 +355,8 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
@@ -37,8 +37,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBoo
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap#values()}.
@@ -84,20 +88,20 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
         BooleanIterator iterator = collection.booleanIterator();
         for (int i = 0; i \< 6; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
@@ -105,35 +109,35 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
@@ -141,7 +145,7 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new BooleanArrayList()));
     }
 
@@ -151,11 +155,11 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         <name>BooleanHashMap map = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.remove(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
     }
 
     @Override
@@ -163,15 +167,15 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void containsAllArray()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll());
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
+        assertTrue(emptyCollection.containsAll());
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll());
-        Assert.assertTrue(classUnderTest.containsAll(true));
-        Assert.assertTrue(classUnderTest.containsAll(false));
-        Assert.assertTrue(classUnderTest.containsAll(false, true));
+        assertTrue(classUnderTest.containsAll());
+        assertTrue(classUnderTest.containsAll(true));
+        assertTrue(classUnderTest.containsAll(false));
+        assertTrue(classUnderTest.containsAll(false, true));
     }
 
     @Override
@@ -180,7 +184,7 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(UnmodifiableBooleanCollection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -188,29 +192,29 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void containsAllIterable()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
 
         MutableBooleanCollection classUnderTest = this.classUnderTest();
-        Assert.assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertTrue(classUnderTest.containsAll(new BooleanArrayList()));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(classUnderTest.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith().removeAll(BooleanArrayList.newListWith(false, true)));
     }
 
@@ -218,14 +222,14 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith().retainAll(BooleanArrayList.newListWith(false, true)));
     }
 
@@ -234,7 +238,7 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void clear()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
+        assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override
@@ -242,13 +246,13 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void contains()
     {
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.contains(true));
-        Assert.assertFalse(emptyCollection.contains(false));
+        assertFalse(emptyCollection.contains(true));
+        assertFalse(emptyCollection.contains(false));
         BooleanIterable booleanIterable = this.classUnderTest();
-        Assert.assertTrue(booleanIterable.contains(true));
-        Assert.assertTrue(booleanIterable.contains(false));
-        Assert.assertFalse(this.newWith(true, true, true).contains(false));
-        Assert.assertFalse(this.newWith(false, false, false).contains(true));
+        assertTrue(booleanIterable.contains(true));
+        assertTrue(booleanIterable.contains(false));
+        assertFalse(this.newWith(true, true, true).contains(false));
+        assertFalse(this.newWith(false, false, false).contains(true));
     }
 
     @Override
@@ -274,8 +278,8 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void collect()
     {
         BooleanToObjectFunction\<Integer> function = (boolean parameter) -> parameter ? 1 : 0;
-        Assert.assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
     }
 
     @Override
@@ -284,22 +288,22 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", "/", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true).appendString(appendable1);
-        Assert.assertEquals("true", appendable1.toString());
+        assertEquals("true", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
         BooleanIterable iterable = this.newWith(true, false);
         iterable.appendString(appendable2);
-        Assert.assertTrue("true, false".equals(appendable2.toString())
+        assertTrue("true, false".equals(appendable2.toString())
                 || "false, true".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("true/false".equals(appendable3.toString())
+        assertTrue("true/false".equals(appendable3.toString())
                 || "false/true".equals(appendable3.toString()));
     }
 
@@ -329,8 +333,8 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
                 Lists.mutable.with(BooleanBags.mutable.with(false, true)),
                 iterable3.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
     }
 
     @Override
@@ -371,9 +375,9 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -381,8 +385,8 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
@@ -26,8 +26,13 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap#keySet()}.
@@ -57,14 +62,14 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -72,35 +77,35 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -108,28 +113,28 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                  this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
@@ -137,7 +142,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
@@ -145,14 +150,14 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
@@ -160,7 +165,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -176,7 +181,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -184,7 +189,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
+        assertFalse(this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).noneSatisfy(<name>Predicates.equal(<(literal.(type))("0")>)));
     }
 
     @Override
@@ -192,7 +197,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -200,25 +205,25 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 
     @Override
     public void <type>Iterator_with_remove()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
     public void <type>Iterator_throws_for_remove_before_next()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -235,14 +240,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -250,7 +255,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
@@ -37,8 +37,14 @@ import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap}.
@@ -82,35 +88,35 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
     @Test
     public void removeKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type))("5")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type))("5")>));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type))("5")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type))("5")>));
     }
 
     @Override
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type))("0")>, "one"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type))("0")>, "one"));
     }
 
     @Override
     @Test
     public void putPair()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one")));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one")));
     }
 
     @Override
@@ -118,28 +124,28 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     public void putAll()
     {
         <name>ObjectHashMap\<String> hashMap = <name>ObjectHashMap.newMap();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(hashMap));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(hashMap));
     }
 
     @Override
     @Test
     public void withKeysValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type))("1")>, "one"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type))("1")>, "one"));
     }
 
     @Override
     @Test
     public void withoutKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type))("32")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type))("32")>));
     }
 
     @Override
     @Test
     public void withoutAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
     }
 
@@ -147,7 +153,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     @Test
     public void withAllKeyValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, "one"))));
     }
 
@@ -156,7 +162,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     public void putDuplicateWithRemovedSlot()
     {
         <type> collision1 = AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, "one"));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, "one"));
     }
 
 <if(primitive.floatingPoint)>
@@ -169,12 +175,12 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     @Test
     public void get()
     {
-        Assert.assertEquals("zero", this.map.get(<(literal.(type))("0")>));
-        Assert.assertEquals("thirtyOne", this.map.get(<(literal.(type))("31")>));
-        Assert.assertEquals("thirtyTwo", this.map.get(<(literal.(type))("32")>));
+        assertEquals("zero", this.map.get(<(literal.(type))("0")>));
+        assertEquals("thirtyOne", this.map.get(<(literal.(type))("31")>));
+        assertEquals("thirtyTwo", this.map.get(<(literal.(type))("32")>));
 
-        Assert.assertNull(this.map.get(<(literal.(type))("1")>));
-        Assert.assertNull(this.map.get(<(literal.(type))("33")>));
+        assertNull(this.map.get(<(literal.(type))("1")>));
+        assertNull(this.map.get(<(literal.(type))("33")>));
     }
 
     @Override
@@ -183,38 +189,38 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     {
         Function0\<String> ifAbsent = () -> "ifAbsent";
 
-        Assert.assertEquals("zero", this.map.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
-        Assert.assertEquals("thirtyOne", this.map.getIfAbsent(<(literal.(type))("31")>, ifAbsent));
-        Assert.assertEquals("thirtyTwo", this.map.getIfAbsent(<(literal.(type))("32")>, ifAbsent));
+        assertEquals("zero", this.map.getIfAbsent(<(literal.(type))("0")>, ifAbsent));
+        assertEquals("thirtyOne", this.map.getIfAbsent(<(literal.(type))("31")>, ifAbsent));
+        assertEquals("thirtyTwo", this.map.getIfAbsent(<(literal.(type))("32")>, ifAbsent));
 
-        Assert.assertEquals("ifAbsent", this.map.getIfAbsent(<(literal.(type))("1")>, ifAbsent));
-        Assert.assertEquals("ifAbsent", this.map.getIfAbsent(<(literal.(type))("33")>, ifAbsent));
+        assertEquals("ifAbsent", this.map.getIfAbsent(<(literal.(type))("1")>, ifAbsent));
+        assertEquals("ifAbsent", this.map.getIfAbsent(<(literal.(type))("33")>, ifAbsent));
     }
 
     @Override
     @Test
     public void getIfAbsentPut_Value()
     {
-        Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
     }
 
     @Test
     public void getIfAbsentPut_Value_throws()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
     }
 
     @Override
     @Test
     public void getIfAbsentPut_Function()
     {
-        Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
     }
 
     @Test
     public void getIfAbsentPut_Function_throws()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
     }
 
@@ -223,14 +229,14 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     public void getIfAbsentPutWith()
     {
         Function\<String, String> toUpperCase = String::toUpperCase;
-        Assert.assertEquals("zero", this.map.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
+        assertEquals("zero", this.map.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
     }
 
     @Test
     public void getIfAbsentPutWithThrowsException()
     {
         Function\<String, String> toUpperCase = String::toUpperCase;
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "zeroValue"));
     }
 
@@ -239,21 +245,21 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     public void getIfAbsentPutWithKey()
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
-        Assert.assertEquals("zero", this.map.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
+        assertEquals("zero", this.map.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
     }
 
     @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> super.removeIf());
+        assertThrows(UnsupportedOperationException.class, () -> super.removeIf());
     }
 
     @Override
@@ -263,7 +269,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Mutable<name>ObjectMap\<String> mutable<name>ObjectMap = this.classUnderTest();
         <name>Set frozenSet = mutable<name>ObjectMap.keySet().freeze();
         <name>Set frozenSetCopy = <name>HashSet.newSetWith(mutable<name>ObjectMap.keySet().toArray());
-        Assert.assertEquals(frozenSet, frozenSetCopy);
+        assertEquals(frozenSet, frozenSetCopy);
     }
 
     @Override
@@ -273,7 +279,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Function\<Integer, Integer> incrementFunction = (Integer integer) -> integer + 1;
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.\<Integer>getEmptyMap().updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
     }
 
@@ -284,7 +290,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Function2\<Integer, Integer, Integer> incrementFunction = AddFunction.INTEGER;
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.\<Integer>getEmptyMap().updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
     }
 
@@ -292,46 +298,46 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.map.contains(null));
-        Assert.assertTrue(this.map.contains("zero"));
-        Assert.assertTrue(this.map.contains("thirtyOne"));
-        Assert.assertTrue(this.map.contains("thirtyTwo"));
+        assertFalse(this.map.contains(null));
+        assertTrue(this.map.contains("zero"));
+        assertTrue(this.map.contains("thirtyOne"));
+        assertTrue(this.map.contains("thirtyTwo"));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey(<(literal.(type))("0")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type))("31")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type))("32")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("1")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("5")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type))("35")>));
+        assertTrue(this.map.containsKey(<(literal.(type))("0")>));
+        assertTrue(this.map.containsKey(<(literal.(type))("31")>));
+        assertTrue(this.map.containsKey(<(literal.(type))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("1")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("5")>));
+        assertFalse(this.map.containsKey(<(literal.(type))("35")>));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.map.containsValue(null));
-        Assert.assertTrue(this.map.containsValue("zero"));
-        Assert.assertTrue(this.map.containsValue("thirtyOne"));
-        Assert.assertTrue(this.map.containsValue("thirtyTwo"));
+        assertFalse(this.map.containsValue(null));
+        assertTrue(this.map.containsValue("zero"));
+        assertTrue(this.map.containsValue("thirtyOne"));
+        assertTrue(this.map.containsValue("thirtyTwo"));
     }
 
     @Override
     @Test
     public void size()
     {
-        Assert.assertEquals(0, this.getEmptyMap().size());
-        Assert.assertEquals(1, this.newWithKeysValues(<(literal.(type))("0")>, "zero").size());
-        Assert.assertEquals(1, this.newWithKeysValues(<(literal.(type))("1")>, "one").size());
+        assertEquals(0, this.getEmptyMap().size());
+        assertEquals(1, this.newWithKeysValues(<(literal.(type))("0")>, "zero").size());
+        assertEquals(1, this.newWithKeysValues(<(literal.(type))("1")>, "one").size());
 
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(3, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type))("6")>, "six", <(literal.(type))("5")>, "five").size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
+        assertEquals(3, this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five").size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type))("6")>, "six", <(literal.(type))("5")>, "five").size());
     }
 
     @Override
@@ -339,7 +345,7 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.map, this.map.asUnmodifiable());
+        assertSame(this.map, this.map.asUnmodifiable());
     }
 
     @Override
@@ -352,24 +358,24 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Iterator\<String> iterator = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero",
                 <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, "thirtyTwo")
                 .withKeyValue(<(literal.(type))("1")>, "one").asUnmodifiable().iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
 
         Unmodifiable<name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Iterator\<String> iterator1 = map1.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator1::remove);
+        assertThrows(UnsupportedOperationException.class, iterator1::remove);
         iterator1.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator1::remove);
+        assertThrows(UnsupportedOperationException.class, iterator1::remove);
     }
 
     @Override
@@ -390,7 +396,7 @@ NaNTests(key) ::= <<
 public void put_<key>()
 {
     Mutable<name>ObjectMap\<String> map = this.getEmptyMap();
-    Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(<wrapperName>.<key>, "one"));
+    assertThrows(UnsupportedOperationException.class, () -> map.put(<wrapperName>.<key>, "one"));
 }
 
 >>
@@ -401,7 +407,7 @@ ZeroTests() ::= <<
 public void put_zero()
 {
     Mutable<name>ObjectMap\<String> map = this.getEmptyMap();
-    Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(<(literal.(type))("0")>, "one"));
+    assertThrows(UnsupportedOperationException.class, () -> map.put(<(literal.(type))("0")>, "one"));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
@@ -29,8 +29,12 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap#values()}.
@@ -57,7 +61,7 @@ public class Unmodifiable<name>ObjectMapValuesTest
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
                     .values().add(4));
     }
@@ -65,7 +69,7 @@ public class Unmodifiable<name>ObjectMapValuesTest
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4)));
     }
 
     @Test
@@ -73,10 +77,10 @@ public class Unmodifiable<name>ObjectMapValuesTest
     {
         Unmodifiable<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.contains(1));
-        Assert.assertTrue(values.contains(2));
-        Assert.assertTrue(values.contains(null));
-        Assert.assertFalse(values.contains(4));
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(2));
+        assertTrue(values.contains(null));
+        assertFalse(values.contains(4));
     }
 
     @Test
@@ -84,11 +88,11 @@ public class Unmodifiable<name>ObjectMapValuesTest
     {
         Unmodifiable<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 4)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(5, 4)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(null, null)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 4)));
+        assertFalse(values.containsAll(FastList.newListWith(5, 4)));
     }
 
     @Test
@@ -96,12 +100,12 @@ public class Unmodifiable<name>ObjectMapValuesTest
     {
         Unmodifiable<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("1")>, null);
         Collection\<Integer> values = map.values();
-        Assert.assertFalse(values.isEmpty());
+        assertFalse(values.isEmpty());
         <name>ObjectHashMap\<Integer> map1 = <name>ObjectHashMap.newMap();
         Collection\<Integer> values1 = map1.values();
-        Assert.assertTrue(values1.isEmpty());
+        assertTrue(values1.isEmpty());
         map1.put(<(literal.(type))("1")>, 1);
-        Assert.assertFalse(values1.isEmpty());
+        assertFalse(values1.isEmpty());
     }
 
     @Test
@@ -119,16 +123,16 @@ public class Unmodifiable<name>ObjectMapValuesTest
         MutableSet\<String> actual = UnifiedSet.newSet();
 
         Iterator\<String> iterator = <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("31")>, "thirtyOne", <(literal.(type))("32")>, null).iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -144,11 +148,11 @@ public class Unmodifiable<name>ObjectMapValuesTest
         Unmodifiable<name>ObjectMap\<Integer> map = this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, null);
         HashBag\<Integer> expected = HashBag.newBagWith(1, 2, null);
         Collection\<Integer> values = map.values();
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray()));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#keySet()}.
@@ -60,14 +65,14 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
@@ -75,49 +80,49 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type1))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type1))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeIf(<name1>Predicates.equal(<(literal.(type1))("1")>)));
     }
 
@@ -125,42 +130,42 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(<(literal.(type1))("1")>));
+        assertTrue(this.classUnderTest().contains(<(literal.(type1))("1")>));
     }
 
     @Override
@@ -176,7 +181,7 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
         Verify.assertEqualsAndHashCode(set1, set4);
         Verify.assertEqualsAndHashCode(set2, set3);
         Verify.assertEqualsAndHashCode(set2, set4);
-        Assert.assertNotEquals(set1, set5);
+        assertNotEquals(set1, set5);
     }
 
     @Override
@@ -184,7 +189,7 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
+        assertFalse(this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).noneSatisfy(<name1>Predicates.equal(<(literal.(type1))("0")>)));
     }
 
     @Override
@@ -192,7 +197,7 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     <if(primitive1.floatPrimitive)>@Test
@@ -206,7 +211,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             set.sum(),
             1.0e-15);
@@ -221,7 +226,7 @@ public void sumConsistentRounding()
             .collect<name1>(i -> <["1.0"]:(decimalLiteral.(type1))()> / (i.<type1>Value() * i.<type1>Value() * i.<type1>Value() * i.<type1>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             set.sum(),
             1.0e-15);
@@ -233,25 +238,25 @@ public void sumConsistentRounding()
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
     public void <type1>Iterator_with_remove()
     {
         Mutable<name1>Iterator iterator = this.classUnderTest().<type1>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
     public void <type1>Iterator_throws_for_remove_before_next()
     {
         Mutable<name1>Iterator iterator = this.classUnderTest().<type1>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -272,14 +277,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
@@ -287,7 +292,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
@@ -34,8 +34,13 @@ import org.eclipse.collections.impl.factory.Iterables;
 import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map}.
@@ -85,98 +90,98 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
     @Test
     public void removeKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type1))("5")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type1))("5")>));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type1))("5")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type1))("5")>));
     }
 
     @Override
     @Test
     public void removeKeyIfAbsent()
     {
-        Assert.assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
     }
 
     @Test
     public void removeKeyIfAbsentThrowsException()
     {
-        Assert.assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>));
+        assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
+        assertThrows(UnsupportedOperationException.class, () -> this.map.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>));
     }
 
     @Override
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
     }
 
     @Override
     @Test
     public void getAndPut()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>));
     }
 
     @Override
     @Test
     public void putPair()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>)));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>)));
     }
 
     @Override
     @Test
     public void updateValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
     }
 
     @Override
     @Test
     public void addToValue()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
     }
 
     @Override
     @Test
     public void withKeysValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
     }
 
     @Override
     @Test
     public void withoutKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type1))("32")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type1))("32")>));
     }
 
     @Override
     @Test
     public void withoutAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.withoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
     }
 
     @Override
     @Test
     public void withAllKeyValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("1")>))));
     }
 
@@ -187,53 +192,53 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         <type1> collision1 = AbstractMutable<name1><name2>MapTestCase.generateCollisions().getFirst();
 
         Unmodifiable<name1><name2>Map hashMap = this.getEmptyMap();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, <(literal.(type2))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, <(literal.(type2))("1")>));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.get(<(literal.(type1))("31")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.get(<(literal.(type1))("32")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("1")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("33")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("0")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.get(<(literal.(type1))("31")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.get(<(literal.(type1))("32")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("1")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.get(<(literal.(type1))("33")>)<(wideDelta.(type2))>);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("6")>, this.map.getIfAbsent(<(literal.(type1))("33")>, <(literal.(type2))("6")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.getIfAbsent(<(literal.(type1))("31")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.getIfAbsent(<(literal.(type1))("32")>, <(literal.(type2))("5")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("6")>, this.map.getIfAbsent(<(literal.(type1))("33")>, <(literal.(type2))("6")>)<(wideDelta.(type2))>);
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("31")>, this.map.getOrThrow(<(literal.(type1))("31")>)<(wideDelta.(type2))>);
-        Assert.assertEquals(<(wideLiteral.(type2))("32")>, this.map.getOrThrow(<(literal.(type1))("32")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getOrThrow(<(literal.(type1))("0")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("31")>, this.map.getOrThrow(<(literal.(type1))("31")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("32")>, this.map.getOrThrow(<(literal.(type1))("32")>)<(wideDelta.(type2))>);
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("1")>));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("33")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("1")>));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(<(literal.(type1))("33")>));
     }
 
     @Override
     @Test
     public void getIfAbsentPut()
     {
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
     }
 
     @Test
     public void getIfAbsentPutThrowsException()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, <(literal.(type2))("100")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, <(literal.(type2))("100")>));
     }
 
     @Override
@@ -242,7 +247,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     {
         <name2>Function0 factory = () -> <(literal.(type2))("100")>;
 
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
     }
 
     @Test
@@ -250,7 +255,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     {
         <name2>Function0 factory = () -> <(literal.(type2))("100")>;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, factory));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, factory));
     }
 
     @Override
@@ -259,7 +264,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     {
         <name2>Function\<String> functionLength = (String string) -> <(castFromInt.(type2))("string.length()")>;
 
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<(wideDelta.(type2))>);
     }
 
     @Test
@@ -267,7 +272,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     {
         <name2>Function\<String> functionLength = (String string) -> <(castFromInt.(type2))("string.length()")>;
 
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.map.getIfAbsentPutWith(<(literal.(type1))("10")>, functionLength, "unused"));
     }
 
@@ -276,7 +281,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     public void getIfAbsentPutWithKey()
     {
         <name1>To<name2>Function function = (<type1> <type1>Parameter) -> <castExactly(type2, {<type1>Parameter}, sameTwoPrimitives)>;
-        Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
+        assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPutWithKey(<(literal.(type1))("0")>, function)<(wideDelta.(type2))>);
     }
 
     @Override
@@ -286,21 +291,21 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Mutable<name1><name2>Map mutable<name1><name2>Map = this.classUnderTest();
         <name1>Set frozenSet = mutable<name1><name2>Map.keySet().freeze();
         <name1>Set frozenSetCopy = <name1>HashSet.newSetWith(mutable<name1><name2>Map.keySet().toArray());
-        Assert.assertEquals(frozenSet, frozenSetCopy);
+        assertEquals(frozenSet, frozenSetCopy);
     }
 
     @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name1>To<name2>Function function = (<type1> <type1>Parameter) -> <castExactly(type2, {<type1>Parameter}, sameTwoPrimitives)>;
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type1))("10")>, function));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type1))("10")>, function));
     }
 
     @Test
     public void putAllThrowsException()
     {
         Unmodifiable<name1><name2>Map copyMap = new Unmodifiable<name1><name2>Map(<name1><name2>HashMap.newWithKeysValues(<["0", "31", "32"]:keyValue(); separator=", ">));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(copyMap));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(copyMap));
     }
 
     @Override
@@ -308,51 +313,51 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     public void updateValue()
     {
         <name2>To<name2>Function incrementFunction = (<type2> value) -> <(castIntToNarrowTypeWithParens.(type2))({value + <(literal.(type2))("1")>})>;
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValue(<keyValue("0")>, incrementFunction));
+        assertThrows(UnsupportedOperationException.class, () -> this.map.updateValue(<keyValue("0")>, incrementFunction));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("0")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("31")>));
-        Assert.assertTrue(this.map.contains(<(literal.(type2))("32")>));
+        assertTrue(this.map.contains(<(literal.(type2))("0")>));
+        assertTrue(this.map.contains(<(literal.(type2))("31")>));
+        assertTrue(this.map.contains(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("31")>));
-        Assert.assertTrue(this.map.containsKey(<(literal.(type1))("32")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("1")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("5")>));
-        Assert.assertFalse(this.map.containsKey(<(literal.(type1))("35")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("0")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("31")>));
+        assertTrue(this.map.containsKey(<(literal.(type1))("32")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("1")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("5")>));
+        assertFalse(this.map.containsKey(<(literal.(type1))("35")>));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("31")>));
-        Assert.assertTrue(this.map.containsValue(<(literal.(type2))("32")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("0")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("31")>));
+        assertTrue(this.map.containsValue(<(literal.(type2))("32")>));
     }
 
     @Override
     @Test
     public void size()
     {
-        Assert.assertEquals(0, this.getEmptyMap().size());
-        Assert.assertEquals(1, this.newWithKeysValues(<keyValue("0")>).size());
-        Assert.assertEquals(1, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).size());
+        assertEquals(0, this.getEmptyMap().size());
+        assertEquals(1, this.newWithKeysValues(<keyValue("0")>).size());
+        assertEquals(1, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).size());
 
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
-        Assert.assertEquals(2, this.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
-        Assert.assertEquals(3, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <keyValue("0")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
-        Assert.assertEquals(2, this.newWithKeysValues(<(literal.(type1))("6")>, <(literal.(type2))("6")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
+        assertEquals(2, this.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
+        assertEquals(3, this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <keyValue("0")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
+        assertEquals(2, this.newWithKeysValues(<(literal.(type1))("6")>, <(literal.(type2))("6")>, <(literal.(type1))("5")>, <(literal.(type2))("5")>).size());
         Verify.assertSize(3, this.map);
     }
 
@@ -361,7 +366,7 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.map, this.map.asUnmodifiable());
+        assertSame(this.map, this.map.asUnmodifiable());
     }
 
     @Override
@@ -369,9 +374,9 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     public void <type2>Iterator_with_remove()
     {
         Mutable<name2>Iterator iterator = this.map.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -379,8 +384,8 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         Mutable<name2>Iterator iterator = this.map.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
@@ -41,8 +41,12 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 <if(primitive2.floatOrDoublePrimitive)><if(primitive1.byteOrShortOrCharPrimitive)>import org.eclipse.collections.impl.list.Interval;<endif><endif>
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#values()}.
@@ -88,13 +92,13 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         <name2>Iterator iterator = bag.<type2>Iterator();
         for (int i = 0; i \< 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -103,9 +107,9 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection <type2>Iterable = this.classUnderTest();
         Mutable<name2>Iterator iterator = <type2>Iterable.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -114,8 +118,8 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection <type2>Iterable = this.classUnderTest();
         Mutable<name2>Iterator iterator = <type2>Iterable.<type2>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -129,7 +133,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
@@ -137,7 +141,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
@@ -146,7 +150,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
@@ -154,7 +158,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
@@ -162,7 +166,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().without(<(literal.(type2))("0")>));
     }
 
@@ -170,7 +174,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
@@ -178,7 +182,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().withoutAll(new <name2>ArrayList()));
     }
 
@@ -186,7 +190,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().remove(<(literal.(type2))("0")>));
     }
 
@@ -194,7 +198,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().removeIf(<name2>Predicates.equal(<(literal.(type2))("0")>)));
     }
 
@@ -204,35 +208,35 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         Mutable<name2>Collection collection = this.classUnderTest();
         Verify.assertInstanceOf(Unmodifiable<name2>Collection.class, collection.asUnmodifiable());
-        Assert.assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
+        assertTrue(collection.asUnmodifiable().containsAll(this.classUnderTest()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name2>ArrayList()));
     }
 
     @Override
@@ -240,7 +244,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void clear()
     {
         Mutable<name2>Collection emptyCollection = this.newWith();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
+        assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override
@@ -248,17 +252,17 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void contains()
     {
         Mutable<name2>Collection collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
 
         <type2>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type2))(); separator=", ">};
         for (<type2> number : numbers)
         {
-            Assert.assertTrue(collection.contains(number));
+            assertTrue(collection.contains(number));
         }
 
-        Assert.assertFalse(collection.contains(<(literal.(type2))("29")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("49")>));
+        assertFalse(collection.contains(<(literal.(type2))("29")>));
+        assertFalse(collection.contains(<(literal.(type2))("49")>));
     }
 
     @Override
@@ -286,60 +290,60 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         super.collect();
 
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString()));
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/"))
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(iterable4.makeString("/")));
-        Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
+        assertTrue("[<["1", "2"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]"))
                 || "[<["2", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(iterable4.makeString("[", "/", "]")));
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
                         || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
                         || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
-        Assert.assertTrue(
+        assertTrue(
                 iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
                         || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
@@ -351,63 +355,63 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         iterable.appendString(appendable2);
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
+        assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString())
                 || "<["2", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable3.toString()));
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        Assert.assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
                 || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        Assert.assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
                 || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        Assert.assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
                 || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        Assert.assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        Assert.assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
                 || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        Assert.assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
                 || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
     }
 
@@ -452,7 +456,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -460,7 +464,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
                 iterable.chunk(1).toSet());
 
         MutableSet\<<name2>Iterable> chunked = iterable.chunk(2).toSet();
-        Assert.assertTrue(
+        assertTrue(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["3"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked)
@@ -471,16 +475,16 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -526,7 +530,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -546,7 +550,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/objectPrimitiveMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/objectPrimitiveMapFactoryTest.stg
@@ -23,8 +23,11 @@ import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file objectPrimitiveMapFactoryTest.stg.
@@ -34,61 +37,61 @@ public class Object<name>MapFactoryTest
     @Test
     public void of()
     {
-        Assert.assertEquals(new Object<name>HashMap(), Object<name>Maps.mutable.of());
-        Assert.assertEquals(Object<name>Maps.mutable.of(), Object<name>Maps.mutable.empty());
-        Assert.assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>), Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>));
-        Assert.assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>),
+        assertEquals(new Object<name>HashMap(), Object<name>Maps.mutable.of());
+        assertEquals(Object<name>Maps.mutable.of(), Object<name>Maps.mutable.empty());
+        assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>), Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>));
+        assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>));
 
-        Assert.assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>),
+        assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>));
 
-        Assert.assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>),
+        assertEquals(Object<name>Maps.mutable.of("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>));
 
-        Assert.assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.empty());
-        Assert.assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.of());
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>).toImmutable(), Object<name>Maps.immutable.of("2", <(literal.(type))("1")>));
+        assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.empty());
+        assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.of());
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>).toImmutable(), Object<name>Maps.immutable.of("2", <(literal.(type))("1")>));
     }
 
     @Test
     public void with()
     {
-        Assert.assertEquals(Object<name>Maps.mutable.with(), Object<name>Maps.mutable.empty());
-        Assert.assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>), Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>));
-        Assert.assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>),
+        assertEquals(Object<name>Maps.mutable.with(), Object<name>Maps.mutable.empty());
+        assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>), Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>));
+        assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>));
 
-        Assert.assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>),
+        assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>));
 
-        Assert.assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>),
+        assertEquals(Object<name>Maps.mutable.with("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>),
                 Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "4", <(literal.(type))("3")>, "6", <(literal.(type))("5")>, "8", <(literal.(type))("7")>));
     }
 
     @Test
     public void ofAll()
     {
-        Assert.assertEquals(Object<name>Maps.mutable.empty(), Object<name>Maps.mutable.ofAll(Object<name>Maps.mutable.empty()));
-        Assert.assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>Maps.mutable.empty()));
-        Assert.assertSame(Object<name>Maps.immutable.empty(), Object<name>Maps.immutable.ofAll(Object<name>Maps.immutable.empty()));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>), Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>)));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>).toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>)));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("3")>).toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("3")>)));
+        assertEquals(Object<name>Maps.mutable.empty(), Object<name>Maps.mutable.ofAll(Object<name>Maps.mutable.empty()));
+        assertEquals(Object<name>Maps.mutable.empty().toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>Maps.mutable.empty()));
+        assertSame(Object<name>Maps.immutable.empty(), Object<name>Maps.immutable.ofAll(Object<name>Maps.immutable.empty()));
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>), Object<name>Maps.mutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>)));
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>).toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>)));
+        assertEquals(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("3")>).toImmutable(), Object<name>Maps.immutable.ofAll(Object<name>HashMap.newWithKeysValues("2", <(literal.(type))("1")>, "3", <(literal.(type))("3")>)));
     }
 
     @Test
     public void from()
     {
         Iterable\<String> iterable = Lists.mutable.with("1", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Object<name>HashMap.newWithKeysValues("1", <if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, "2", <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, "3", <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>),
                 Object<name>Maps.mutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>));
-        Assert.assertTrue(Object<name>Maps.mutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>) instanceof MutableObject<name>Map);
-        Assert.assertEquals(
+        assertTrue(Object<name>Maps.mutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>) instanceof MutableObject<name>Map);
+        assertEquals(
                 Object<name>HashMap.newWithKeysValues("1", <if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, "2", <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, "3", <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>),
                 Object<name>Maps.immutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>));
-        Assert.assertTrue(Object<name>Maps.immutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>) instanceof ImmutableObject<name>Map);
+        assertTrue(Object<name>Maps.immutable.from(iterable, each -> each, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>) instanceof ImmutableObject<name>Map);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitiveBooleanMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitiveBooleanMapFactoryTest.stg
@@ -23,8 +23,10 @@ import org.eclipse.collections.api.map.primitive.Mutable<name>BooleanMap;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This file was automatically generated from template file primitiveBooleanMapFactoryTest.stg.
@@ -34,34 +36,34 @@ public class <name>BooleanMapFactoryTest
     @Test
     public void of()
     {
-        Assert.assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.of());
-        Assert.assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true).toImmutable(), <name>BooleanMaps.immutable.of(<(literal.(type))("1")>, true));
+        assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.of());
+        assertEquals(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true).toImmutable(), <name>BooleanMaps.immutable.of(<(literal.(type))("1")>, true));
     }
 
     @Test
     public void ofAll()
     {
-        Assert.assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.ofAll(<name>BooleanMaps.immutable.of()));
+        assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.ofAll(<name>BooleanMaps.immutable.of()));
     }
 
     @Test
     public void withAll()
     {
-        Assert.assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.withAll(<name>BooleanMaps.immutable.of()));
+        assertEquals(new <name>BooleanHashMap().toImmutable(), <name>BooleanMaps.immutable.withAll(<name>BooleanMaps.immutable.of()));
     }
 
     @Test
     public void from()
     {
         Iterable\<String> iterable = Lists.mutable.with("1", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 <name>BooleanHashMap.newWithKeysValues(<if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, false, <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, true, <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>, false),
                 <name>BooleanMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0));
-        Assert.assertTrue(<name>BooleanMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0) instanceof Mutable<name>BooleanMap);
-        Assert.assertEquals(
+        assertTrue(<name>BooleanMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0) instanceof Mutable<name>BooleanMap);
+        assertEquals(
                 <name>BooleanHashMap.newWithKeysValues(<if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, false, <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, true, <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>, false),
                 <name>BooleanMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0));
-        Assert.assertTrue(<name>BooleanMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0) instanceof Immutable<name>BooleanMap);
+        assertTrue(<name>BooleanMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> Integer.valueOf(each) % 2 == 0) instanceof Immutable<name>BooleanMap);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitiveObjectMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitiveObjectMapFactoryTest.stg
@@ -23,8 +23,11 @@ import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file primitiveObjectMapFactoryTest.stg.
@@ -34,30 +37,30 @@ public class <name>ObjectMapFactoryTest
     @Test
     public void empty()
     {
-        Assert.assertSame(<name>ObjectMaps.immutable.with(), <name>ObjectMaps.immutable.empty());
-        Assert.assertSame(<name>ObjectMaps.immutable.of(), <name>ObjectMaps.immutable.empty());
+        assertSame(<name>ObjectMaps.immutable.with(), <name>ObjectMaps.immutable.empty());
+        assertSame(<name>ObjectMaps.immutable.of(), <name>ObjectMaps.immutable.empty());
 
-        Assert.assertEquals(<name>ObjectMaps.mutable.with(), <name>ObjectMaps.mutable.empty());
-        Assert.assertEquals(<name>ObjectMaps.mutable.of(), <name>ObjectMaps.mutable.empty());
+        assertEquals(<name>ObjectMaps.mutable.with(), <name>ObjectMaps.mutable.empty());
+        assertEquals(<name>ObjectMaps.mutable.of(), <name>ObjectMaps.mutable.empty());
     }
 
     @Test
     public void of()
     {
-        Assert.assertEquals(<name>ObjectMaps.mutable.with().toImmutable(), <name>ObjectMaps.immutable.of());
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1").toImmutable(), <name>ObjectMaps.immutable.of(<(literal.(type))("1")>, "1"));
+        assertEquals(<name>ObjectMaps.mutable.with().toImmutable(), <name>ObjectMaps.immutable.of());
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1").toImmutable(), <name>ObjectMaps.immutable.of(<(literal.(type))("1")>, "1"));
     }
 
     @Test
     public void ofAll()
     {
-        Assert.assertEquals(<name>ObjectMaps.mutable.of(), <name>ObjectMaps.immutable.ofAll(<name>ObjectMaps.immutable.of()));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1")));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2")));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2").toImmutable()));
+        assertEquals(<name>ObjectMaps.mutable.of(), <name>ObjectMaps.immutable.ofAll(<name>ObjectMaps.immutable.of()));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1")));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2")));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2"), <name>ObjectMaps.immutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1", <(literal.(type))("2")>, "2").toImmutable()));
 
-        Assert.assertEquals(<name>ObjectMaps.mutable.empty(), <name>ObjectMaps.mutable.ofAll(<name>ObjectMaps.immutable.of()));
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1"), <name>ObjectMaps.mutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1")));
+        assertEquals(<name>ObjectMaps.mutable.empty(), <name>ObjectMaps.mutable.ofAll(<name>ObjectMaps.immutable.of()));
+        assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1"), <name>ObjectMaps.mutable.ofAll(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "1")));
     }
 
     @Test
@@ -65,15 +68,15 @@ public class <name>ObjectMapFactoryTest
     {
         Iterable\<String> iterable = Lists.mutable.with("1", "2", "3");
 
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, "1", <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, "2", <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>, "3"),
                 <name>ObjectMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each));
-        Assert.assertTrue(<name>ObjectMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each) instanceof Mutable<name>ObjectMap);
+        assertTrue(<name>ObjectMaps.mutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each) instanceof Mutable<name>ObjectMap);
 
-        Assert.assertEquals(
+        assertEquals(
                 <name>ObjectHashMap.newWithKeysValues(<if(!charPrimitive)><(literal.(type))("1")><else>'1'<endif>, "1", <if(!charPrimitive)><(literal.(type))("2")><else>'2'<endif>, "2", <if(!charPrimitive)><(literal.(type))("3")><else>'3'<endif>, "3"),
                 <name>ObjectMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each));
-        Assert.assertTrue(<name>ObjectMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each) instanceof Immutable<name>ObjectMap);
+        assertTrue(<name>ObjectMaps.immutable.from(iterable, <if(!charPrimitive)><wrapperName>::valueOf<else>each -> each.charAt(0)<endif>, each -> each) instanceof Immutable<name>ObjectMap);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitivePrimitiveMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitivePrimitiveMapFactoryTest.stg
@@ -36,8 +36,10 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This file was automatically generated from template file primitivePrimitiveMapFactoryTest.stg.
@@ -48,7 +50,7 @@ public class <name1><name2>MapFactoryTest
     public void of()
     {
         Verify.assertEmpty(<name1><name2>Maps.immutable.of());
-        Assert.assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toImmutable(), <name1><name2>Maps.immutable.of(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
+        assertEquals(<name1><name2>HashMap.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>).toImmutable(), <name1><name2>Maps.immutable.of(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
     }
 
     @Test
@@ -56,21 +58,21 @@ public class <name1><name2>MapFactoryTest
     {
         Immutable<name1><name2>Map map = <name1><name2>Maps.immutable.of();
 
-        Assert.assertEquals(<name1><name2>Maps.mutable.empty().toImmutable(), <name1><name2>Maps.immutable.withAll(map));
+        assertEquals(<name1><name2>Maps.mutable.empty().toImmutable(), <name1><name2>Maps.immutable.withAll(map));
     }
 
     @Test
     public void from()
     {
         Iterable\<String> iterable = Lists.mutable.with("1", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 <name1><name2>HashMap.newWithKeysValues(<if(!charPrimitive1)><(literal.(type1))("1")><else>'1'<endif>, <if(!charPrimitive2)><(literal.(type2))("1")><else>'1'<endif>, <if(!charPrimitive1)><(literal.(type1))("2")><else>'2'<endif>, <if(!charPrimitive2)><(literal.(type2))("2")><else>'2'<endif>, <if(!charPrimitive1)><(literal.(type1))("3")><else>'3'<endif>, <if(!charPrimitive2)><(literal.(type2))("3")><else>'3'<endif>),
                 <name1><name2>Maps.mutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>));
-        Assert.assertTrue(<name1><name2>Maps.mutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>) instanceof Mutable<name1><name2>Map);
-        Assert.assertEquals(
+        assertTrue(<name1><name2>Maps.mutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>) instanceof Mutable<name1><name2>Map);
+        assertEquals(
                 <name1><name2>HashMap.newWithKeysValues(<if(!charPrimitive1)><(literal.(type1))("1")><else>'1'<endif>, <if(!charPrimitive2)><(literal.(type2))("1")><else>'1'<endif>, <if(!charPrimitive1)><(literal.(type1))("2")><else>'2'<endif>, <if(!charPrimitive2)><(literal.(type2))("2")><else>'2'<endif>, <if(!charPrimitive1)><(literal.(type1))("3")><else>'3'<endif>, <if(!charPrimitive2)><(literal.(type2))("3")><else>'3'<endif>),
                 <name1><name2>Maps.immutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>));
-        Assert.assertTrue(<name1><name2>Maps.immutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>) instanceof Immutable<name1><name2>Map);
+        assertTrue(<name1><name2>Maps.immutable.from(iterable, <if(!charPrimitive1)><wrapperName1>::valueOf<else>each -> each.charAt(0)<endif>, <if(!charPrimitive2)><wrapperName2>::valueOf<else>each -> each.charAt(0)<endif>) instanceof Immutable<name1><name2>Map);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/abstractImmutablePrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/abstractImmutablePrimitiveSetTestCase.stg
@@ -37,8 +37,14 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.impl.factory.Sets;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Set}.
@@ -82,28 +88,28 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     public void isEmpty()
     {
         super.isEmpty();
-        Assert.assertFalse(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)).isEmpty());
+        assertFalse(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)).isEmpty());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)).notEmpty());
+        assertTrue(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)).notEmpty());
     }
 
     @Test
     public void freeze()
     {
         Immutable<name>Set immutable<name>Set = this.classUnderTest();
-        Assert.assertSame(immutable<name>Set, immutable<name>Set.freeze());
+        assertSame(immutable<name>Set, immutable<name>Set.freeze());
     }
 
     @Test
     public void toImmutable()
     {
         Immutable<name>Set immutable<name>Set = this.classUnderTest();
-        Assert.assertSame(immutable<name>Set, immutable<name>Set.toImmutable());
+        assertSame(immutable<name>Set, immutable<name>Set.toImmutable());
     }
 
     @Override
@@ -114,19 +120,19 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
         MutableSet\<<wrapperName>\> actual = UnifiedSet.newSet();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
         <name>Iterator iterator = set.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -140,7 +146,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
             iterator.next();
         }
 
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -152,7 +158,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
         set.forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(32L + AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst() + AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1), sum[0]<(delta.(type))>);
+        assertEquals(32L + AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst() + AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1), sum[0]<(delta.(type))>);
     }
 
     @Override
@@ -161,9 +167,9 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     {
         super.count();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
-        Assert.assertEquals(4L, set.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertEquals(3L, set.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
-        Assert.assertEquals(1L, set.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
+        assertEquals(4L, set.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertEquals(3L, set.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
+        assertEquals(1L, set.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
     }
 
     @Override
@@ -192,9 +198,9 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     {
         super.detectIfNone();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
-        Assert.assertEquals(<(literal.(type))("0")>, set.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<(delta.(type))>);
-        Assert.assertEquals(AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1), set.detectIfNone(<name>Predicates.greaterThan(AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst()), <(literal.(type))("9")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("9")>, set.detectIfNone(<name>Predicates.greaterThan(AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, set.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1), set.detectIfNone(<name>Predicates.greaterThan(AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst()), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("9")>, set.detectIfNone(<name>Predicates.greaterThan(AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)), <(literal.(type))("9")>)<(delta.(type))>);
     }
 
     @Override
@@ -203,7 +209,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     {
         super.collect();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
-        Assert.assertEquals(UnifiedSet.newSetWith(<["-1", "0", "30"]:(literal.(type))(); separator=", ">, <(castIntToNarrowTypeWithParens.(type))({AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst() - 1})>, <(castIntToNarrowTypeWithParens.(type))({AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1) - 1})>),
+        assertEquals(UnifiedSet.newSetWith(<["-1", "0", "30"]:(literal.(type))(); separator=", ">, <(castIntToNarrowTypeWithParens.(type))({AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst() - 1})>, <(castIntToNarrowTypeWithParens.(type))({AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1) - 1})>),
                 set.collect(byteParameter -> <(castIntToNarrowTypeWithParens.(type))("byteParameter - 1")>));
     }
 
@@ -213,7 +219,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     {
         super.toSortedArray();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
-        Assert.assertArrayEquals(new <type>[]{<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)}, set.toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1)}, set.toSortedArray()<(delta.(type))>);
     }
 
     @Override
@@ -239,16 +245,16 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
         super.testHashCode();
         Immutable<name>Set set1 = this.newWith(<["1", "31", "32"]:(literal.(type))(); separator=", ">);
         Immutable<name>Set set2 = this.newWith(<["32", "31", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
     }
 
     @Override
@@ -257,7 +263,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     {
         super.asLazy();
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
-        Assert.assertEquals(set.toSet(), set.asLazy().toSet());
+        assertEquals(set.toSet(), set.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, set.asLazy());
     }
 
@@ -298,7 +304,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertUnion(Immutable<name>Set set1, Immutable<name>Set set2, Immutable<name>Set expected)
     {
         Immutable<name>Set actual = set1.union(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -338,7 +344,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertIntersect(Immutable<name>Set set1, Immutable<name>Set set2, Immutable<name>Set expected)
     {
         Immutable<name>Set actual = set1.intersect(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -373,7 +379,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertDifference(Immutable<name>Set set1, Immutable<name>Set set2, Immutable<name>Set expected)
     {
         Immutable<name>Set actual = set1.difference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -408,7 +414,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertSymmetricDifference(Immutable<name>Set set1, Immutable<name>Set set2, Immutable<name>Set expected)
     {
         Immutable<name>Set actual = set1.symmetricDifference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -448,7 +454,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertIsSubsetOf(Immutable<name>Set set1, Immutable<name>Set set2, boolean expected)
     {
         boolean actual = set1.isSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -488,7 +494,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertIsProperSubsetOf(Immutable<name>Set set1, Immutable<name>Set set2, boolean expected)
     {
         boolean actual = set1.isProperSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -526,7 +532,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     private void assertCartesianProduct(Immutable<name>Set set1, Immutable<name>Set set2, ImmutableSet\<<name><name>Pair> expected)
     {
         ImmutableSet\<<name><name>Pair> actual = set1.cartesianProduct(set2).toSet().toImmutable();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
@@ -23,8 +23,11 @@ import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>EmptySet}.
@@ -48,49 +51,49 @@ public class Immutable<name>EmptySetTest extends AbstractImmutable<name>HashSetT
     @Test
     public void average()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
     }
 
     @Override
     @Test
     public void median()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -104,7 +107,7 @@ public class Immutable<name>EmptySetTest extends AbstractImmutable<name>HashSetT
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>Bags.immutable.empty(), this.classUnderTest().toBag());
+        assertEquals(<name>Bags.immutable.empty(), this.classUnderTest().toBag());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
@@ -22,7 +22,8 @@ import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ByteHashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutable<name>HashSetTestCase;
-import org.junit.Assert;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>Set} created from the freeze() method.
@@ -56,8 +57,8 @@ public class Immutable<primitive.name>MapKeySetTest extends AbstractImmutable<na
         <name>ByteHashMap <type>ByteHashMap = <name>ByteHashMap.newWithKeysValues(collision1, (byte) 0, collision2, (byte) 0);
         <type>ByteHashMap.removeKey(collision2);
         <name>Set <type>Set = <type>ByteHashMap.keySet().freeze();
-        Assert.assertTrue(<type>Set.contains(collision1));
-        Assert.assertFalse(<type>Set.contains(collision2));
+        assertTrue(<type>Set.contains(collision1));
+        assertFalse(<type>Set.contains(collision2));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
@@ -22,7 +22,8 @@ import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.map.mutable.primitive.<primitive.name><primitive.name>HashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutable<name>HashSetTestCase;
-import org.junit.Assert;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link Immutable<name>Set} created from the freeze() method.
@@ -56,8 +57,8 @@ public class Immutable<primitive.name><primitive.name>MapKeySetTest extends Abst
         <name><name>HashMap <type><name>HashMap = <name><name>HashMap.newWithKeysValues(collision1, collision1, collision2, collision2);
         <type><name>HashMap.removeKey(collision2);
         <name>Set <type>Set = <type><name>HashMap.keySet().freeze();
-        Assert.assertTrue(<type>Set.contains(collision1));
-        Assert.assertFalse(<type>Set.contains(collision2));
+        assertTrue(<type>Set.contains(collision1));
+        assertFalse(<type>Set.contains(collision2));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveSetFactoryImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveSetFactoryImplTest.stg
@@ -22,8 +22,9 @@ import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>SetFactoryImpl}.
@@ -35,7 +36,7 @@ public class Immutable<name>SetFactoryImplTest
     public void of()
     {
         Verify.assertEmpty(<name>Sets.immutable.of());
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>).toImmutable(), <name>Sets.immutable.of(<(literal.(type))("1")>));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>).toImmutable(), <name>Sets.immutable.of(<(literal.(type))("1")>));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class Immutable<name>SetFactoryImplTest
     public void ofAll()
     {
         Immutable<name>Set set = <name>Sets.immutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>HashSet.newSet(set).toImmutable(), <name>Sets.immutable.ofAll(set));
+        assertEquals(<name>HashSet.newSet(set).toImmutable(), <name>Sets.immutable.ofAll(set));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
@@ -34,8 +34,13 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.impl.factory.Sets;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Set}.
@@ -102,14 +107,14 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     public void isEmpty()
     {
         super.isEmpty();
-        Assert.assertFalse(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)).isEmpty());
+        assertFalse(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)).isEmpty());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)).notEmpty());
+        assertTrue(this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)).notEmpty());
     }
 
     @Override
@@ -120,11 +125,11 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         set.clear();
         Verify.assertSize(0, set);
-        Assert.assertFalse(set.contains(<(literal.(type))("0")>));
-        Assert.assertFalse(set.contains(<(literal.(type))("31")>));
-        Assert.assertFalse(set.contains(<(literal.(type))("1")>));
-        Assert.assertFalse(set.contains(Abstract<name>SetTestCase.generateCollisions1().getFirst()));
-        Assert.assertFalse(set.contains(Abstract<name>SetTestCase.generateCollisions1().get(1)));
+        assertFalse(set.contains(<(literal.(type))("0")>));
+        assertFalse(set.contains(<(literal.(type))("31")>));
+        assertFalse(set.contains(<(literal.(type))("1")>));
+        assertFalse(set.contains(Abstract<name>SetTestCase.generateCollisions1().getFirst()));
+        assertFalse(set.contains(Abstract<name>SetTestCase.generateCollisions1().get(1)));
     }
 
     @Override
@@ -133,20 +138,20 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.add();
         Mutable<name>Set set = this.newWith();
-        Assert.assertTrue(set.add(<(literal.(type))("14")>));
-        Assert.assertFalse(set.add(<(literal.(type))("14")>));
-        Assert.assertTrue(set.add(<(literal.(type))("2")>));
-        Assert.assertFalse(set.add(<(literal.(type))("2")>));
-        Assert.assertTrue(set.add(<(literal.(type))("35")>));
-        Assert.assertFalse(set.add(<(literal.(type))("35")>));
-        Assert.assertTrue(set.add(<(literal.(type))("31")>));
-        Assert.assertFalse(set.add(<(literal.(type))("31")>));
-        Assert.assertTrue(set.add(<(literal.(type))("32")>));
-        Assert.assertFalse(set.add(<(literal.(type))("32")>));
-        Assert.assertTrue(set.add(<(literal.(type))("0")>));
-        Assert.assertFalse(set.add(<(literal.(type))("0")>));
-        Assert.assertTrue(set.add(<(literal.(type))("1")>));
-        Assert.assertFalse(set.add(<(literal.(type))("1")>));
+        assertTrue(set.add(<(literal.(type))("14")>));
+        assertFalse(set.add(<(literal.(type))("14")>));
+        assertTrue(set.add(<(literal.(type))("2")>));
+        assertFalse(set.add(<(literal.(type))("2")>));
+        assertTrue(set.add(<(literal.(type))("35")>));
+        assertFalse(set.add(<(literal.(type))("35")>));
+        assertTrue(set.add(<(literal.(type))("31")>));
+        assertFalse(set.add(<(literal.(type))("31")>));
+        assertTrue(set.add(<(literal.(type))("32")>));
+        assertFalse(set.add(<(literal.(type))("32")>));
+        assertTrue(set.add(<(literal.(type))("0")>));
+        assertFalse(set.add(<(literal.(type))("0")>));
+        assertTrue(set.add(<(literal.(type))("1")>));
+        assertFalse(set.add(<(literal.(type))("1")>));
     }
 
 <if(primitive.floatingPoint)>
@@ -160,28 +165,28 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.addAllIterable();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(set.addAll(new <name>ArrayList()));
-        Assert.assertFalse(set.addAll(<name>ArrayList.newListWith(<(literal.(type))("31")>, Abstract<name>SetTestCase.generateCollisions1().get(0), Abstract<name>SetTestCase.generateCollisions1().get(1))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertFalse(set.addAll(new <name>ArrayList()));
+        assertFalse(set.addAll(<name>ArrayList.newListWith(<(literal.(type))("31")>, Abstract<name>SetTestCase.generateCollisions1().get(0), Abstract<name>SetTestCase.generateCollisions1().get(1))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
 
-        Assert.assertTrue(set.addAll(<name>HashSet.newSetWith(<["0", "1", "2", "30"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(4))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4)), set);
+        assertTrue(set.addAll(<name>HashSet.newSetWith(<["0", "1", "2", "30"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(4))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4)), set);
 
-        Assert.assertTrue(set.addAll(<name>HashSet.newSetWith(<(literal.(type))("5")>)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4)), set);
+        assertTrue(set.addAll(<name>HashSet.newSetWith(<(literal.(type))("5")>)));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4)), set);
 
-        Assert.assertTrue(set.addAll(<name>HashSet.newSetWith(Abstract<name>SetTestCase.generateCollisions1().get(5))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(5)), set);
+        assertTrue(set.addAll(<name>HashSet.newSetWith(Abstract<name>SetTestCase.generateCollisions1().get(5))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1), Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(5)), set);
 
         <name>HashSet set1 = new <name>HashSet();
-        Assert.assertTrue(set1.addAll(<["2", "35"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["2", "35"]:(literal.(type))(); separator=", ">), set1);
+        assertTrue(set1.addAll(<["2", "35"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>HashSet.newSetWith(<["2", "35"]:(literal.(type))(); separator=", ">), set1);
     }
 
     @Test
     public void testOfAllFactory()
     {
-        Assert.assertEquals(
+        assertEquals(
                 <name>HashSet.newSetWith(<["0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">),
                 <name>Sets.mutable.ofAll(<name>HashBag.newBagWith(<["0", "1", "2", "5", "30", "31", "0", "1", "2", "5", "30", "31"]:(literal.(type))(); separator=", ">)));
     }
@@ -192,20 +197,20 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.remove();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(this.newWith().remove(<(literal.(type))("15")>));
-        Assert.assertFalse(set.remove(<(literal.(type))("15")>));
-        Assert.assertTrue(set.remove(<(literal.(type))("0")>));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertFalse(set.remove(Abstract<name>SetTestCase.generateNonCollisions().getFirst()));
-        Assert.assertFalse(set.remove(Abstract<name>SetTestCase.generateCollisions1().get(3)));
-        Assert.assertTrue(set.remove(Abstract<name>SetTestCase.generateCollisions1().get(1)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst()), set);
-        Assert.assertTrue(set.remove(Abstract<name>SetTestCase.generateCollisions1().getFirst()));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">), set);
-        Assert.assertTrue(set.remove(<(literal.(type))("31")>));
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), set);
-        Assert.assertTrue(set.remove(<(literal.(type))("1")>));
-        Assert.assertEquals(<name>HashSet.newSetWith(), set);
+        assertFalse(this.newWith().remove(<(literal.(type))("15")>));
+        assertFalse(set.remove(<(literal.(type))("15")>));
+        assertTrue(set.remove(<(literal.(type))("0")>));
+        assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertFalse(set.remove(Abstract<name>SetTestCase.generateNonCollisions().getFirst()));
+        assertFalse(set.remove(Abstract<name>SetTestCase.generateCollisions1().get(3)));
+        assertTrue(set.remove(Abstract<name>SetTestCase.generateCollisions1().get(1)));
+        assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst()), set);
+        assertTrue(set.remove(Abstract<name>SetTestCase.generateCollisions1().getFirst()));
+        assertEquals(<name>HashSet.newSetWith(<["1", "31"]:(literal.(type))(); separator=", ">), set);
+        assertTrue(set.remove(<(literal.(type))("31")>));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>), set);
+        assertTrue(set.remove(<(literal.(type))("1")>));
+        assertEquals(<name>HashSet.newSetWith(), set);
     }
 
     @Override
@@ -214,15 +219,15 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.removeAll();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(set.removeAll());
-        Assert.assertFalse(set.removeAll(<(literal.(type))("15")>, Abstract<name>SetTestCase.generateCollisions1().get(2), Abstract<name>SetTestCase.generateCollisions1().get(3)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.removeAll(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(3)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.removeAll(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)));
-        Assert.assertEquals(new <name>HashSet(), set);
-        Assert.assertFalse(set.removeAll(<(literal.(type))("1")>));
-        Assert.assertEquals(new <name>HashSet(), set);
+        assertFalse(set.removeAll());
+        assertFalse(set.removeAll(<(literal.(type))("15")>, Abstract<name>SetTestCase.generateCollisions1().get(2), Abstract<name>SetTestCase.generateCollisions1().get(3)));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.removeAll(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(3)));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.removeAll(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)));
+        assertEquals(new <name>HashSet(), set);
+        assertFalse(set.removeAll(<(literal.(type))("1")>));
+        assertEquals(new <name>HashSet(), set);
     }
 
     @Override
@@ -231,15 +236,15 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.removeAll_iterable();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(set.removeAll(new <name>ArrayList()));
-        Assert.assertFalse(set.removeAll(<name>ArrayList.newListWith(<(literal.(type))("15")>, Abstract<name>SetTestCase.generateCollisions1().get(2), Abstract<name>SetTestCase.generateCollisions1().get(3))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.removeAll(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.removeAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1))));
-        Assert.assertEquals(new <name>HashSet(), set);
-        Assert.assertFalse(set.removeAll(<name>HashSet.newSetWith(<(literal.(type))("1")>)));
-        Assert.assertEquals(new <name>HashSet(), set);
+        assertFalse(set.removeAll(new <name>ArrayList()));
+        assertFalse(set.removeAll(<name>ArrayList.newListWith(<(literal.(type))("15")>, Abstract<name>SetTestCase.generateCollisions1().get(2), Abstract<name>SetTestCase.generateCollisions1().get(3))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.removeAll(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4))));
+        assertEquals(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.removeAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1))));
+        assertEquals(new <name>HashSet(), set);
+        assertFalse(set.removeAll(<name>HashSet.newSetWith(<(literal.(type))("1")>)));
+        assertEquals(new <name>HashSet(), set);
     }
 
     @Override
@@ -248,14 +253,14 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.retainAll();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(set.retainAll(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.retainAll(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(1)));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.retainAll(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst()));
-        Assert.assertEquals(new <name>HashSet(), set);
-        Assert.assertFalse(set.retainAll(<(literal.(type))("1")>));
-        Assert.assertEquals(new <name>HashSet(), set);
+        assertFalse(set.retainAll(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.retainAll(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(1)));
+        assertEquals(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.retainAll(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst()));
+        assertEquals(new <name>HashSet(), set);
+        assertFalse(set.retainAll(<(literal.(type))("1")>));
+        assertEquals(new <name>HashSet(), set);
     }
 
     @Override
@@ -264,14 +269,14 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.retainAll_iterable();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertFalse(set.retainAll(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.retainAll(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(1))));
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
-        Assert.assertTrue(set.retainAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst())));
-        Assert.assertEquals(new <name>HashSet(), set);
-        Assert.assertFalse(set.retainAll(<name>HashSet.newSetWith(<(literal.(type))("1")>)));
-        Assert.assertEquals(new <name>HashSet(), set);
+        assertFalse(set.retainAll(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.retainAll(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(4), Abstract<name>SetTestCase.generateCollisions1().get(1))));
+        assertEquals(<name>HashSet.newSetWith(<["0", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().get(1)), set);
+        assertTrue(set.retainAll(<name>HashSet.newSetWith(<(literal.(type))("1")>, Abstract<name>SetTestCase.generateCollisions1().getFirst())));
+        assertEquals(new <name>HashSet(), set);
+        assertFalse(set.retainAll(<name>HashSet.newSetWith(<(literal.(type))("1")>)));
+        assertEquals(new <name>HashSet(), set);
     }
 
     @Override
@@ -282,19 +287,19 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         MutableSet\<<wrapperName>\> actual = UnifiedSet.newSet();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         <name>Iterator iterator = set.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -308,7 +313,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
             iterator.next();
         }
 
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -319,7 +324,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
 
         Mutable<name>Set set = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum = set.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("33")>), sum);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("33")>), sum);
     }
 
     @Override
@@ -331,7 +336,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         set.forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(32L + Abstract<name>SetTestCase.generateCollisions1().getFirst() + Abstract<name>SetTestCase.generateCollisions1().get(1), sum[0]<(delta.(type))>);
+        assertEquals(32L + Abstract<name>SetTestCase.generateCollisions1().getFirst() + Abstract<name>SetTestCase.generateCollisions1().get(1), sum[0]<(delta.(type))>);
     }
 
     @Override
@@ -340,9 +345,9 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.count();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertEquals(4L, set.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
-        Assert.assertEquals(3L, set.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
-        Assert.assertEquals(1L, set.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
+        assertEquals(4L, set.count(<name>Predicates.greaterThan(<(literal.(type))("0")>)));
+        assertEquals(3L, set.count(<name>Predicates.lessThan(<(literal.(type))("32")>)));
+        assertEquals(1L, set.count(<name>Predicates.greaterThan(<(literal.(type))("32")>)));
     }
 
     @Override
@@ -371,9 +376,9 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.detectIfNone();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertEquals(<(literal.(type))("0")>, set.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<(delta.(type))>);
-        Assert.assertEquals(Abstract<name>SetTestCase.generateCollisions1().get(1), set.detectIfNone(<name>Predicates.greaterThan(Abstract<name>SetTestCase.generateCollisions1().getFirst()), <(literal.(type))("9")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("9")>, set.detectIfNone(<name>Predicates.greaterThan(Abstract<name>SetTestCase.generateCollisions1().get(1)), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, set.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(Abstract<name>SetTestCase.generateCollisions1().get(1), set.detectIfNone(<name>Predicates.greaterThan(Abstract<name>SetTestCase.generateCollisions1().getFirst()), <(literal.(type))("9")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("9")>, set.detectIfNone(<name>Predicates.greaterThan(Abstract<name>SetTestCase.generateCollisions1().get(1)), <(literal.(type))("9")>)<(delta.(type))>);
     }
 
     @Override
@@ -382,7 +387,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.collect();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(<["-1", "0", "30"]:(literal.(type))(); separator=", ">, <(castIntToNarrowTypeWithParens.(type))({Abstract<name>SetTestCase.generateCollisions1().getFirst() - 1})>, <(castIntToNarrowTypeWithParens.(type))({Abstract<name>SetTestCase.generateCollisions1().get(1) - 1})>),
                 set.collect((<type> byteParameter) -> <(castIntToNarrowTypeWithParens.(type))("byteParameter - 1")>));
     }
@@ -393,7 +398,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.toSortedArray();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertArrayEquals(new <type>[]{<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)}, set.toSortedArray()<(delta.(type))>);
+        assertArrayEquals(new <type>[]{<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)}, set.toSortedArray()<(delta.(type))>);
     }
 
     @Override
@@ -419,16 +424,16 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         super.testEquals();
         Mutable<name>Set set1 = this.newWith(<["1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
     }
 
     @Override
@@ -437,7 +442,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     {
         super.asLazy();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
-        Assert.assertEquals(set.toSet(), set.asLazy().toSet());
+        assertEquals(set.toSet(), set.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, set.asLazy());
     }
 
@@ -448,7 +453,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         super.asSynchronized();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         Verify.assertInstanceOf(Synchronized<name>Set.class, set.asSynchronized());
-        Assert.assertEquals(new Synchronized<name>Set(set), set.asSynchronized());
+        assertEquals(new Synchronized<name>Set(set), set.asSynchronized());
     }
 
     @Override
@@ -458,7 +463,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
         super.asUnmodifiable();
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         Verify.assertInstanceOf(Unmodifiable<name>Set.class, set.asUnmodifiable());
-        Assert.assertEquals(new Unmodifiable<name>Set(set), set.asUnmodifiable());
+        assertEquals(new Unmodifiable<name>Set(set), set.asUnmodifiable());
     }
 
     @Test
@@ -498,7 +503,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertUnion(Mutable<name>Set set1, Mutable<name>Set set2, Mutable<name>Set expected)
     {
         Mutable<name>Set actual = set1.union(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -538,7 +543,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertIntersect(Mutable<name>Set set1, Mutable<name>Set set2, Mutable<name>Set expected)
     {
         Mutable<name>Set actual = set1.intersect(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -573,7 +578,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertDifference(Mutable<name>Set set1, Mutable<name>Set set2, Mutable<name>Set expected)
     {
         Mutable<name>Set actual = set1.difference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -608,7 +613,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertSymmetricDifference(Mutable<name>Set set1, Mutable<name>Set set2, Mutable<name>Set expected)
     {
         Mutable<name>Set actual = set1.symmetricDifference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -648,7 +653,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertIsSubsetOf(Mutable<name>Set set1, Mutable<name>Set set2, boolean expected)
     {
         boolean actual = set1.isSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -688,7 +693,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertIsProperSubsetOf(Mutable<name>Set set1, Mutable<name>Set set2, boolean expected)
     {
         boolean actual = set1.isProperSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -726,7 +731,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     private void assertCartesianProduct(Mutable<name>Set set1, Mutable<name>Set set2, MutableSet\<<name><name>Pair> expected)
     {
         MutableSet\<<name><name>Pair> actual = set1.cartesianProduct(set2).toSet();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }
 
@@ -738,10 +743,10 @@ public void add_<key>()
 {
     Mutable<name>Set set = this.newWith(<wrapperName>.<key>);
     Set\<<wrapperName>\> hashSet = new HashSet\<>();
-    Assert.assertTrue(hashSet.add(<wrapperName>.<key>));
+    assertTrue(hashSet.add(<wrapperName>.<key>));
 
-    Assert.assertFalse(hashSet.add(<wrapperName>.<key>));
-    Assert.assertFalse(set.add(<wrapperName>.<key>));
+    assertFalse(hashSet.add(<wrapperName>.<key>));
+    assertFalse(set.add(<wrapperName>.<key>));
     Verify.assertSize(hashSet.size(), set);
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
@@ -23,8 +23,12 @@ import java.util.HashSet;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link BoxedMutable<name>Set}.
@@ -40,7 +44,7 @@ public class BoxedMutable<name>SetTest
     @Test
     public void setCreationValidation()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new BoxedMutable<name>Set(null));
+        assertThrows(NullPointerException.class, () -> new BoxedMutable<name>Set(null));
     }
 
     @Test
@@ -55,13 +59,13 @@ public class BoxedMutable<name>SetTest
     @Test
     public void getFirst()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getLast());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getLast());
     }
 
     @Test
@@ -87,10 +91,10 @@ public class BoxedMutable<name>SetTest
     public void add()
     {
         BoxedMutable<name>Set set = this.classUnderTest();
-        Assert.assertFalse(set.add(<(literal.(type))("1")>));
-        Assert.assertEquals(Sets.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">), set);
-        Assert.assertTrue(set.add(<(literal.(type))("4")>));
-        Assert.assertEquals(Sets.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), set);
+        assertFalse(set.add(<(literal.(type))("1")>));
+        assertEquals(Sets.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">), set);
+        assertTrue(set.add(<(literal.(type))("4")>));
+        assertEquals(Sets.mutable.of(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), set);
     }
 
     @Test
@@ -100,7 +104,7 @@ public class BoxedMutable<name>SetTest
         Verify.assertTrue(set.remove(<(literal.(type))("1")>));
         Verify.assertFalse(set.remove(<(literal.(type))("1")>));
         Verify.assertFalse(set.remove("abc"));
-        Assert.assertEquals(Sets.mutable.of(<(literal.(type))("2")>, <(literal.(type))("3")>), set);
+        assertEquals(Sets.mutable.of(<(literal.(type))("2")>, <(literal.(type))("3")>), set);
     }
 
     @Test
@@ -114,7 +118,7 @@ public class BoxedMutable<name>SetTest
     @Test
     public void asParallel()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().asParallel(null, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().asParallel(null, 1));
     }
 
     @Test
@@ -122,7 +126,7 @@ public class BoxedMutable<name>SetTest
     {
         MutableSet\<<wrapperName>\> result = Sets.mutable.empty();
         this.classUnderTest().iterator().forEachRemaining(result::add);
-        Assert.assertEquals(Sets.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(Sets.mutable.of(<["1", "2", "3"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -140,16 +144,16 @@ public class BoxedMutable<name>SetTest
         BoxedMutable<name>Set set = new BoxedMutable<name>Set(original);
 
         original.remove(<(literal.(type))("2")>);
-        Assert.assertEquals(Sets.mutable.of(<["1", "3"]:(literal.(type))(); separator=", ">), set);
+        assertEquals(Sets.mutable.of(<["1", "3"]:(literal.(type))(); separator=", ">), set);
 
         original.add(<(literal.(type))("5")>);
-        Assert.assertEquals(Sets.mutable.of(<["1", "3", "5"]:(literal.(type))(); separator=", ">), set);
+        assertEquals(Sets.mutable.of(<["1", "3", "5"]:(literal.(type))(); separator=", ">), set);
 
         original.clear();
         Verify.assertEmpty(set);
 
         original.add(<(literal.(type))("7")>);
-        Assert.assertEquals(Sets.mutable.of(<(literal.(type))("7")>), set);
+        assertEquals(Sets.mutable.of(<(literal.(type))("7")>), set);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
@@ -23,8 +23,12 @@ import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>HashSet}.
@@ -50,7 +54,7 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         Field table = <name>HashSet.class.getDeclaredField("table");
         table.setAccessible(true);
         <name>HashSet hashSet = new <name>HashSet();
-        Assert.assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
     }
 
     @Test
@@ -59,16 +63,16 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         Field table = <name>HashSet.class.getDeclaredField("table");
         table.setAccessible(true);
         <name>HashSet hashSet = new <name>HashSet(3);
-        Assert.assertEquals(8L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(8L, ((<type>[]) table.get(hashSet)).length);
 
         <name>HashSet hashSet2 = new <name>HashSet(10);
-        Assert.assertEquals(32L, ((<type>[]) table.get(hashSet2)).length);
+        assertEquals(32L, ((<type>[]) table.get(hashSet2)).length);
     }
 
     @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>HashSet(-1));
+        assertThrows(IllegalArgumentException.class, () -> new <name>HashSet(-1));
     }
 
     @Override
@@ -79,108 +83,108 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         <name>HashSet set = <name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
         <name>HashSet hashSetFromList = <name>HashSet.newSet(<name>ArrayList.newListWith(<["0", "0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1)));
         <name>HashSet hashSetFromSet = <name>HashSet.newSet(set);
-        Assert.assertEquals(set, hashSetFromList);
-        Assert.assertEquals(set, hashSetFromSet);
+        assertEquals(set, hashSetFromList);
+        assertEquals(set, hashSetFromSet);
     }
 
     @Test
     public void addAndCheckField() throws NoSuchFieldException, IllegalAccessException
     {
         <name>HashSet hashSet = new <name>HashSet();
-        Assert.assertTrue(hashSet.add(<(literal.(type))("14")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("14")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("2")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("2")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("35")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("35")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("31")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("31")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("32")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("32")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("0")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("0")>));
-        Assert.assertTrue(hashSet.add(<(literal.(type))("1")>));
-        Assert.assertFalse(hashSet.add(<(literal.(type))("1")>));
+        assertTrue(hashSet.add(<(literal.(type))("14")>));
+        assertFalse(hashSet.add(<(literal.(type))("14")>));
+        assertTrue(hashSet.add(<(literal.(type))("2")>));
+        assertFalse(hashSet.add(<(literal.(type))("2")>));
+        assertTrue(hashSet.add(<(literal.(type))("35")>));
+        assertFalse(hashSet.add(<(literal.(type))("35")>));
+        assertTrue(hashSet.add(<(literal.(type))("31")>));
+        assertFalse(hashSet.add(<(literal.(type))("31")>));
+        assertTrue(hashSet.add(<(literal.(type))("32")>));
+        assertFalse(hashSet.add(<(literal.(type))("32")>));
+        assertTrue(hashSet.add(<(literal.(type))("0")>));
+        assertFalse(hashSet.add(<(literal.(type))("0")>));
+        assertTrue(hashSet.add(<(literal.(type))("1")>));
+        assertFalse(hashSet.add(<(literal.(type))("1")>));
         Field zeroToThirtyOne = <name>HashSet.class.getDeclaredField("zeroToThirtyOne");
         zeroToThirtyOne.setAccessible(true);
-        Assert.assertEquals(-2147467257L, ((Integer) zeroToThirtyOne.get(hashSet)).longValue());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["14", "2", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">), hashSet);
+        assertEquals(-2147467257L, ((Integer) zeroToThirtyOne.get(hashSet)).longValue());
+        assertEquals(<name>HashSet.newSetWith(<["14", "2", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">), hashSet);
     }
 
     @Test
     public void addWithRehash() throws NoSuchFieldException, IllegalAccessException
     {
         <name>HashSet hashSet = new <name>HashSet();
-        Assert.assertTrue(hashSet.addAll(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">));
+        assertTrue(hashSet.addAll(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">));
 
         Field table = <name>HashSet.class.getDeclaredField("table");
         table.setAccessible(true);
-        Assert.assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
 
         Field occupiedWithData = <name>HashSet.class.getDeclaredField("occupiedWithData");
         Field occupiedWithSentinels = <name>HashSet.class.getDeclaredField("occupiedWithSentinels");
         occupiedWithData.setAccessible(true);
         occupiedWithSentinels.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashSet));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashSet));
+        assertEquals(8, occupiedWithData.get(hashSet));
+        assertEquals(0, occupiedWithSentinels.get(hashSet));
 
-        Assert.assertEquals(<name>HashSet.newSetWith(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">), hashSet);
+        assertEquals(<name>HashSet.newSetWith(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">), hashSet);
 
         hashSet.remove(<(literal.(type))("32")>);
-        Assert.assertEquals(7, occupiedWithData.get(hashSet));
-        Assert.assertEquals(1, occupiedWithSentinels.get(hashSet));
+        assertEquals(7, occupiedWithData.get(hashSet));
+        assertEquals(1, occupiedWithSentinels.get(hashSet));
 
         hashSet.add(<(literal.(type))("32")>); //adding to a REMOVED slot
-        Assert.assertEquals(8, occupiedWithData.get(hashSet));
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashSet));
+        assertEquals(8, occupiedWithData.get(hashSet));
+        assertEquals(0, occupiedWithSentinels.get(hashSet));
 
-        Assert.assertTrue(hashSet.add(<(literal.(type))("43")>));
-        Assert.assertEquals(32L, ((<type>[]) table.get(hashSet)).length);
-        Assert.assertEquals(9, occupiedWithData.get(hashSet));
+        assertTrue(hashSet.add(<(literal.(type))("43")>));
+        assertEquals(32L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(9, occupiedWithData.get(hashSet));
     }
 
     @Test
     public void removeWithRehash() throws NoSuchFieldException, IllegalAccessException
     {
         <name>HashSet hashSet = new <name>HashSet();
-        Assert.assertTrue(hashSet.addAll(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">));
+        assertTrue(hashSet.addAll(<["32", "33", "34", "35", "36", "37", "38", "39"]:(literal.(type))(); separator=", ">));
 
         Field table = <name>HashSet.class.getDeclaredField("table");
         table.setAccessible(true);
-        Assert.assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
 
         Field occupiedWithData = <name>HashSet.class.getDeclaredField("occupiedWithData");
         occupiedWithData.setAccessible(true);
-        Assert.assertEquals(8, occupiedWithData.get(hashSet));
+        assertEquals(8, occupiedWithData.get(hashSet));
 
         Field occupiedWithSentinels = <name>HashSet.class.getDeclaredField("occupiedWithSentinels");
         occupiedWithSentinels.setAccessible(true);
-        Assert.assertEquals(0, occupiedWithSentinels.get(hashSet));
+        assertEquals(0, occupiedWithSentinels.get(hashSet));
 
         for (int i = 0; i \< 4; i++)
         {
             hashSet.remove(<(castIntToNarrowTypeWithParens.(type))("i + 32")>);
-            Assert.assertEquals(7 - i, occupiedWithData.get(hashSet));
-            Assert.assertEquals(i + 1, occupiedWithSentinels.get(hashSet));
+            assertEquals(7 - i, occupiedWithData.get(hashSet));
+            assertEquals(i + 1, occupiedWithSentinels.get(hashSet));
         }
 
-        Assert.assertEquals(<name>HashSet.newSetWith(<["36", "37", "38", "39"]:(literal.(type))(); separator=", ">), hashSet);
-        Assert.assertTrue(hashSet.remove(<(literal.(type))("36")>));
-        Assert.assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
-        Assert.assertEquals(3, occupiedWithData.get(hashSet));
-        Assert.assertEquals(5, occupiedWithSentinels.get(hashSet));
+        assertEquals(<name>HashSet.newSetWith(<["36", "37", "38", "39"]:(literal.(type))(); separator=", ">), hashSet);
+        assertTrue(hashSet.remove(<(literal.(type))("36")>));
+        assertEquals(16L, ((<type>[]) table.get(hashSet)).length);
+        assertEquals(3, occupiedWithData.get(hashSet));
+        assertEquals(5, occupiedWithSentinels.get(hashSet));
 
-        Assert.assertFalse(hashSet.remove(<(literal.(type))("36")>));
-        Assert.assertEquals(3, occupiedWithData.get(hashSet));
-        Assert.assertEquals(5, occupiedWithSentinels.get(hashSet));
+        assertFalse(hashSet.remove(<(literal.(type))("36")>));
+        assertEquals(3, occupiedWithData.get(hashSet));
+        assertEquals(5, occupiedWithSentinels.get(hashSet));
 
-        Assert.assertFalse(hashSet.remove(<(literal.(type))("1")>));
-        Assert.assertEquals(3, occupiedWithData.get(hashSet));
-        Assert.assertEquals(5, occupiedWithSentinels.get(hashSet));
+        assertFalse(hashSet.remove(<(literal.(type))("1")>));
+        assertEquals(3, occupiedWithData.get(hashSet));
+        assertEquals(5, occupiedWithSentinels.get(hashSet));
 
         <name>HashSet setForCopyTable = <name>HashSet.newSetWith(<["36", "37", "38", "39"]:(literal.(type))(); separator=", ">);
         setForCopyTable.freeze();
-        Assert.assertTrue(setForCopyTable.remove(<(literal.(type))("36")>));
+        assertTrue(setForCopyTable.remove(<(literal.(type))("36")>));
     }
 
     @Test
@@ -206,7 +210,7 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
     {
         Verify.assertSize(max, set);
         Mutable<name>Iterator iterator = set.<type>Iterator();
-        Assert.assertThrows(IllegalStateException.class, () -> iterator.remove());
+        assertThrows(IllegalStateException.class, () -> iterator.remove());
 
         while (iterator.hasNext())
         {
@@ -230,9 +234,9 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
     {
         for (<type> i = <(literal.(type))("100")>; i \< <(literal.(type))("200")>; i++)
         {
-            Assert.assertFalse(hashSet.contains(i));
-            Assert.assertTrue(hashSet.add(i));
-            Assert.assertTrue(hashSet.remove(i));
+            assertFalse(hashSet.contains(i));
+            assertTrue(hashSet.add(i));
+            assertTrue(hashSet.remove(i));
         }
     }
 
@@ -245,28 +249,28 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         <type> collision4 = Abstract<name>SetTestCase.generateCollisions1().get(3);
 
         <name>HashSet hashSet = new <name>HashSet();
-        Assert.assertTrue(hashSet.add(collision1));
-        Assert.assertTrue(hashSet.add(collision2));
-        Assert.assertTrue(hashSet.add(collision3));
-        Assert.assertTrue(hashSet.remove(collision2));
-        Assert.assertTrue(hashSet.add(collision4));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision1, collision3, collision4), hashSet);
+        assertTrue(hashSet.add(collision1));
+        assertTrue(hashSet.add(collision2));
+        assertTrue(hashSet.add(collision3));
+        assertTrue(hashSet.remove(collision2));
+        assertTrue(hashSet.add(collision4));
+        assertEquals(<name>HashSet.newSetWith(collision1, collision3, collision4), hashSet);
 
         <name>HashSet hashSet2 = new <name>HashSet();
-        Assert.assertTrue(hashSet2.add(collision1));
-        Assert.assertTrue(hashSet2.add(collision2));
-        Assert.assertTrue(hashSet2.add(collision3));
-        Assert.assertTrue(hashSet2.remove(collision1));
-        Assert.assertTrue(hashSet2.add(collision4));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision2, collision3, collision4), hashSet2);
+        assertTrue(hashSet2.add(collision1));
+        assertTrue(hashSet2.add(collision2));
+        assertTrue(hashSet2.add(collision3));
+        assertTrue(hashSet2.remove(collision1));
+        assertTrue(hashSet2.add(collision4));
+        assertEquals(<name>HashSet.newSetWith(collision2, collision3, collision4), hashSet2);
 
         <name>HashSet hashSet3 = new <name>HashSet();
-        Assert.assertTrue(hashSet3.add(collision1));
-        Assert.assertTrue(hashSet3.add(collision2));
-        Assert.assertTrue(hashSet3.add(collision3));
-        Assert.assertTrue(hashSet3.remove(collision3));
-        Assert.assertTrue(hashSet3.add(collision4));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision1, collision2, collision4), hashSet3);
+        assertTrue(hashSet3.add(collision1));
+        assertTrue(hashSet3.add(collision2));
+        assertTrue(hashSet3.add(collision3));
+        assertTrue(hashSet3.remove(collision3));
+        assertTrue(hashSet3.add(collision4));
+        assertEquals(<name>HashSet.newSetWith(collision1, collision2, collision4), hashSet3);
     }
 
     @Test
@@ -275,9 +279,9 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         <name>HashSet hashSet = new <name>HashSet();
         <type> collision1 = Abstract<name>SetTestCase.generateCollisions1().getFirst();
         <type> collision2 = Abstract<name>SetTestCase.generateCollisions1().get(1);
-        Assert.assertTrue(hashSet.add(collision1));
-        Assert.assertTrue(hashSet.add(collision2));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision1, collision2), hashSet);
+        assertTrue(hashSet.add(collision1));
+        assertTrue(hashSet.add(collision2));
+        assertEquals(<name>HashSet.newSetWith(collision1, collision2), hashSet);
     }
 
     @Test
@@ -290,15 +294,15 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         <type> collision5 = Abstract<name>SetTestCase.generateCollisions1().get(4);
 
         <name>HashSet hashSet = <name>HashSet.newSetWith(collision1, collision2, collision4);
-        Assert.assertTrue(hashSet.remove(collision1));
-        Assert.assertTrue(hashSet.add(collision3));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision3, collision2, collision4), hashSet);
-        Assert.assertTrue(hashSet.remove(collision2));
-        Assert.assertTrue(hashSet.add(collision5));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision3, collision5, collision4), hashSet);
-        Assert.assertTrue(hashSet.remove(collision4));
-        Assert.assertTrue(hashSet.add(collision1));
-        Assert.assertEquals(<name>HashSet.newSetWith(collision3, collision5, collision1), hashSet);
+        assertTrue(hashSet.remove(collision1));
+        assertTrue(hashSet.add(collision3));
+        assertEquals(<name>HashSet.newSetWith(collision3, collision2, collision4), hashSet);
+        assertTrue(hashSet.remove(collision2));
+        assertTrue(hashSet.add(collision5));
+        assertEquals(<name>HashSet.newSetWith(collision3, collision5, collision4), hashSet);
+        assertTrue(hashSet.remove(collision4));
+        assertTrue(hashSet.add(collision1));
+        assertEquals(<name>HashSet.newSetWith(collision3, collision5, collision1), hashSet);
     }
 
     @Test
@@ -307,23 +311,23 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         <name>HashSet hashSet = <name>HashSet.newSetWith();
         for (<type> i = <(literal.(type))("0")>; i \<= <(literal.(type))("31")>; i++)
         {
-            Assert.assertTrue(hashSet.add(i));
-            Assert.assertFalse(hashSet.add(i));
+            assertTrue(hashSet.add(i));
+            assertFalse(hashSet.add(i));
         }
         for (<type> i = <(literal.(type))("0")>; i \<= <(literal.(type))("31")>; i++)
         {
-            Assert.assertTrue(hashSet.contains(i));
+            assertTrue(hashSet.contains(i));
         }
 
         for (<type> i = <(literal.(type))("0")>; i \<= <(literal.(type))("31")>; i++)
         {
-            Assert.assertTrue(hashSet.contains(i));
-            Assert.assertTrue(hashSet.remove(i));
-            Assert.assertFalse(hashSet.contains(i));
-            Assert.assertFalse(hashSet.remove(i));
+            assertTrue(hashSet.contains(i));
+            assertTrue(hashSet.remove(i));
+            assertFalse(hashSet.contains(i));
+            assertFalse(hashSet.remove(i));
         }
 
-        Assert.assertEquals(new <name>HashSet(), hashSet);
+        assertEquals(new <name>HashSet(), hashSet);
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/synchronizedPrimitiveSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/synchronizedPrimitiveSetTest.stg
@@ -18,8 +18,10 @@ body(type, wrapperName, name) ::= <<
 package org.eclipse.collections.impl.set.mutable.primitive;
 
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>Set}.
@@ -46,10 +48,10 @@ public class Synchronized<name>SetTest extends Abstract<name>SetTestCase
         super.asSynchronized();
         Synchronized<name>Set set = this.classUnderTest();
         Mutable<name>Set setWithLockObject = new Synchronized<name>Set(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), new Object());
-        Assert.assertEquals(set, setWithLockObject);
-        Assert.assertSame(setWithLockObject, setWithLockObject.asSynchronized());
-        Assert.assertSame(set, set.asSynchronized());
-        Assert.assertEquals(set, set.asSynchronized());
+        assertEquals(set, setWithLockObject);
+        assertSame(setWithLockObject, setWithLockObject.asSynchronized());
+        assertSame(set, set.asSynchronized());
+        assertEquals(set, set.asSynchronized());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
@@ -22,8 +22,13 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>Set}.
@@ -47,14 +52,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -62,14 +67,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(this.newMutableCollectionWith()));
     }
 
@@ -77,14 +82,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
@@ -92,14 +97,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().removeAll(this.newMutableCollectionWith()));
     }
 
@@ -107,14 +112,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().retainAll(this.newMutableCollectionWith()));
     }
 
@@ -122,14 +127,14 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>)));
     }
 
@@ -137,7 +142,7 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>));
     }
 
@@ -145,7 +150,7 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                         this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)
                         .withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
     }
@@ -155,24 +160,24 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     public void contains()
     {
         Unmodifiable<name>Set set = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertFalse(set.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(set.contains(<(literal.(type))("49")>));
+        assertFalse(set.contains(<(literal.(type))("29")>));
+        assertFalse(set.contains(<(literal.(type))("49")>));
 
         <type>[] numbers = {<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">};
         for (<type> number : numbers)
         {
-            Assert.assertTrue(set.contains(number));
+            assertTrue(set.contains(number));
         }
 
-        Assert.assertFalse(set.contains(<(literal.(type))("-1")>));
-        Assert.assertFalse(set.contains(<(literal.(type))("29")>));
-        Assert.assertFalse(set.contains(<(literal.(type))("49")>));
+        assertFalse(set.contains(<(literal.(type))("-1")>));
+        assertFalse(set.contains(<(literal.(type))("29")>));
+        assertFalse(set.contains(<(literal.(type))("49")>));
 
         Unmodifiable<name>Set set1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertTrue(set1.contains(<(literal.(type))("0")>));
-        Assert.assertTrue(set1.contains(<(literal.(type))("1")>));
-        Assert.assertTrue(set1.contains(<(literal.(type))("2")>));
-        Assert.assertFalse(set1.contains(<(literal.(type))("3")>));
+        assertTrue(set1.contains(<(literal.(type))("0")>));
+        assertTrue(set1.contains(<(literal.(type))("1")>));
+        assertTrue(set1.contains(<(literal.(type))("2")>));
+        assertFalse(set1.contains(<(literal.(type))("3")>));
     }
 
     @Override
@@ -185,7 +190,7 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
         {
             iterator.next();
         }
-        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -194,25 +199,25 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     {
         Unmodifiable<name>Set set = this.classUnderTest();
         super.asUnmodifiable();
-        Assert.assertSame(set, set.asUnmodifiable());
-        Assert.assertEquals(set, set.asUnmodifiable());
+        assertSame(set, set.asUnmodifiable());
+        assertEquals(set, set.asUnmodifiable());
     }
 
     @Override
     public void <type>Iterator_with_remove()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
     public void <type>Iterator_throws_for_remove_before_next()
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -229,14 +234,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
                     this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -244,14 +249,14 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 @Test
 public void boxed()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("4")>));
+    assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("4")>));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
@@ -29,8 +29,12 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Stack}.
@@ -81,11 +85,11 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
         Immutable<name>Stack stack = this.classUnderTest();
         int size = stack.size();
         Immutable<name>Stack modified = stack.push(<(literal.(type))("5")>);
-        Assert.assertEquals(<(literal.(type))("5")>, modified.peek()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("5")>, modified.peek()<wideDelta.(type)>);
         Verify.assertSize(size + 1, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test
@@ -94,11 +98,11 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
         Immutable<name>Stack stack = this.classUnderTest();
         int size = stack.size();
         Immutable<name>Stack modified = stack.pop();
-        Assert.assertEquals(size - 1, modified.peek()<wideDelta.(type)>);
+        assertEquals(size - 1, modified.peek()<wideDelta.(type)>);
         Verify.assertSize(size - 1, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test
@@ -106,27 +110,27 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     {
         Immutable<name>Stack stack = this.classUnderTest();
         Immutable<name>Stack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
         int size = stack.size();
         Immutable<name>Stack modified = stack.pop(2);
-        Assert.assertEquals(size - 2, modified.peek()<wideDelta.(type)>);
+        assertEquals(size - 2, modified.peek()<wideDelta.(type)>);
         Verify.assertSize(size - 2, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test
     public void pop_with_negative_count_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().pop(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().pop(-1));
     }
 
     @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 this.classUnderTest().pop(this.classUnderTest().size() + 1));
     }
 
@@ -134,16 +138,16 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     @Test
     public void testToString()
     {
-        Assert.assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
+        assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
-        Assert.assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
+        assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
+        assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
+        assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
     }
 
     @Override
@@ -152,15 +156,15 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     {
         StringBuilder appendable1 = new StringBuilder();
         this.classUnderTest().appendString(appendable1);
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
+        assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2, "|");
-        Assert.assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
+        assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "{", "|", "}");
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
+        assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
     }
 
     @Override
@@ -169,14 +173,14 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     {
         <name>ArrayList expected = <name>ArrayList.newListWith();
         this.classUnderTest().forEach(expected::add);
-        Assert.assertEquals(expected, this.classUnderTest().toList());
+        assertEquals(expected, this.classUnderTest().toList());
     }
 
     @Override
     @Test
     public void medianThrowsOnEmpty()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> <name>Stacks.immutable.of().median());
+        assertThrows(ArithmeticException.class, () -> <name>Stacks.immutable.of().median());
     }
 
     @Override
@@ -185,7 +189,7 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     {
         super.toImmutable();
         Immutable<name>Stack expected = this.classUnderTest();
-        Assert.assertSame(expected, expected.toImmutable());
+        assertSame(expected, expected.toImmutable());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
@@ -25,8 +25,10 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Immutable<name>ArrayStack}.
@@ -43,20 +45,20 @@ public class Immutable<name>ArrayStackTest extends AbstractImmutable<name>StackT
     @Test
     public void testNewStack_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 Immutable<name>ArrayStack.newStack(<name>Stacks.mutable.with(<["1"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void newWithIterable()
     {
-        Assert.assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWithIterable(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWithIterable(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void newWithTopToBottom()
     {
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWithTopToBottom(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWithTopToBottom(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
@@ -67,14 +69,14 @@ public class Immutable<name>ArrayStackTest extends AbstractImmutable<name>StackT
 
         Immutable<name>ArrayStack iterable = Immutable<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAllReversed(Immutable<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack, Immutable<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toStack());
+        assertEquals(stack, Immutable<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyStack}.
@@ -48,14 +53,14 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     @Test
     public void pop()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop());
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop());
     }
 
     @Override
     @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop(1));
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop(1));
     }
 
     @Override
@@ -64,8 +69,8 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     {
         Immutable<name>Stack stack = this.classUnderTest();
         Immutable<name>Stack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
@@ -73,84 +78,84 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     public void <type>Iterator()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
     @Test
     public void peek()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peek());
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().peek());
     }
 
     @Test
     public void peekWithCount()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertThrows(EmptyStackException.class, () -> { this.classUnderTest().peek(1); });
+        assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertThrows(EmptyStackException.class, () -> { this.classUnderTest().peek(1); });
     }
 
     @Override
     @Test
     public void peek_at_index_equal_to_size_throws_exception()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(0));
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(0));
     }
 
     @Override
     @Test
     public void peek_at_index_greater_than_size_throws_exception()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(1));
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(1));
     }
 
     @Override
     @Test
     public void average()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
     }
 
     @Override
     @Test
     public void median()
     {
-        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Override
@@ -175,15 +180,15 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
 
         Immutable<name>EmptyStack iterable = new Immutable<name>EmptyStack();
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = this.classUnderTest().toStack();
-        Assert.assertTrue(stack.isEmpty());
-        Assert.assertEquals(<name>Stacks.mutable.empty(), stack);
+        assertTrue(stack.isEmpty());
+        assertEquals(<name>Stacks.mutable.empty(), stack);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveSingletonStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveSingletonStackTest.stg
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>SingletonStack}.
@@ -51,8 +56,8 @@ public class Immutable<name>SingletonStackTest extends AbstractImmutable<name>St
         Immutable<name>Stack modified = stack.pop();
         Verify.assertEmpty(modified);
         Verify.assertSize(1, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
@@ -61,13 +66,13 @@ public class Immutable<name>SingletonStackTest extends AbstractImmutable<name>St
     {
         Immutable<name>Stack stack = this.classUnderTest();
         Immutable<name>Stack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
         Immutable<name>Stack modified = stack.pop(1);
         Verify.assertEmpty(modified);
         Verify.assertSize(1, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
@@ -75,19 +80,19 @@ public class Immutable<name>SingletonStackTest extends AbstractImmutable<name>St
     public void detectIfNone()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
     }
 
     @Override
     @Test
     public void peek()
     {
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().peek()<wideDelta.(type)>);
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>),
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().peek()<wideDelta.(type)>);
+        assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>),
                 this.classUnderTest().peek(1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> { this.classUnderTest().peek(2); });
+        assertThrows(IllegalArgumentException.class, () -> { this.classUnderTest().peek(2); });
     }
 
     @Override
@@ -95,13 +100,13 @@ public class Immutable<name>SingletonStackTest extends AbstractImmutable<name>St
     public void testEquals()
     {
         Immutable<name>Stack stack = this.classUnderTest();
-        Assert.assertEquals(stack, stack);
+        assertEquals(stack, stack);
         Verify.assertPostSerializedEqualsAndHashCode(stack);
-        Assert.assertEquals(stack, <name>ArrayStack.newStackWith(<(literal.(type))("1")>));
-        Assert.assertNotEquals(stack, this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>));
-        Assert.assertNotEquals(stack, <name>ArrayList.newListWith(<(literal.(type))("1")>));
-        Assert.assertEquals(stack, this.newWith(<(literal.(type))("1")>));
-        Assert.assertNotEquals(stack, this.newWith());
+        assertEquals(stack, <name>ArrayStack.newStackWith(<(literal.(type))("1")>));
+        assertNotEquals(stack, this.newWith(<(literal.(type))("1")>, <(literal.(type))("2")>));
+        assertNotEquals(stack, <name>ArrayList.newListWith(<(literal.(type))("1")>));
+        assertEquals(stack, this.newWith(<(literal.(type))("1")>));
+        assertNotEquals(stack, this.newWith());
     }
 
     @Override
@@ -112,14 +117,14 @@ public class Immutable<name>SingletonStackTest extends AbstractImmutable<name>St
 
         Immutable<name>SingletonStack iterable = new Immutable<name>SingletonStack(<(literal.(type))("1")>);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("1")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.with(<(literal.(type))("1")>);
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
@@ -26,8 +26,12 @@ import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Stack}.
@@ -58,7 +62,7 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         Mutable<name>Stack stack = this.classUnderTest();
         int size = stack.size();
         stack.pop(2);
-        Assert.assertEquals(size - 2, stack.peekAt(0)<wideDelta.(type)>);
+        assertEquals(size - 2, stack.peekAt(0)<wideDelta.(type)>);
     }
 
     @Override
@@ -70,7 +74,7 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         int size = this.classUnderTest().size();
         for (int i = 0; i \< size; i++)
         {
-            Assert.assertEquals(size - i, stack.peek()<wideDelta.(type)>);
+            assertEquals(size - i, stack.peek()<wideDelta.(type)>);
             stack.pop();
         }
     }
@@ -80,51 +84,51 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
     {
         Mutable<name>Stack stack = this.classUnderTest();
         int size = stack.size();
-        Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), stack.peek(2));
+        assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), stack.peek(2));
         stack.pop(2);
-        Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowTypeWithParens.(type))("size - 2")>), stack.peek(1));
+        assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowTypeWithParens.(type))("size - 2")>), stack.peek(1));
     }
 
     @Test
     public void peek_empty_stack_throws_exception()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newWith().peek());
+        assertThrows(EmptyStackException.class, () -> this.newWith().peek());
     }
 
     @Test
     public void testNewStackWithOrder()
     {
         Mutable<name>Stack stack = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
     }
 
     @Test
     public void testNewStackIterableOrder()
     {
         Mutable<name>Stack stack = this.newWithIterable(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
     }
 
     @Test
     public void testNewStackFromTopToBottomOrder()
     {
         Mutable<name>Stack stack = this.newWithTopToBottom(<["3", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
     }
 
     @Test
     public void testNewStackFromTopToBottomIterableOrder()
     {
         Mutable<name>Stack stack = this.newWithIterableTopToBottom(<name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
-        Assert.assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("3")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("2")>, stack.pop()<wideDelta.(type)>);
+        assertEquals(<(literal.(type))("1")>, stack.pop()<wideDelta.(type)>);
     }
 
     @Test
@@ -136,7 +140,7 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         Verify.assertSize(size + 1, stack);
         stack.pop();
         Verify.assertSize(size, stack);
-        Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), stack.peek(2));
+        assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), stack.peek(2));
     }
 
     @Test
@@ -146,7 +150,7 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         int size = stack.size();
         for (int i = 0; i \< size; i++)
         {
-            Assert.assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, stack.pop()<wideDelta.(type)>);
+            assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, stack.pop()<wideDelta.(type)>);
             Verify.assertSize(size - i - 1, stack);
         }
     }
@@ -155,7 +159,7 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
     public void popWithCount()
     {
         int size = this.classUnderTest().size();
-        Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), this.classUnderTest().pop(2));
+        assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("size")>, <(castIntToNarrowTypeWithParens.(type))("size - 1")>), this.classUnderTest().pop(2));
     }
 
     @Test
@@ -173,33 +177,33 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
     @Test
     public void pop_empty_stack_throws_exception()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newWith().pop());
+        assertThrows(EmptyStackException.class, () -> this.newWith().pop());
     }
 
     @Test
     public void pop_with_negative_count_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(-1));
     }
 
     @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(2));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(2));
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(Synchronized<name>Stack.class, this.classUnderTest().asSynchronized());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().asSynchronized());
+        assertEquals(this.classUnderTest(), this.classUnderTest().asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(Unmodifiable<name>Stack.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
     }
 
     /**
@@ -208,8 +212,8 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
     @Test
     public void newEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().newEmpty().isEmpty());
-        Assert.assertNotSame(this.classUnderTest(), this.classUnderTest().newEmpty());
+        assertTrue(this.classUnderTest().newEmpty().isEmpty());
+        assertNotSame(this.classUnderTest(), this.classUnderTest().newEmpty());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
@@ -41,8 +41,12 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Abstract JUnit test for {@link <name>Stack}.
@@ -78,19 +82,19 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         int size = this.classUnderTest().size();
         for (int i = 0; i \< size; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, iterator.next()<wideDelta.(type)>);
+            assertTrue(iterator.hasNext());
+            assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, iterator.next()<wideDelta.(type)>);
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(size, this.classUnderTest().<type>Iterator().next()<wideDelta.(type)>);
+        assertFalse(iterator.hasNext());
+        assertEquals(size, this.classUnderTest().<type>Iterator().next()<wideDelta.(type)>);
     }
 
     @Test
     public void peek()
     {
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().peek()<wideDelta.(type)>);
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("this.classUnderTest().size()")>, <(castIntToNarrowTypeWithParens.(type))("this.classUnderTest().size() - 1")>),
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().peek()<wideDelta.(type)>);
+        assertEquals(<name>ArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowType.(type))("this.classUnderTest().size()")>, <(castIntToNarrowTypeWithParens.(type))("this.classUnderTest().size() - 1")>),
                 this.classUnderTest().peek(2));
     }
 
@@ -100,27 +104,27 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         int size = this.classUnderTest().size();
         for (int i = 0; i \< size; i++)
         {
-            Assert.assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, this.classUnderTest().peekAt(i)<wideDelta.(type)>);
+            assertEquals(<(castIntToNarrowTypeWithParens.(type))("size - i")>, this.classUnderTest().peekAt(i)<wideDelta.(type)>);
         }
     }
 
     @Test
     public void peek_at_index_less_than_zero_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().peekAt(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().peekAt(-1));
     }
 
     @Test
     public void peek_at_index_greater_than_size_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 this.classUnderTest().peekAt(this.classUnderTest().size() + 1));
     }
 
     @Test
     public void peek_at_index_equal_to_size_throws_exception()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 this.classUnderTest().peekAt(this.classUnderTest().size()));
     }
 
@@ -129,7 +133,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
+        assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
     }
 
     @Override
@@ -143,7 +147,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         {
             list.add(<(castIntToNarrowTypeWithParens.(type))("size - i")>);
         }
-        Assert.assertEquals(list, this.classUnderTest().toList());
+        assertEquals(list, this.classUnderTest().toList());
     }
 
     @Override
@@ -151,9 +155,9 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
-        Assert.assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
+        assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
+        assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
+        assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
     }
 
     protected String createExpectedString(String start, String sep, String end)
@@ -175,15 +179,15 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
     {
         <name>Iterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
-        Assert.assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<wideDelta.(type)>);
-        Assert.assertEquals(size > 0 ? <(wideLiteral.(type))("3")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
-        Assert.assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(size > 0 ? <(wideLiteral.(type))("3")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<wideDelta.(type)>);
+        assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<wideDelta.(type)>);
 
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<wideDelta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<wideDelta.(type)>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<wideDelta.(type)>);
     }
 
     @Override
@@ -193,21 +197,21 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.classUnderTest().appendString(appendable1);
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
+        assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2, "|");
-        Assert.assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
+        assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "{", "|", "}");
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
+        assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(Immutable<name>Stack.class, this.classUnderTest().toImmutable());
     }
 
@@ -220,7 +224,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         <name>Stack stack = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         <name>Stack selected = stack.selectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Stacks.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Stacks.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -232,7 +236,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         <name>Stack stack = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = stack.selectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["7", "1"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.immutable.with(<["7", "1"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -244,7 +248,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         <name>Stack stack = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         <name>Stack rejected = stack.rejectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Stacks.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Stacks.mutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -256,7 +260,7 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         <name>Stack stack = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List rejected = stack.rejectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["9", "3"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Lists.immutable.with(<["9", "3"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -267,10 +271,10 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
     {
         StackIterable\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
     }
@@ -283,17 +287,17 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
     {
         MutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["7", "9", "1", "3"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
 
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Sets.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Sets.mutable.empty()));
     }
@@ -346,35 +350,35 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
 
         Verify.assertIterablesEqual(Lists.mutable.with(), this.newWith().chunk(1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(-1));
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
     }
 
     @Test
     public void indexOf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().indexOf(<["0"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
     public void injectIntoWithIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().injectIntoWithIndex(null, null));
     }
 
     @Test
     public void forEachWithIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().forEachWithIndex(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().forEachWithIndex(null));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/primitiveArrayStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/primitiveArrayStackTest.stg
@@ -24,8 +24,9 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link <name>ArrayStack}.
@@ -80,37 +81,37 @@ public class <name>ArrayStackTest extends AbstractMutable<name>StackTestCase
     {
         <name>ArrayStack stack = <name>ArrayStack.newStackFromTopToBottom();
         stack.push(<["1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1"]:(literal.(type))(); separator=", ">), stack);
+        assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1"]:(literal.(type))(); separator=", ">), stack);
 
         stack.push(<["2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack);
+        assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack);
 
         stack.push(<["3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<["3"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack);
+        assertEquals(<["3"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack);
 
-        Assert.assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peekAt(1)<(delta.(type))>);
-        Assert.assertEquals(<["3"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
-        Assert.assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
-        Assert.assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
-        Assert.assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
-        Assert.assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
+        assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peekAt(1)<(delta.(type))>);
+        assertEquals(<["3"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
+        assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
+        assertEquals(<["2"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
+        assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.peek()<(delta.(type))>);
+        assertEquals(<["1"]:(literal.(type))(); separator=", ">, stack.pop()<(delta.(type))>);
 
         <name>ArrayStack stack2 = <name>ArrayStack.newStackFromTopToBottom(<["5"]:(literal.(type))(); separator=", ">, <["4"]:(literal.(type))(); separator=", ">, <["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">);
         stack2.pop(2);
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack2);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">), stack2.peek(2));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["1"]:(literal.(type))(); separator=", ">), stack2);
+        assertEquals(<name>ArrayList.newListWith(<["3"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">), stack2.peek(2));
 
         <name>ArrayStack stack8 = <name>ArrayStack.newStackFromTopToBottom(<["1"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["3"]:(literal.(type))(); separator=", ">, <["4"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(0, stack8.pop(0));
-        Assert.assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["3"]:(literal.(type))(); separator=", ">, <["4"]:(literal.(type))(); separator=", ">), stack8);
-        Assert.assertEquals(new <name>ArrayList(), stack8.peek(0));
+        assertEquals(<name>ArrayStack.newStackFromTopToBottom(<["1"]:(literal.(type))(); separator=", ">, <["2"]:(literal.(type))(); separator=", ">, <["3"]:(literal.(type))(); separator=", ">, <["4"]:(literal.(type))(); separator=", ">), stack8);
+        assertEquals(new <name>ArrayList(), stack8.peek(0));
 
         <name>ArrayStack stack9 = <name>ArrayStack.newStackFromTopToBottom();
-        Assert.assertEquals(new <name>ArrayList(), stack9.pop(0));
-        Assert.assertEquals(new <name>ArrayList(), stack9.peek(0));
+        assertEquals(new <name>ArrayList(), stack9.pop(0));
+        assertEquals(new <name>ArrayList(), stack9.peek(0));
     }
 
     @Test
@@ -123,7 +124,7 @@ public class <name>ArrayStackTest extends AbstractMutable<name>StackTestCase
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/synchronizedPrimitiveStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/synchronizedPrimitiveStackTest.stg
@@ -20,8 +20,10 @@ package org.eclipse.collections.impl.stack.mutable.primitive;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file synchronizedPrimitiveStackTest.stg.
@@ -69,15 +71,15 @@ public class Synchronized<name>StackTest extends AbstractMutable<name>StackTestC
     public void asSynchronized()
     {
         Mutable<name>Stack stack1 = new Synchronized<name>Stack(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), new Object());
-        Assert.assertEquals(stack1, stack1.asSynchronized());
-        Assert.assertSame(stack1, stack1.asSynchronized());
+        assertEquals(stack1, stack1.asSynchronized());
+        assertSame(stack1, stack1.asSynchronized());
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
@@ -22,8 +22,12 @@ import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 
 /**
  * This file was automatically generated from template file unmodifiablePrimitiveStackTest.stg.
@@ -57,34 +61,34 @@ public class Unmodifiable<name>StackTest extends Abstract<name>StackTestCase
     @Test
     public void push()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().push(<(literal.(type))("5")>));
     }
 
     @Test
     public void pop()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop());
     }
 
     @Test
     public void popWithCount()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop(2));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop(2));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Mutable<name>Stack stack1 = new Unmodifiable<name>Stack(<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(stack1, stack1.asUnmodifiable());
-        Assert.assertSame(stack1, stack1.asUnmodifiable());
+        assertEquals(stack1, stack1.asUnmodifiable());
+        assertSame(stack1, stack1.asUnmodifiable());
     }
 
     @Test
@@ -99,9 +103,9 @@ public class Unmodifiable<name>StackTest extends Abstract<name>StackTestCase
     {
         Unmodifiable<name>Stack <type>Iterable = (Unmodifiable<name>Stack) this.classUnderTest();
         Mutable<name>Iterator iterator = (Mutable<name>Iterator) <type>Iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Test
@@ -109,15 +113,15 @@ public class Unmodifiable<name>StackTest extends Abstract<name>StackTestCase
     {
         Unmodifiable<name>Stack <type>Iterable = (Unmodifiable<name>Stack) this.classUnderTest();
         Mutable<name>Iterator iterator = (Mutable<name>Iterator) <type>Iterable.<type>Iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/booleanPrimitivePairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/booleanPrimitivePairImplTest.stg
@@ -22,8 +22,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link Boolean<name>PairImpl}.
@@ -36,37 +40,37 @@ public class Boolean<name>PairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair(true, <(literal.(type))("1")>), PrimitiveTuples.pair(true, <(literal.(type))("1")>));
-        Assert.assertNotEquals(PrimitiveTuples.pair(false, <(literal.(type))("1")>), PrimitiveTuples.pair(true, <(literal.(type))("1")>));
-        Assert.assertEquals(Tuples.pair(true, <(literal.(type))("1")>).hashCode(), PrimitiveTuples.pair(true, <(literal.(type))("1")>).hashCode());
+        assertNotEquals(PrimitiveTuples.pair(false, <(literal.(type))("1")>), PrimitiveTuples.pair(true, <(literal.(type))("1")>));
+        assertEquals(Tuples.pair(true, <(literal.(type))("1")>).hashCode(), PrimitiveTuples.pair(true, <(literal.(type))("1")>).hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertTrue(PrimitiveTuples.pair(true, <(literal.(type))("1")>).getOne());
-        Assert.assertFalse(PrimitiveTuples.pair(false, <(literal.(type))("5")>).getOne());
+        assertTrue(PrimitiveTuples.pair(true, <(literal.(type))("1")>).getOne());
+        assertFalse(PrimitiveTuples.pair(false, <(literal.(type))("5")>).getOne());
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, PrimitiveTuples.pair(true, <(literal.(type))("1")>).getTwo(), <(literal.(type))("0")>);
-        Assert.assertEquals(<(literal.(type))("2")>, PrimitiveTuples.pair(true, <(literal.(type))("2")>).getTwo(), <(literal.(type))("0")>);
+        assertEquals(<(literal.(type))("1")>, PrimitiveTuples.pair(true, <(literal.(type))("1")>).getTwo(), <(literal.(type))("0")>);
+        assertEquals(<(literal.(type))("2")>, PrimitiveTuples.pair(true, <(literal.(type))("2")>).getTwo(), <(literal.(type))("0")>);
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("true:<(toStringLiteral.(type))("1")>", PrimitiveTuples.pair(true, <(literal.(type))("1")>).toString());
-        Assert.assertEquals("false:<(toStringLiteral.(type))("2")>", PrimitiveTuples.pair(false, <(literal.(type))("2")>).toString());
+        assertEquals("true:<(toStringLiteral.(type))("1")>", PrimitiveTuples.pair(true, <(literal.(type))("1")>).toString());
+        assertEquals("false:<(toStringLiteral.(type))("2")>", PrimitiveTuples.pair(false, <(literal.(type))("2")>).toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(1, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(false, <(literal.(type))("2")>)));
-        Assert.assertEquals(0, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(true, <(literal.(type))("1")>)));
-        Assert.assertEquals(-1, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(true, <(literal.(type))("2")>)));
+        assertEquals(1, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(false, <(literal.(type))("2")>)));
+        assertEquals(0, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(true, <(literal.(type))("1")>)));
+        assertEquals(-1, PrimitiveTuples.pair(true, <(literal.(type))("1")>).compareTo(PrimitiveTuples.pair(true, <(literal.(type))("2")>)));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/primitiveBooleanPairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/primitiveBooleanPairImplTest.stg
@@ -22,8 +22,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link <name>BooleanPairImpl}.
@@ -36,38 +40,38 @@ public class <name>BooleanPairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair(<(literal.(type))("1")>, true), PrimitiveTuples.pair(<(literal.(type))("1")>, true));
-        Assert.assertNotEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("1")>, true));
-        Assert.assertEquals(Tuples.pair(<(literal.(type))("1")>, true).hashCode(), PrimitiveTuples.pair(<(literal.(type))("1")>, true).hashCode());
+        assertNotEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false), PrimitiveTuples.pair(<(literal.(type))("1")>, true));
+        assertEquals(Tuples.pair(<(literal.(type))("1")>, true).hashCode(), PrimitiveTuples.pair(<(literal.(type))("1")>, true).hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, PrimitiveTuples.pair(<(literal.(type))("1")>, true).getOne(), <(literal.(type))("0")>);
-        Assert.assertEquals(<(literal.(type))("3")>, PrimitiveTuples.pair(<(literal.(type))("3")>, true).getOne(), <(literal.(type))("0")>);
+        assertEquals(<(literal.(type))("1")>, PrimitiveTuples.pair(<(literal.(type))("1")>, true).getOne(), <(literal.(type))("0")>);
+        assertEquals(<(literal.(type))("3")>, PrimitiveTuples.pair(<(literal.(type))("3")>, true).getOne(), <(literal.(type))("0")>);
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, true).getTwo());
-        Assert.assertFalse(PrimitiveTuples.pair(<(literal.(type))("1")>, false).getTwo());
+        assertTrue(PrimitiveTuples.pair(<(literal.(type))("1")>, true).getTwo());
+        assertFalse(PrimitiveTuples.pair(<(literal.(type))("1")>, false).getTwo());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>:true", PrimitiveTuples.pair(<(literal.(type))("1")>, true).toString());
-        Assert.assertEquals("<(toStringLiteral.(type))("2")>:false", PrimitiveTuples.pair(<(literal.(type))("2")>, false).toString());
-        Assert.assertNotEquals("<(toStringLiteral.(type))("2")>, false", PrimitiveTuples.pair(<(literal.(type))("2")>, false).toString());
+        assertEquals("<(toStringLiteral.(type))("1")>:true", PrimitiveTuples.pair(<(literal.(type))("1")>, true).toString());
+        assertEquals("<(toStringLiteral.(type))("2")>:false", PrimitiveTuples.pair(<(literal.(type))("2")>, false).toString());
+        assertNotEquals("<(toStringLiteral.(type))("2")>, false", PrimitiveTuples.pair(<(literal.(type))("2")>, false).toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(-1, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("2")>, false)));
-        Assert.assertEquals(0, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("1")>, true)));
-        Assert.assertEquals(1, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
+        assertEquals(-1, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("2")>, false)));
+        assertEquals(0, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("1")>, true)));
+        assertEquals(1, PrimitiveTuples.pair(<(literal.(type))("1")>, true).compareTo(PrimitiveTuples.pair(<(literal.(type))("1")>, false)));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/primitivePrimitivePairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/primitivePrimitivePairImplTest.stg
@@ -24,8 +24,10 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * JUnit test for {@link <name1><name2>PairImpl}.
@@ -38,37 +40,37 @@ public class <name1><name2>PairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
-        Assert.assertNotEquals(PrimitiveTuples.pair(<(literal.(type1))("8")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
-        Assert.assertEquals(Tuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode(), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode());
+        assertNotEquals(PrimitiveTuples.pair(<(literal.(type1))("8")>, <(literal.(type2))("2")>), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>));
+        assertEquals(Tuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode(), PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertEquals(<(literal.(type1))("1")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getOne(), <(literal.(type1))("0")>);
-        Assert.assertEquals(<(literal.(type1))("12")>, PrimitiveTuples.pair(<(literal.(type1))("12")>, <(literal.(type2))("2")>).getOne(), <(literal.(type1))("0")>);
+        assertEquals(<(literal.(type1))("1")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getOne(), <(literal.(type1))("0")>);
+        assertEquals(<(literal.(type1))("12")>, PrimitiveTuples.pair(<(literal.(type1))("12")>, <(literal.(type2))("2")>).getOne(), <(literal.(type1))("0")>);
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertEquals(<(literal.(type2))("2")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getTwo(), <(literal.(type1))("0")>);
-        Assert.assertEquals(<(literal.(type2))("0")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("0")>).getTwo(), <(literal.(type1))("0")>);
+        assertEquals(<(literal.(type2))("2")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).getTwo(), <(literal.(type1))("0")>);
+        assertEquals(<(literal.(type2))("0")>, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("0")>).getTwo(), <(literal.(type1))("0")>);
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).toString());
-        Assert.assertEquals("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("8")>", PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("8")>).toString());
+        assertEquals("<(toStringLiteral.(type1))("1")>:<(toStringLiteral.(type2))("2")>", PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).toString());
+        assertEquals("<(toStringLiteral.(type1))("2")>:<(toStringLiteral.(type2))("8")>", PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("8")>).toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(1, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
-        Assert.assertEquals(0, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
-        Assert.assertEquals(-1, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("3")>)));
+        assertEquals(1, PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
+        assertEquals(0, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>)));
+        assertEquals(-1, PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("2")>).compareTo(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("3")>)));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIterableIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIterableIterateTest.stg
@@ -25,8 +25,9 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link <name>IterableIterate}.
@@ -41,7 +42,7 @@ public class <name>IterableIterateTest
     {
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         <name>IterableIterate.forEach(this.iterable, (<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIteratorIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIteratorIterateTest.stg
@@ -27,8 +27,10 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
+
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name>IteratorIterate}.
@@ -67,8 +69,8 @@ public class <name>IteratorIterateTest
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, <name>IteratorIterate.sum(this.iterable.<type>Iterator())<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>IteratorIterate.sum(new <name>ArrayList().<type>Iterator())<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, <name>IteratorIterate.sum(this.iterable.<type>Iterator())<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, <name>IteratorIterate.sum(new <name>ArrayList().<type>Iterator())<(wideDelta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -82,7 +84,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -97,7 +99,7 @@ public void sumConsistentRounding()
             .collect<name>(i -> <["1.0"]:(decimalLiteral.(type))()> / (i.<type>Value() * i.<type>Value() * i.<type>Value() * i.<type>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -107,15 +109,15 @@ public void sumConsistentRounding()
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, <name>IteratorIterate.min(this.iterable.<type>Iterator())<(wideDelta.(type))>);
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>IteratorIterate.min(new <name>ArrayList().<type>Iterator()));
+        assertEquals(<(literal.(type))("1")>, <name>IteratorIterate.min(this.iterable.<type>Iterator())<(wideDelta.(type))>);
+        assertThrows(NoSuchElementException.class, () -> <name>IteratorIterate.min(new <name>ArrayList().<type>Iterator()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, <name>IteratorIterate.min(this.iterable.<type>Iterator())<(wideDelta.(type))>);
-        Assert.assertThrows(NoSuchElementException.class, () -> <name>IteratorIterate.max(new <name>ArrayList().<type>Iterator()));
+        assertEquals(<(literal.(type))("1")>, <name>IteratorIterate.min(this.iterable.<type>Iterator())<(wideDelta.(type))>);
+        assertThrows(NoSuchElementException.class, () -> <name>IteratorIterate.max(new <name>ArrayList().<type>Iterator()));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/lazyPrimitiveIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/lazyPrimitiveIterateTest.stg
@@ -22,8 +22,9 @@ import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link Lazy<name>Iterate}.
@@ -36,19 +37,19 @@ public class Lazy<name>IterateTest
     @Test
     public void adapt()
     {
-        Assert.assertEquals(this.iterable, Lazy<name>Iterate.adapt(this.iterable).toList());
+        assertEquals(this.iterable, Lazy<name>Iterate.adapt(this.iterable).toList());
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(this.iterable.collect(each -> each), Lazy<name>Iterate.collectIf(this.iterable, each -> true, each -> each).toList());
+        assertEquals(this.iterable.collect(each -> each), Lazy<name>Iterate.collectIf(this.iterable, each -> true, each -> each).toList());
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(Lazy<name>Iterate.empty().isEmpty());
+        assertTrue(Lazy<name>Iterate.empty().isEmpty());
     }
 
     @Test
@@ -56,8 +57,8 @@ public class Lazy<name>IterateTest
     {
         Mutable<name>List list = <name>Lists.mutable.empty();
         Lazy<name>Iterable <type>Iterable = Lazy<name>Iterate.tap(this.iterable, (<name>Procedure) list::add);
-        Assert.assertEquals(this.iterable, <name>Lists.mutable.ofAll(<type>Iterable));
-        Assert.assertEquals(this.iterable, list);
+        assertEquals(this.iterable, <name>Lists.mutable.ofAll(<type>Iterable));
+        assertEquals(this.iterable, list);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/singletonPrimitiveIteratorTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/singletonPrimitiveIteratorTest.stg
@@ -19,8 +19,11 @@ package org.eclipse.collections.impl.iterator;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 /**
  * This file was automatically generated from template file singletonPrimitiveIterator.stg.
@@ -31,25 +34,25 @@ public final class Singleton<name>IteratorTest
     public void hasNext()
     {
         Singleton<name>Iterator iterator = new Singleton<name>Iterator(<(literal.(type))("5")>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void next()
     {
         Singleton<name>Iterator iterator = new Singleton<name>Iterator(<(literal.(type))("5")>);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, iterator.next()<(wideDelta.(type))>);
+        assertTrue(iterator.hasNext());
+        assertEquals(<(wideLiteral.(type))("5")>, iterator.next()<(wideDelta.(type))>);
 
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         try
         {
             iterator.next();
-            Assert.fail("NoSuchElementException should have been thrown");
+            fail("NoSuchElementException should have been thrown");
         }
         catch (NoSuchElementException e)
         {


### PR DESCRIPTION
This PR prepares the test templates for Junit5 Migration by moving all assertions to static imports.

cc @motlin