### PR TITLE
Format yaml files using Spotless.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
+  - package-ecosystem: 'maven'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,11 +38,11 @@ jobs:
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - run: ./mvnw --color=always install -DskipTests=true
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
       - name: Mutation Test
         run: mvn eu.stamp-project:pitmp-maven-plugin:run -DwithHistory -DtimeoutConstant=8000
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
       - name: Archive pitest reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 11
       - run: ./mvnw --threads 2C --color=always verify
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -56,7 +56,7 @@ jobs:
       - name: Run maven-enforcer-plugin
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-enforcer-plugin -DskipTests
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -84,7 +84,7 @@ jobs:
       - name: Run maven-dependency-plugin
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-dependency-plugin -DskipTests
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -93,7 +93,7 @@ jobs:
     name: Unit Tests ${{ matrix.java-version }}
     strategy:
       matrix:
-        java-version: [ 17, 21, 22 ]
+        java-version: [17, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
       - name: Unit-Test
         run: ./mvnw --color=always verify
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -153,7 +153,7 @@ jobs:
       - name: Unit-Test
         run: ./mvnw --color=always verify
         env:
-          MAVEN_OPTS: "-Xmx2g"
+          MAVEN_OPTS: '-Xmx2g'
 
   acceptance-tests:
     name: Acceptance Tests
@@ -178,7 +178,7 @@ jobs:
           java-version: 11
       - run: ./mvnw --color=always install --projects acceptance-tests --also-make --activate-profiles all
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -206,7 +206,7 @@ jobs:
           java-version: 11
       - run: ./mvnw --color=always install --projects performance-tests --also-make --activate-profiles all -DskipTests=true
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -225,7 +225,7 @@ jobs:
       - name: Checkstyle
         run: ./mvnw --color=always install checkstyle:check --activate-profiles all -DskipTests=true
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
   javadoc:
     name: Javadoc 11
@@ -252,11 +252,11 @@ jobs:
       - name: JavaDoc Aggregate
         run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
       - name: JavaDoc Jar
         run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean install javadoc:jar --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
-          MAVEN_OPTS: "-Xmx1g"
+          MAVEN_OPTS: '-Xmx1g'
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -295,6 +295,6 @@ jobs:
       - name: Javadoc
         run: ./mvnw --threads 2C --color=always --activate-profiles maven-javadoc-plugin -DskipTests javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
-          MAVEN_OPTS: "-Xmx2g"
+          MAVEN_OPTS: '-Xmx2g'
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections


### PR DESCRIPTION
Another example based on #1687, to show off the kind of thing that Spotless can do, this time in a language other than Java.

This was created with the command:

`mvn spotless:apply --activate-profiles 'spotless-apply,spotless-yaml'`