### PR TITLE
Delete four flaky tests: Collectors2AdditionalTest.sumBy*Parallel().

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
@@ -150,14 +150,6 @@ public class Collectors2AdditionalTest
     }
 
     @Test
-    public void sumByIntParallel()
-    {
-        assertEquals(
-                LARGE_INTERVAL.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue),
-                LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue)));
-    }
-
-    @Test
     public void sumByLong()
     {
         MutableList<Long> smallLongs = SMALL_INTERVAL.collect(Long::valueOf).toList();
@@ -169,15 +161,6 @@ public class Collectors2AdditionalTest
         assertEquals(
                 largeLongs.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue),
                 largeLongs.stream().collect(Collectors2.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue)));
-    }
-
-    @Test
-    public void sumByLongParallel()
-    {
-        MutableList<Long> largeLongs = LARGE_INTERVAL.collect(Long::valueOf).toList();
-        assertEquals(
-                largeLongs.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue),
-                largeLongs.parallelStream().collect(Collectors2.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue)));
     }
 
     @Test
@@ -195,15 +178,6 @@ public class Collectors2AdditionalTest
     }
 
     @Test
-    public void sumByFloatParallel()
-    {
-        MutableList<Float> largeLongs = LARGE_INTERVAL.collect(Float::valueOf).toList();
-        assertEquals(
-                largeLongs.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue),
-                largeLongs.parallelStream().collect(Collectors2.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue)));
-    }
-
-    @Test
     public void sumByDouble()
     {
         MutableList<Double> smallLongs = SMALL_INTERVAL.collect(Double::valueOf).toList();
@@ -215,15 +189,6 @@ public class Collectors2AdditionalTest
         assertEquals(
                 largeLongs.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue),
                 largeLongs.stream().collect(Collectors2.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue)));
-    }
-
-    @Test
-    public void sumByDoubleParallel()
-    {
-        MutableList<Double> largeLongs = LARGE_INTERVAL.collect(Double::valueOf).toList();
-        assertEquals(
-                largeLongs.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue),
-                largeLongs.parallelStream().collect(Collectors2.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue)));
     }
 
     @Test
@@ -239,14 +204,6 @@ public class Collectors2AdditionalTest
     }
 
     @Test
-    public void sumByBigIntegerParallel()
-    {
-        assertEquals(
-                Iterate.sumByBigInteger(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue())),
-                LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByBigInteger(each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue()))));
-    }
-
-    @Test
     public void sumByBigDecimal()
     {
         assertEquals(
@@ -256,14 +213,6 @@ public class Collectors2AdditionalTest
         assertEquals(
                 Iterate.sumByBigDecimal(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new),
                 LARGE_INTERVAL.stream().collect(Collectors2.sumByBigDecimal(each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new)));
-    }
-
-    @Test
-    public void sumByBigDecimalParallel()
-    {
-        assertEquals(
-                Iterate.sumByBigDecimal(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new),
-                LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByBigDecimal(each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new)));
     }
 
     @Test


### PR DESCRIPTION
These four tests are flaky. They fail a small percentage of the time and I usually rerun them and move on. I finally looked at the code and they are clearly not thread-safe. They all run some form of `.parallelStream().collect(Collectors2.sumBy*(), ...)`.

The `Collectors2.sumBy*()` methods all delegate directly to a non-thread-safe map, so this is a pretty clear case of non-thread-safe code. I have no opinion on whether the Collectors ought to be thread-safe; if so let's file an issue to fix them separately. For now, I just want to remove the tests since they waste time.

There are serial versions of the same tests, so deleting the tests does not decrease coverage.

cc @donraab 