### PR TITLE
Configure maven-surefire-plugin printSummary to false, to stop logging successful tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                         <argLine>-XX:-OmitStackTraceInFastThrow -Xms1024m -Xmx2048m --add-opens java.base/java.lang=ALL-UNNAMED @{argLine}</argLine>
                         <runOrder>random</runOrder>
                         <!--<forkCount>2C</forkCount>-->
+                        <printSummary>false</printSummary>
                     </configuration>
                     <!-- Configure surefire to run JUnit 4 and 5 tests -->
                     <!-- In maven 3.9.6 and 4.x, maven is able to auto-detect JUnit and these dependencies are not required -->


### PR DESCRIPTION
Before, thousands of lines of tests running:

```console
13:22:26:761 [INFO] --- surefire:3.4.0:test (default-test) @ unit-tests ---
13:22:26:765 [INFO] Tests will run in random order. To reproduce ordering use flag -Dsurefire.runOrder.random.seed=358056349203
13:22:26:793 [INFO] Surefire report directory: /home/runner/work/eclipse-collections/eclipse-collections/unit-tests/target/surefire-reports
13:22:26:793 [INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
13:22:26:797 [INFO] 
13:22:26:797 [INFO] -------------------------------------------------------
13:22:26:798 [INFO]  T E S T S
13:22:26:798 [INFO] -------------------------------------------------------
13:22:37:527 [INFO] Running org.eclipse.collections.impl.map.mutable.primitive.UnmodifiableObjectLongMapKeysViewTest
13:22:37:894 [INFO] Tests run: 107, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.367 s -- in org.eclipse.collections.impl.map.mutable.primitive.UnmodifiableObjectLongMapKeysViewTest
13:22:37:895 [INFO] Running org.eclipse.collections.impl.list.fixed.EmptyListTest
13:22:37:939 [INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s -- in org.eclipse.collections.impl.list.fixed.EmptyListTest
13:22:37:940 [INFO] Running org.eclipse.collections.impl.set.immutable.ImmutableSingletonSetTest
13:22:38:271 [INFO] Tests run: 129, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.325 s -- in org.eclipse.collections.impl.set.immutable.ImmutableSingletonSetTest
13:22:38:271 [INFO] Running org.eclipse.collections.impl.partition.set.PartitionUnifiedSetTest
13:22:38:272 [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in org.eclipse.collections.impl.partition.set.PartitionUnifiedSetTest
... snipped ...
```

After, just the one compiler warning we already got:

```console
13:22:23:008 [INFO] --- surefire:3.2.5:test (default-test) @ unit-tests ---
13:22:23:012 [INFO] Tests will run in random order. To reproduce ordering use flag -Dsurefire.runOrder.random.seed=322222792571
13:22:23:044 [INFO] Surefire report directory: /home/runner/work/eclipse-collections/eclipse-collections/unit-tests/target/surefire-reports
13:22:23:044 [INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.eclipse.collections.impl.utility.ArrayListIterate (file:/home/runner/work/eclipse-collections/eclipse-collections/eclipse-collections/target/eclipse-collections-12.0.0-SNAPSHOT.jar) to field java.util.ArrayList.elementData
WARNING: Please consider reporting this to the maintainers of org.eclipse.collections.impl.utility.ArrayListIterate
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```