### PR TITLE
Categorize methods in RichIterable using region/endregion comments.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -54,6 +54,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -92,8 +93,97 @@ import org.eclipse.collections.api.tuple.Pair;
  * RichIterable is a read-only interface which extends the InternalIterable interface and adds many internal iterator methods.
  * The basic methods were inspired by the Smalltalk Collection protocol. These methods include select, reject, detect,
  * collect, injectInto, anySatisfy, allSatisfy. The API also includes converter methods to convert a RichIterable to
- * other mutable and immutable collection types. The converter methods all have a prefix of "to" (e.g. toList, toSet,
- * toBag, toMap, etc).
+ * other mutable and immutable collection types. The converter methods typically have a prefix of "to" (e.g. toList, toSet,
+ * toBag, toMap, etc.).
+ * <p>
+ * The methods in RichIterable are organized into the following method categories via region comments which are collapsible
+ * in various IDEs.
+ * Links are provided below as a convenience to help discover specific methods in Javadoc.
+ *
+ * <ul>
+ * <li><b>Iterating Methods</b>
+ * <ul><li>
+ * {@link #each(Procedure)}, {@link #forEach(Procedure)}, {@link #forEachWith(Procedure2, Object)},
+ * {@link #forEachWithIndex(ObjectIntProcedure)}, {@link #tap(Procedure)}, {@link #asLazy()}, {@link #iterator()},
+ * {@link #spliterator()}
+ * </ul></li>
+ * <li><b>Counting Methods</b>
+ * <ul><li>
+ * {@link #count(Predicate)} , {@link #countBy(Function)} , {@link #countByEach(Function)},
+ * {@link #countByWith(Function2, Object)}, {@link #countWith(Predicate2, Object)} , {@link #size()}
+ * </li></ul>
+ * <li><b>Testing Methods</b>
+ * <ul><li>
+ * {@link #anySatisfy(Predicate)}, {@link #anySatisfyWith(Predicate2, Object)}, {@link #noneSatisfy(Predicate)},
+ * {@link #noneSatisfyWith(Predicate2, Object)}, {@link #allSatisfy(Predicate)}, {@link #allSatisfyWith(Predicate2, Object)},
+ * {@link #contains(Object)} ,
+ * {@link #containsAll(Collection)}, {@link #containsAllArguments(Object...)}, {@link #containsAllIterable(Iterable)},
+ * {@link #containsAny(Collection)} , {@link #containsAnyIterable(Iterable)},
+ * {@link #containsNone(Collection)} , {@link #containsNoneIterable(Iterable)} ,
+ * {@link #containsBy(Function, Object)},
+ * {@link #isEmpty()}, {@link #notEmpty()}
+ * </li></ul>
+ * <li><b>Finding Methods</b>
+ * <ul><li>
+ * {@link #detect(Predicate)}, {@link #detectIfNone(Predicate, Function0)} ,
+ * {@link #detectWith(Predicate2, Object)}, {@link #detectWithIfNone(Predicate2, Object, Function0)},
+ * {@link #detectOptional(Predicate)}, {@link #detectWithOptional(Predicate2, Object)},
+ * {@link #getAny()}, {@link #getFirst()}, {@link #getLast()}, {@link #getOnly()},
+ * {@link #min()}, {@link #max()},
+ * {@link #minBy(Function)}, {@link #minByOptional(Function)}, {@link #minOptional()}
+ * {@link #maxBy(Function)}, {@link #maxByOptional(Function)}, {@link #maxOptional()}
+ * </li></ul>
+ * <li><b>Filtering Methods</b>
+ * <ul><li>
+ * {@link #select(Predicate)}, {@link #selectInstancesOf(Class)}, {@link #selectWith(Predicate2, Object)},
+ * {@link #reject(Predicate)}, {@link #rejectWith(Predicate2, Object)} ,
+ * {@link #partition(Predicate)}, {@link #partitionWith(Predicate2, Object)}
+ * </li></ul>
+ * <li><b>Transforming Methods</b>
+ * <ul><li>
+ * {@link #collect(Function)}, {@link #collectIf(Predicate, Function)}, {@link #collectWith(Function2, Object)},
+ * {@link #collectBoolean(BooleanFunction)}, {@link #collectByte(ByteFunction)}, {@link #collectChar(CharFunction)},
+ * {@link #collectDouble(DoubleFunction)}, {@link #collectFloat(FloatFunction)}, {@link #collectInt(IntFunction)},
+ * {@link #collectLong(LongFunction)}, {@link #collectShort(ShortFunction)},
+ * {@link #flatCollect(Function)}, {@link #flatCollectWith(Function2, Object)},
+ * {@link #flatCollectBoolean(Function, MutableBooleanCollection)}, {@link #flatCollectByte(Function, MutableByteCollection)} ,
+ * {@link #flatCollectChar(Function, MutableCharCollection)}, {@link #flatCollectDouble(Function, MutableDoubleCollection)} ,
+ * {@link #flatCollectFloat(Function, MutableFloatCollection)}, {@link #flatCollectInt(Function, MutableIntCollection)} ,
+ * {@link #flatCollectLong(Function, MutableLongCollection)}, {@link #flatCollectShort(Function, MutableShortCollection)} ,
+ * {@link #zip(Iterable)}, {@link #zipWithIndex(Collection)}
+ * </li></ul>
+ * <li><b>Grouping Methods</b>
+ * <ul><li>
+ * {@link #chunk(int)} , {@link #groupBy(Function)} , {@link #groupByAndCollect(Function, Function, MutableMultimap)} ,
+ * {@link #groupByEach(Function)} , {@link #groupByUniqueKey(Function)}
+ * </li></ul>
+ * <li><b>Aggregating Methods</b>
+ * <ul><li>
+ * {@link #aggregateBy(Function, Function0, Function2)} , {@link #aggregateInPlaceBy(Function, Function0, Procedure2)} ,
+ * {@link #injectInto(Object, Function2)} ,
+ * {@link #injectIntoDouble(double, DoubleObjectToDoubleFunction)} ,
+ * {@link #injectIntoFloat(float, FloatObjectToFloatFunction)} , {@link #injectIntoInt(int, IntObjectToIntFunction)} ,
+ * {@link #injectIntoLong(long, LongObjectToLongFunction)} ,
+ * {@link #reduce(BinaryOperator)}, {@link #reduceBy(Function, Function2)}, {@link #reduceInPlace(Collector)} ,
+ * {@link #sumByDouble(Function, DoubleFunction)} , {@link #sumByFloat(Function, FloatFunction)} ,
+ * {@link #sumByInt(Function, IntFunction)} , {@link #sumByLong(Function, LongFunction)} ,
+ * {@link #sumOfDouble(DoubleFunction)}, {@link #sumOfFloat(FloatFunction)}, {@link #sumOfInt(IntFunction)}, {@link #sumOfLong(LongFunction)} ,
+ * {@link #summarizeDouble(DoubleFunction)}, {@link #summarizeFloat(FloatFunction)},
+ * {@link #summarizeInt(IntFunction)}, {@link #summarizeLong(LongFunction)}
+ * </li></ul>
+ * <li><b>Converting Methods</b>
+ * <ul><li>
+ * {@link #into(Collection)}, {@link #appendString(Appendable)}, {@link #makeString()}, {@link #toString()},
+ * {@link #toArray()}, {@link #toBag()}, {@link #toBiMap(Function, Function)}, {@link #toList()} ,
+ * {@link #toMap(Function, Function)}, {@link #toSet()}, {@link #toSortedBag()}, {@link #toSortedBagBy(Function)},
+ * {@link #toSortedList()}, {@link #toSortedListBy(Function)}, {@link #toSortedMap(Function, Function)},
+ * {@link #toSortedMapBy(Function, Function, Function)}, {@link #toSortedSet()}, {@link #toSortedSetBy(Function)},
+ * {@link #toImmutableBag()}, {@link #toImmutableBiMap(Function, Function)}, {@link #toImmutableList()},
+ * {@link #toImmutableMap(Function, Function)}, {@link #toImmutableSet()},
+ * {@link #toImmutableSortedBag()}, {@link #toImmutableSortedBagBy(Function)}, {@link #toImmutableSortedList()},
+ * {@link #toImmutableSortedListBy(Function)} , {@link #toImmutableSortedSet()} , {@link #toImmutableSortedSetBy(Function)}
+ * </li></ul>
+ * </ul>
  *
  * @since 1.0
  */
@@ -101,6 +191,8 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface RichIterable<T>
         extends InternalIterable<T>
 {
+    //region [Category: Iterating Methods]
+
     @Override
     default void forEach(Procedure<? super T> procedure)
     {
@@ -108,11 +200,146 @@ public interface RichIterable<T>
     }
 
     /**
+     * The procedure is executed for each element in the iterable.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * people.each(person -&gt; LOGGER.info(person.getName()));
+     * </pre>
+     * This method is a variant of {@link InternalIterable#forEach(Procedure)}
+     * that has a signature conflict with {@link Iterable#forEach(java.util.function.Consumer)}.
+     *
+     * @see InternalIterable#forEach(Procedure)
+     * @see Iterable#forEach(java.util.function.Consumer)
+     * @since 6.0
+     */
+    @SuppressWarnings("UnnecessaryFullyQualifiedName")
+    void each(Procedure<? super T> procedure);
+
+    /**
+     * Executes the Procedure for each element in the iterable and returns {@code this}.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * RichIterable&lt;Person&gt; tapped =
+     *     people.<b>tap</b>(person -&gt; LOGGER.info(person.getName()));
+     * </pre>
+     *
+     * @see #each(Procedure)
+     * @see #forEach(Procedure)
+     * @since 6.0
+     */
+    RichIterable<T> tap(Procedure<? super T> procedure);
+
+    /**
+     * Returns a lazy (deferred) iterable, most likely implemented by calling LazyIterate.adapt(this).
+     *
+     * @since 1.0.
+     */
+    LazyIterable<T> asLazy();
+
+    //endregion [Category: Iterating Methods]
+
+    //region [Category: Counting Methods]
+
+    /**
      * Returns the number of items in this iterable.
      *
      * @since 1.0
      */
     int size();
+
+    /**
+     * Return the total number of elements that answer true to the specified predicate.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * int count =
+     *     people.<b>count</b>(person -&gt; person.getAddress().getState().getName().equals("New York"));
+     * </pre>
+     *
+     * @since 1.0
+     */
+    int count(Predicate<? super T> predicate);
+
+    /**
+     * Returns the total number of elements that evaluate to true for the specified predicate.
+     *
+     * <pre>e.g.
+     * return lastNames.<b>countWith</b>(Predicates2.equal(), "Smith");
+     * </pre>
+     */
+    <P> int countWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection.
+     *
+     * @since 9.0
+     */
+    default <V> Bag<V> countBy(Function<? super T, ? extends V> function)
+    {
+        return this.countBy(function, Bags.mutable.empty());
+    }
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection.
+     *
+     * @since 9.0
+     */
+    default <V, R extends MutableBagIterable<V>> R countBy(Function<? super T, ? extends V> function, R target)
+    {
+        return this.collect(function, target);
+    }
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection with the specified parameter as the second argument.
+     *
+     * @since 9.0
+     */
+    default <V, P> Bag<V> countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter)
+    {
+        return this.countByWith(function, parameter, Bags.mutable.empty());
+    }
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection with the specified parameter as the second argument.
+     *
+     * @since 9.0
+     */
+    default <V, P, R extends MutableBagIterable<V>> R countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter, R target)
+    {
+        return this.collectWith(function, parameter, target);
+    }
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection.
+     *
+     * @since 10.0.0
+     */
+    default <V> Bag<V> countByEach(Function<? super T, ? extends Iterable<V>> function)
+    {
+        return this.asLazy().flatCollect(function).toBag();
+    }
+
+    /**
+     * This method will count the number of occurrences of each value calculated by applying the
+     * function to each element of the collection.
+     *
+     * @since 10.0.0
+     */
+    default <V, R extends MutableBagIterable<V>> R countByEach(Function<? super T, ? extends Iterable<V>> function, R target)
+    {
+        return this.flatCollect(function, target);
+    }
+
+    //endregion [Category: Counting Methods]
+
+    //region [Category: Testing Methods]
 
     /**
      * Returns true if this iterable has zero items.
@@ -129,64 +356,6 @@ public interface RichIterable<T>
     default boolean notEmpty()
     {
         return !this.isEmpty();
-    }
-
-    /**
-     * Returns any element of an iterable.
-     *
-     * @return an element of an iterable.
-     * @since 10.0
-     */
-    default T getAny()
-    {
-        return this.getFirst();
-    }
-
-    /**
-     * Returns the first element of an iterable. In the case of a List it is the element at the first index. In the
-     * case of any other Collection, it is the first element that would be returned during an iteration. If the
-     * iterable is empty, null is returned. If null is a valid element of the container, then a developer would need to
-     * check to see if the iterable is empty to validate that a null result was not due to the container being empty.
-     * <p>
-     * The order of Sets are not guaranteed (except for TreeSets and other Ordered Set implementations), so if you use
-     * this method, the first element could be any element from the Set.
-     *
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#getFirst()} instead.
-     */
-    @Deprecated
-    T getFirst();
-
-    /**
-     * Returns the last element of an iterable. In the case of a List it is the element at the last index. In the case
-     * of any other Collection, it is the last element that would be returned during an iteration. If the iterable is
-     * empty, null is returned. If null is a valid element of the container, then a developer would need to check to
-     * see if the iterable is empty to validate that a null result was not due to the container being empty.
-     * <p>
-     * The order of Sets are not guaranteed (except for TreeSets and other Ordered Set implementations), so if you use
-     * this method, the last element could be any element from the Set.
-     *
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#getLast()} instead.
-     */
-    @Deprecated
-    T getLast();
-
-    /**
-     * Returns the element if the iterable has exactly one element. Otherwise, throw {@link IllegalStateException}.
-     *
-     * @return an element of an iterable.
-     * @throws IllegalStateException if iterable is empty or has multiple elements.
-     * @since 8.0
-     */
-    default T getOnly()
-    {
-        if (this.size() == 1)
-        {
-            return this.getFirst();
-        }
-
-        throw new IllegalStateException("Size must be 1 but was " + this.size());
     }
 
     /**
@@ -317,36 +486,346 @@ public interface RichIterable<T>
     boolean containsAllArguments(Object... elements);
 
     /**
-     * Executes the Procedure for each element in the iterable and returns {@code this}.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * RichIterable&lt;Person&gt; tapped =
-     *     people.<b>tap</b>(person -&gt; LOGGER.info(person.getName()));
-     * </pre>
+     * Returns true if the predicate evaluates to true for any element of the iterable.
+     * Returns false if the iterable is empty, or if no element returned true when evaluating the predicate.
      *
-     * @see #each(Procedure)
-     * @see #forEach(Procedure)
-     * @since 6.0
+     * @since 1.0
      */
-    RichIterable<T> tap(Procedure<? super T> procedure);
+    boolean anySatisfy(Predicate<? super T> predicate);
 
     /**
-     * The procedure is executed for each element in the iterable.
+     * Returns true if the predicate evaluates to true for any element of the collection, or return false.
+     * Returns false if the collection is empty.
+     *
+     * @since 5.0
+     */
+    <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    /**
+     * Returns true if the predicate evaluates to true for every element of the iterable or if the iterable is empty.
+     * Otherwise, returns false.
+     *
+     * @since 1.0
+     */
+    boolean allSatisfy(Predicate<? super T> predicate);
+
+    /**
+     * Returns true if the predicate evaluates to true for every element of the collection, or returns false.
+     *
+     * @since 5.0
+     */
+    <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    /**
+     * Returns true if the predicate evaluates to false for every element of the iterable or if the iterable is empty.
+     * Otherwise, returns false.
+     *
+     * @since 3.0
+     */
+    boolean noneSatisfy(Predicate<? super T> predicate);
+
+    /**
+     * Returns true if the predicate evaluates to false for every element of the collection, or return false.
+     * Returns true if the collection is empty.
+     *
+     * @since 5.0
+     */
+    <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    //endregion [Category: Testing Methods]
+
+    //region [Category: Finding Methods]
+
+    /**
+     * Returns any element of an iterable.
+     *
+     * @return an element of an iterable.
+     * @since 10.0
+     */
+    default T getAny()
+    {
+        return this.getFirst();
+    }
+
+    /**
+     * Returns the first element of an iterable. In the case of a List it is the element at the first index. In the
+     * case of any other Collection, it is the first element that would be returned during an iteration. If the
+     * iterable is empty, null is returned. If null is a valid element of the container, then a developer would need to
+     * check to see if the iterable is empty to validate that a null result was not due to the container being empty.
+     * <p>
+     * The order of Sets are not guaranteed (except for TreeSets and other Ordered Set implementations), so if you use
+     * this method, the first element could be any element from the Set.
+     *
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#getFirst()} instead.
+     */
+    @Deprecated
+    T getFirst();
+
+    /**
+     * Returns the last element of an iterable. In the case of a List it is the element at the last index. In the case
+     * of any other Collection, it is the last element that would be returned during an iteration. If the iterable is
+     * empty, null is returned. If null is a valid element of the container, then a developer would need to check to
+     * see if the iterable is empty to validate that a null result was not due to the container being empty.
+     * <p>
+     * The order of Sets are not guaranteed (except for TreeSets and other Ordered Set implementations), so if you use
+     * this method, the last element could be any element from the Set.
+     *
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#getLast()} instead.
+     */
+    @Deprecated
+    T getLast();
+
+    /**
+     * Returns the element if the iterable has exactly one element. Otherwise, throw {@link IllegalStateException}.
+     *
+     * @return an element of an iterable.
+     * @throws IllegalStateException if iterable is empty or has multiple elements.
+     * @since 8.0
+     */
+    default T getOnly()
+    {
+        if (this.size() == 1)
+        {
+            return this.getFirst();
+        }
+
+        throw new IllegalStateException("Size must be 1 but was " + this.size());
+    }
+
+    /**
+     * Returns the first element of the iterable for which the predicate evaluates to true or null in the case where no
+     * element returns true. This method is commonly called find.
      * <p>
      * Example using a Java 8 lambda expression:
      * <pre>
-     * people.each(person -&gt; LOGGER.info(person.getName()));
+     * Person person =
+     *     people.detect(person -&gt; person.getFirstName().equals("John") &amp;&amp; person.getLastName().equals("Smith"));
      * </pre>
-     * This method is a variant of {@link InternalIterable#forEach(Procedure)}
-     * that has a signature conflict with {@link Iterable#forEach(java.util.function.Consumer)}.
      *
-     * @see InternalIterable#forEach(Procedure)
-     * @see Iterable#forEach(java.util.function.Consumer)
-     * @since 6.0
+     * @since 1.0
      */
-    @SuppressWarnings("UnnecessaryFullyQualifiedName")
-    void each(Procedure<? super T> procedure);
+    T detect(Predicate<? super T> predicate);
+
+    /**
+     * Returns the first element that evaluates to true for the specified predicate2 and parameter, or null if none
+     * evaluate to true.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * Person person =
+     *     people.detectWith((person, fullName) -&gt; person.getFullName().equals(fullName), "John Smith");
+     * </pre>
+     *
+     * @since 5.0
+     */
+    <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    /**
+     * Returns the first element of the iterable for which the predicate evaluates to true as an Optional. This method is commonly called find.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * Person person =
+     *     people.detectOptional(person -&gt; person.getFirstName().equals("John") &amp;&amp; person.getLastName().equals("Smith"));
+     * </pre>
+     * <p>
+     *
+     * @throws NullPointerException if the element selected is null
+     * @since 8.0
+     */
+    Optional<T> detectOptional(Predicate<? super T> predicate);
+
+    /**
+     * Returns the first element that evaluates to true for the specified predicate2 and parameter as an Optional.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * Optional&lt;Person&gt; person =
+     *     people.detectWithOptional((person, fullName) -&gt; person.getFullName().equals(fullName), "John Smith");
+     * </pre>
+     * <p>
+     *
+     * @throws NullPointerException if the element selected is null
+     * @since 8.0
+     */
+    <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    /**
+     * Returns the first element of the iterable for which the predicate evaluates to true. If no element matches
+     * the predicate, then returns the value of applying the specified function.
+     *
+     * @since 1.0
+     */
+    default T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
+    {
+        T result = this.detect(predicate);
+        return result == null ? function.value() : result;
+    }
+
+    /**
+     * Returns the first element of the iterable that evaluates to true for the specified predicate2 and parameter, or
+     * returns the value of evaluating the specified function.
+     *
+     * @since 5.0
+     */
+    <P> T detectWithIfNone(
+            Predicate2<? super T, ? super P> predicate,
+            P parameter,
+            Function0<? extends T> function);
+
+    /**
+     * Returns the minimum element out of this container based on the comparator.
+     *
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    T min(Comparator<? super T> comparator);
+
+    /**
+     * Returns the maximum element out of this container based on the comparator.
+     *
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    T max(Comparator<? super T> comparator);
+
+    /**
+     * Returns the minimum element out of this container based on the comparator as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws NullPointerException if the minimum element is null
+     * @since 8.2
+     */
+    default Optional<T> minOptional(Comparator<? super T> comparator)
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.min(comparator));
+    }
+
+    /**
+     * Returns the maximum element out of this container based on the comparator as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws NullPointerException if the maximum element is null
+     * @since 8.2
+     */
+    default Optional<T> maxOptional(Comparator<? super T> comparator)
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.max(comparator));
+    }
+
+    /**
+     * Returns the minimum element out of this container based on the natural order.
+     *
+     * @throws ClassCastException     if the elements are not {@link Comparable}
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    T min();
+
+    /**
+     * Returns the maximum element out of this container based on the natural order.
+     *
+     * @throws ClassCastException     if the elements are not {@link Comparable}
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    T max();
+
+    /**
+     * Returns the minimum element out of this container based on the natural order as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws ClassCastException   if the elements are not {@link Comparable}
+     * @throws NullPointerException if the minimum element is null
+     * @since 8.2
+     */
+    default Optional<T> minOptional()
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.min());
+    }
+
+    /**
+     * Returns the maximum element out of this container based on the natural order as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws ClassCastException   if the elements are not {@link Comparable}
+     * @throws NullPointerException if the maximum element is null
+     * @since 8.2
+     */
+    default Optional<T> maxOptional()
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.max());
+    }
+
+    /**
+     * Returns the minimum elements out of this container based on the natural order of the attribute returned by Function.
+     *
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    <V extends Comparable<? super V>> T minBy(Function<? super T, ? extends V> function);
+
+    /**
+     * Returns the maximum elements out of this container based on the natural order of the attribute returned by Function.
+     *
+     * @throws NoSuchElementException if the RichIterable is empty
+     * @since 1.0
+     */
+    <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function);
+
+    /**
+     * Returns the minimum elements out of this container based on the natural order of the attribute returned by Function as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws NullPointerException if the minimum element is null
+     * @since 8.2
+     */
+    default <V extends Comparable<? super V>> Optional<T> minByOptional(Function<? super T, ? extends V> function)
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.minBy(function));
+    }
+
+    /**
+     * Returns the maximum elements out of this container based on the natural order of the attribute returned by Function as an Optional.
+     * If the container is empty {@link Optional#empty()} is returned.
+     *
+     * @throws NullPointerException if the maximum element is null
+     * @since 8.2
+     */
+    default <V extends Comparable<? super V>> Optional<T> maxByOptional(Function<? super T, ? extends V> function)
+    {
+        if (this.isEmpty())
+        {
+            return Optional.empty();
+        }
+        return Optional.of(this.maxBy(function));
+    }
+
+    //endregion [Category: Finding Methods]
+
+    //region [Category: Filtering Methods]
 
     /**
      * Returns all elements of the source collection that return true when evaluating the predicate. This method is also
@@ -497,6 +976,18 @@ public interface RichIterable<T>
             R targetCollection);
 
     /**
+     * Returns all elements of the source collection that are instances of the Class {@code clazz}.
+     *
+     * <pre>
+     * RichIterable&lt;Integer&gt; integers =
+     *     List.mutable.with(new Integer(0), new Long(0L), new Double(0.0)).selectInstancesOf(Integer.class);
+     * </pre>
+     *
+     * @since 2.0
+     */
+    <S> RichIterable<S> selectInstancesOf(Class<S> clazz);
+
+    /**
      * Filters a collection into a PartitionedIterable based on the evaluation of the predicate.
      * <p>
      * Example using a Java 8 lambda expression:
@@ -522,17 +1013,9 @@ public interface RichIterable<T>
      */
     <P> PartitionIterable<T> partitionWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
-    /**
-     * Returns all elements of the source collection that are instances of the Class {@code clazz}.
-     *
-     * <pre>
-     * RichIterable&lt;Integer&gt; integers =
-     *     List.mutable.with(new Integer(0), new Long(0L), new Double(0.0)).selectInstancesOf(Integer.class);
-     * </pre>
-     *
-     * @since 2.0
-     */
-    <S> RichIterable<S> selectInstancesOf(Class<S> clazz);
+    //endregion [Category: Filtering Methods]
+
+    //region [Category: Transforming Methods]
 
     /**
      * Returns a new collection with the results of applying the specified function on each element of the source
@@ -943,6 +1426,36 @@ public interface RichIterable<T>
     <V> RichIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     /**
+     * Same as flatCollect, only with a Function2 that is passed an extra parameter.
+     *
+     * @since 9.2
+     */
+    default <P, V> RichIterable<V> flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter)
+    {
+        return this.flatCollect(each -> function.apply(each, parameter));
+    }
+
+    /**
+     * Same as flatCollect, only the results are collected into the target collection.
+     *
+     * @param function The {@link Function} to apply
+     * @param target   The collection into which results should be added.
+     * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
+     * @see #flatCollect(Function)
+     */
+    <V, R extends Collection<V>> R flatCollect(Function<? super T, ? extends Iterable<V>> function, R target);
+
+    /**
+     * Same as flatCollectWith, only the results are collected into the target collection.
+     *
+     * @since 9.2
+     */
+    default <P, V, R extends Collection<V>> R flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter, R target)
+    {
+        return this.flatCollect(each -> function.apply(each, parameter), target);
+    }
+
+    /**
      * Same as flatCollect, only the results are collected into the target collection.
      *
      * @param function The {@link Function} to apply
@@ -1055,185 +1568,160 @@ public interface RichIterable<T>
     }
 
     /**
-     * Same as flatCollect, only with a Function2 that is passed an extra parameter.
+     * Returns a {@code RichIterable} formed from this {@code RichIterable} and another {@code RichIterable} by
+     * combining corresponding elements in pairs. If one of the two {@code RichIterable}s is longer than the other, its
+     * remaining elements are ignored.
      *
-     * @since 9.2
+     * @param that The {@code RichIterable} providing the second half of each result pair
+     * @param <S>  the type of the second half of the returned pairs
+     * @return A new {@code RichIterable} containing pairs consisting of corresponding elements of this {@code
+     * RichIterable} and that. The length of the returned {@code RichIterable} is the minimum of the lengths of
+     * this {@code RichIterable} and that.
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.
      */
-    default <P, V> RichIterable<V> flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter)
+    @Deprecated
+    <S> RichIterable<Pair<T, S>> zip(Iterable<S> that);
+
+    /**
+     * Same as {@link #zip(Iterable)} but uses {@code target} for output.
+     *
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable, Collection)} instead;
+     */
+    @Deprecated
+    <S, R extends Collection<Pair<T, S>>> R zip(Iterable<S> that, R target);
+
+    /**
+     * Zips this {@code RichIterable} with its indices.
+     *
+     * @return A new {@code RichIterable} containing pairs consisting of all elements of this {@code RichIterable}
+     * paired with their index. Indices start at 0.
+     * @see #zip(Iterable)
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex()} instead.
+     */
+    @Deprecated
+    RichIterable<Pair<T, Integer>> zipWithIndex();
+
+    /**
+     * Same as {@link #zipWithIndex()} but uses {@code target} for output.
+     *
+     * @since 1.0
+     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex(Collection)} instead.
+     */
+    @Deprecated
+    <R extends Collection<Pair<T, Integer>>> R zipWithIndex(R target);
+
+    //endregion [Category: Transforming Methods]
+
+    //region [Category: Grouping Methods]
+    /**
+     * For each element of the iterable, the function is evaluated and the results of these evaluations are collected
+     * into a new multimap, where the transformed value is the key and the original values are added to the same (or similar)
+     * species of collection as the source iterable.
+     * <p>
+     * Example using a Java 8 method reference:
+     * <pre>
+     * Multimap&lt;String, Person&gt; peopleByLastName =
+     *     people.groupBy(Person::getLastName);
+     * </pre>
+     *
+     * @since 1.0
+     */
+    <V> Multimap<V, T> groupBy(Function<? super T, ? extends V> function);
+
+    /**
+     * Same as {@link #groupBy(Function)}, except that the results are gathered into the specified {@code target}
+     * multimap.
+     * <p>
+     * Example using a Java 8 method reference:
+     * <pre>
+     * FastListMultimap&lt;String, Person&gt; peopleByLastName =
+     *     people.groupBy(Person::getLastName, new FastListMultimap&lt;String, Person&gt;());
+     * </pre>
+     *
+     * @since 1.0
+     */
+    <V, R extends MutableMultimap<V, T>> R groupBy(Function<? super T, ? extends V> function, R target);
+
+    /**
+     * Similar to {@link #groupBy(Function)}, except the result of evaluating function will return a collection of keys
+     * for each value.
+     *
+     * @since 1.0
+     */
+    <V> Multimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
+
+    /**
+     * Same as {@link #groupByEach(Function)}, except that the results are gathered into the specified {@code target}
+     * multimap.
+     *
+     * @since 1.0
+     */
+    <V, R extends MutableMultimap<V, T>> R groupByEach(
+            Function<? super T, ? extends Iterable<V>> function,
+            R target);
+
+    /**
+     * For each element of the iterable, the function is evaluated, and the results of these evaluations are collected
+     * into a new map, where the transformed value is the key. The generated keys must each be unique, or else an
+     * exception is thrown.
+     *
+     * @throws IllegalStateException if the keys returned by the function are not unique
+     * @see #groupBy(Function)
+     * @since 5.0
+     */
+    <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+
+    /**
+     * Same as {@link #groupByUniqueKey(Function)}, except that the results are gathered into the specified {@code target}
+     * map.
+     *
+     * @throws IllegalStateException if the keys returned by the function are not unique
+     * @see #groupByUniqueKey(Function)
+     * @since 6.0
+     */
+    <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
+            Function<? super T, ? extends V> function,
+            R target);
+
+    /**
+     * Partitions elements in fixed size chunks.
+     *
+     * @param size the number of elements per chunk
+     * @return A {@code RichIterable} containing {@code RichIterable}s of size {@code size}, except the last will be
+     * truncated if the elements don't divide evenly.
+     * @since 1.0
+     */
+    RichIterable<RichIterable<T>> chunk(int size);
+
+    /**
+     * Applies a groupBy function over the iterable, followed by a collect function.
+     *
+     * @param groupByFunction a {@link Function} to use as the groupBy transformation function
+     * @param collectFunction a {@link Function} to use as the collect transformation function
+     *
+     * @return The {@code target} collection where the key is the transformed result from applying the groupBy function
+     * and the value is the transformed result from applying the collect function.
+     *
+     * @see #groupBy(Function)
+     * @see Multimap#collectValues(Function)
+     *
+     * @since 10.1.0
+     */
+    default <K, V, R extends MutableMultimap<K, V>> R groupByAndCollect(
+            Function<? super T, ? extends K> groupByFunction,
+            Function<? super T, ? extends V> collectFunction,
+            R target)
     {
-        return this.flatCollect(each -> function.apply(each, parameter));
+        this.forEach(each -> target.put(groupByFunction.apply(each), collectFunction.apply(each)));
+        return target;
     }
 
-    /**
-     * Same as flatCollect, only the results are collected into the target collection.
-     *
-     * @param function The {@link Function} to apply
-     * @param target   The collection into which results should be added.
-     * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
-     * @see #flatCollect(Function)
-     */
-    <V, R extends Collection<V>> R flatCollect(Function<? super T, ? extends Iterable<V>> function, R target);
+    //endregion [Category: Grouping Methods]
 
-    /**
-     * Same as flatCollectWith, only the results are collected into the target collection.
-     *
-     * @since 9.2
-     */
-    default <P, V, R extends Collection<V>> R flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter, R target)
-    {
-        return this.flatCollect(each -> function.apply(each, parameter), target);
-    }
-
-    /**
-     * Returns the first element of the iterable for which the predicate evaluates to true or null in the case where no
-     * element returns true. This method is commonly called find.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * Person person =
-     *     people.detect(person -&gt; person.getFirstName().equals("John") &amp;&amp; person.getLastName().equals("Smith"));
-     * </pre>
-     *
-     * @since 1.0
-     */
-    T detect(Predicate<? super T> predicate);
-
-    /**
-     * Returns the first element that evaluates to true for the specified predicate2 and parameter, or null if none
-     * evaluate to true.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * Person person =
-     *     people.detectWith((person, fullName) -&gt; person.getFullName().equals(fullName), "John Smith");
-     * </pre>
-     *
-     * @since 5.0
-     */
-    <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter);
-
-    /**
-     * Returns the first element of the iterable for which the predicate evaluates to true as an Optional. This method is commonly called find.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * Person person =
-     *     people.detectOptional(person -&gt; person.getFirstName().equals("John") &amp;&amp; person.getLastName().equals("Smith"));
-     * </pre>
-     * <p>
-     *
-     * @throws NullPointerException if the element selected is null
-     * @since 8.0
-     */
-    Optional<T> detectOptional(Predicate<? super T> predicate);
-
-    /**
-     * Returns the first element that evaluates to true for the specified predicate2 and parameter as an Optional.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * Optional&lt;Person&gt; person =
-     *     people.detectWithOptional((person, fullName) -&gt; person.getFullName().equals(fullName), "John Smith");
-     * </pre>
-     * <p>
-     *
-     * @throws NullPointerException if the element selected is null
-     * @since 8.0
-     */
-    <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter);
-
-    /**
-     * Returns the first element of the iterable for which the predicate evaluates to true. If no element matches
-     * the predicate, then returns the value of applying the specified function.
-     *
-     * @since 1.0
-     */
-    default T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
-    {
-        T result = this.detect(predicate);
-        return result == null ? function.value() : result;
-    }
-
-    /**
-     * Returns the first element of the iterable that evaluates to true for the specified predicate2 and parameter, or
-     * returns the value of evaluating the specified function.
-     *
-     * @since 5.0
-     */
-    <P> T detectWithIfNone(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter,
-            Function0<? extends T> function);
-
-    /**
-     * Return the total number of elements that answer true to the specified predicate.
-     * <p>
-     * Example using a Java 8 lambda expression:
-     * <pre>
-     * int count =
-     *     people.<b>count</b>(person -&gt; person.getAddress().getState().getName().equals("New York"));
-     * </pre>
-     *
-     * @since 1.0
-     */
-    int count(Predicate<? super T> predicate);
-
-    /**
-     * Returns the total number of elements that evaluate to true for the specified predicate.
-     *
-     * <pre>e.g.
-     * return lastNames.<b>countWith</b>(Predicates2.equal(), "Smith");
-     * </pre>
-     */
-    <P> int countWith(Predicate2<? super T, ? super P> predicate, P parameter);
-
-    /**
-     * Returns true if the predicate evaluates to true for any element of the iterable.
-     * Returns false if the iterable is empty, or if no element returned true when evaluating the predicate.
-     *
-     * @since 1.0
-     */
-    boolean anySatisfy(Predicate<? super T> predicate);
-
-    /**
-     * Returns true if the predicate evaluates to true for any element of the collection, or return false.
-     * Returns false if the collection is empty.
-     *
-     * @since 5.0
-     */
-    <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
-
-    /**
-     * Returns true if the predicate evaluates to true for every element of the iterable or if the iterable is empty.
-     * Otherwise, returns false.
-     *
-     * @since 1.0
-     */
-    boolean allSatisfy(Predicate<? super T> predicate);
-
-    /**
-     * Returns true if the predicate evaluates to true for every element of the collection, or returns false.
-     *
-     * @since 5.0
-     */
-    <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
-
-    /**
-     * Returns true if the predicate evaluates to false for every element of the iterable or if the iterable is empty.
-     * Otherwise, returns false.
-     *
-     * @since 3.0
-     */
-    boolean noneSatisfy(Predicate<? super T> predicate);
-
-    /**
-     * Returns true if the predicate evaluates to false for every element of the collection, or return false.
-     * Returns true if the collection is empty.
-     *
-     * @since 5.0
-     */
-    <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
-
+    //region [Category: Aggregating Methods]
     /**
      * Returns the final result of evaluating function using each element of the iterable and the previous evaluation
      * result as the parameters. The injected value is used for the first parameter of the first evaluation, and the current
@@ -1334,6 +1822,295 @@ public interface RichIterable<T>
     {
         return this.injectInto(injectedValue, function);
     }
+
+    /**
+     * Returns the final long result of evaluating function for each element of the iterable and adding the results
+     * together.
+     *
+     * @since 2.0
+     */
+    long sumOfInt(IntFunction<? super T> function);
+
+    /**
+     * Returns the final double result of evaluating function for each element of the iterable and adding the results
+     * together. It uses Kahan summation algorithm to reduce numerical error.
+     *
+     * @since 2.0
+     */
+    double sumOfFloat(FloatFunction<? super T> function);
+
+    /**
+     * Returns the final long result of evaluating function for each element of the iterable and adding the results
+     * together.
+     *
+     * @since 2.0
+     */
+    long sumOfLong(LongFunction<? super T> function);
+
+    /**
+     * Returns the final double result of evaluating function for each element of the iterable and adding the results
+     * together. It uses Kahan summation algorithm to reduce numerical error.
+     *
+     * @since 2.0
+     */
+    double sumOfDouble(DoubleFunction<? super T> function);
+
+    /**
+     * Returns the result of summarizing the value returned from applying the IntFunction to
+     * each element of the iterable.
+     *
+     * <pre>
+     * IntSummaryStatistics stats =
+     *     Lists.mutable.with(1, 2, 3).summarizeInt(Integer::intValue);
+     * </pre>
+     *
+     * @since 8.0
+     */
+    default IntSummaryStatistics summarizeInt(IntFunction<? super T> function)
+    {
+        IntSummaryStatistics stats = new IntSummaryStatistics();
+        this.each(each -> stats.accept(function.intValueOf(each)));
+        return stats;
+    }
+
+    /**
+     * Returns the result of summarizing the value returned from applying the FloatFunction to
+     * each element of the iterable.
+     *
+     * <pre>
+     * DoubleSummaryStatistics stats =
+     *     Lists.mutable.with(1, 2, 3).summarizeFloat(Integer::floatValue);
+     * </pre>
+     *
+     * @since 8.0
+     */
+    default DoubleSummaryStatistics summarizeFloat(FloatFunction<? super T> function)
+    {
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        this.each(each -> stats.accept(function.floatValueOf(each)));
+        return stats;
+    }
+
+    /**
+     * Returns the result of summarizing the value returned from applying the LongFunction to
+     * each element of the iterable.
+     *
+     * <pre>
+     * LongSummaryStatistics stats =
+     *     Lists.mutable.with(1, 2, 3).summarizeLong(Integer::longValue);
+     * </pre>
+     *
+     * @since 8.0
+     */
+    default LongSummaryStatistics summarizeLong(LongFunction<? super T> function)
+    {
+        LongSummaryStatistics stats = new LongSummaryStatistics();
+        this.each(each -> stats.accept(function.longValueOf(each)));
+        return stats;
+    }
+
+    /**
+     * Returns the result of summarizing the value returned from applying the DoubleFunction to
+     * each element of the iterable.
+     *
+     * <pre>
+     * DoubleSummaryStatistics stats =
+     *     Lists.mutable.with(1, 2, 3).summarizeDouble(Integer::doubleValue);
+     * </pre>
+     *
+     * @since 8.0
+     */
+    default DoubleSummaryStatistics summarizeDouble(DoubleFunction<? super T> function)
+    {
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        this.each(each -> stats.accept(function.doubleValueOf(each)));
+        return stats;
+    }
+
+    /**
+     * This method produces the equivalent result as {@link Stream#collect(Collector)}.
+     *
+     * <pre>
+     * MutableObjectLongMap&lt;Integer&gt; map2 =
+     *     Lists.mutable.with(1, 2, 3, 4, 5).reduceInPlace(Collectors2.sumByInt(i -&gt; Integer.valueOf(i % 2), Integer::intValue));
+     * </pre>
+     *
+     * @since 8.0
+     */
+    default <R, A> R reduceInPlace(Collector<? super T, A, R> collector)
+    {
+        A mutableResult = collector.supplier().get();
+        BiConsumer<A, ? super T> accumulator = collector.accumulator();
+        this.each(each -> accumulator.accept(mutableResult, each));
+        return collector.finisher().apply(mutableResult);
+    }
+
+    /**
+     * This method produces the equivalent result as {@link Stream#collect(Supplier, BiConsumer, BiConsumer)}.
+     * The combiner used in collect is unnecessary in the serial case, so is not included in the API.
+     *
+     * @since 8.0
+     */
+    default <R> R reduceInPlace(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator)
+    {
+        R result = supplier.get();
+        this.each(each -> accumulator.accept(result, each));
+        return result;
+    }
+
+    /**
+     * This method produces the equivalent result as {@link Stream#reduce(BinaryOperator)}.
+     *
+     * @since 8.0
+     */
+    default Optional<T> reduce(BinaryOperator<T> accumulator)
+    {
+        boolean[] seenOne = new boolean[1];
+        T[] result = (T[]) new Object[1];
+        this.each(each ->
+        {
+            if (seenOne[0])
+            {
+                result[0] = accumulator.apply(result[0], each);
+            }
+            else
+            {
+                seenOne[0] = true;
+                result[0] = each;
+            }
+        });
+        return seenOne[0] ? Optional.of(result[0]) : Optional.empty();
+    }
+
+    /**
+     * Groups and sums the values using the two specified functions.
+     *
+     * @since 6.0
+     */
+    <V> ObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
+
+    /**
+     * Groups and sums the values using the two specified functions.
+     *
+     * @since 6.0
+     */
+    <V> ObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
+
+    /**
+     * Groups and sums the values using the two specified functions.
+     *
+     * @since 6.0
+     */
+    <V> ObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
+
+    /**
+     * Groups and sums the values using the two specified functions.
+     *
+     * @since 6.0
+     */
+    <V> ObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
+
+    /**
+     * Applies an aggregate procedure over the iterable grouping results into a Map based on the specific groupBy function.
+     * Aggregate results are required to be mutable as they will be changed in place by the procedure. A second function
+     * specifies the initial "zero" aggregate value to work with (i.e. new AtomicInteger(0)).
+     *
+     * @since 3.0
+     */
+    default <K, V> MapIterable<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator)
+    {
+        MutableMap<K, V> map = Maps.mutable.empty();
+        this.forEach(each ->
+        {
+            K key = groupBy.valueOf(each);
+            V value = map.getIfAbsentPut(key, zeroValueFactory);
+            mutatingAggregator.value(value, each);
+        });
+        return map;
+    }
+
+    /**
+     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
+     * Aggregate results are allowed to be immutable as they will be replaced in place in the map. A second function
+     * specifies the initial "zero" aggregate value to work with (i.e. Integer.valueOf(0)).
+     *
+     * @since 3.0
+     */
+    default <K, V> MapIterable<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    {
+        return this.aggregateBy(
+                groupBy,
+                zeroValueFactory,
+                nonMutatingAggregator,
+                Maps.mutable.empty());
+    }
+
+    /**
+     * Applies an aggregate function over the iterable grouping results into the target map based on the specific
+     * groupBy function. Aggregate results are allowed to be immutable as they will be replaced in place in the map. A
+     * second function specifies the initial "zero" aggregate value to work with (i.e. Integer.valueOf(0)).
+     *
+     * @since 10.3
+     */
+    default <K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator,
+            R target)
+    {
+        this.forEach(each ->
+        {
+            K key = groupBy.valueOf(each);
+            target.updateValueWith(key, zeroValueFactory, nonMutatingAggregator, each);
+        });
+        return target;
+    }
+
+    /**
+     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
+     * Aggregate results are allowed to be immutable as they will be replaced in place in the map.
+     *
+     * @since 12.0
+     *
+     */
+    default <K> MapIterable<K, T> reduceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function2<? super T, ? super T, ? extends T> reduceFunction)
+    {
+        return this.reduceBy(
+                groupBy,
+                reduceFunction,
+                Maps.mutable.empty());
+    }
+
+    /**
+     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
+     * Aggregate results are allowed to be immutable as they will be replaced in place in the map.
+     *
+     * @since 12.0
+     */
+    default <K, R extends MutableMapIterable<K, T>> R reduceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function2<? super T, ? super T, ? extends T> reduceFunction,
+            R target)
+    {
+        this.forEach(each ->
+        {
+            K key = groupBy.valueOf(each);
+            target.merge(key, each, reduceFunction);
+        });
+        return target;
+    }
+
+    //endregion Category: Aggregating Methods
+
+    //region [Category: Converting Methods]
 
     /**
      * Adds all the elements in this iterable to the specific target Collection.
@@ -1660,13 +2437,6 @@ public interface RichIterable<T>
     }
 
     /**
-     * Returns a lazy (deferred) iterable, most likely implemented by calling LazyIterate.adapt(this).
-     *
-     * @since 1.0.
-     */
-    LazyIterable<T> asLazy();
-
-    /**
      * Converts this iterable to an array.
      *
      * @see Collection#toArray()
@@ -1684,339 +2454,21 @@ public interface RichIterable<T>
     <E> E[] toArray(E[] array);
 
     /**
-     * Returns the minimum element out of this container based on the comparator.
-     *
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    T min(Comparator<? super T> comparator);
-
-    /**
-     * Returns the maximum element out of this container based on the comparator.
-     *
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    T max(Comparator<? super T> comparator);
-
-    /**
-     * Returns the minimum element out of this container based on the comparator as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws NullPointerException if the minimum element is null
-     * @since 8.2
-     */
-    default Optional<T> minOptional(Comparator<? super T> comparator)
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.min(comparator));
-    }
-
-    /**
-     * Returns the maximum element out of this container based on the comparator as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws NullPointerException if the maximum element is null
-     * @since 8.2
-     */
-    default Optional<T> maxOptional(Comparator<? super T> comparator)
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.max(comparator));
-    }
-
-    /**
-     * Returns the minimum element out of this container based on the natural order.
-     *
-     * @throws ClassCastException     if the elements are not {@link Comparable}
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    T min();
-
-    /**
-     * Returns the maximum element out of this container based on the natural order.
-     *
-     * @throws ClassCastException     if the elements are not {@link Comparable}
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    T max();
-
-    /**
-     * Returns the minimum element out of this container based on the natural order as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws ClassCastException   if the elements are not {@link Comparable}
-     * @throws NullPointerException if the minimum element is null
-     * @since 8.2
-     */
-    default Optional<T> minOptional()
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.min());
-    }
-
-    /**
-     * Returns the maximum element out of this container based on the natural order as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws ClassCastException   if the elements are not {@link Comparable}
-     * @throws NullPointerException if the maximum element is null
-     * @since 8.2
-     */
-    default Optional<T> maxOptional()
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.max());
-    }
-
-    /**
-     * Returns the minimum elements out of this container based on the natural order of the attribute returned by Function.
-     *
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    <V extends Comparable<? super V>> T minBy(Function<? super T, ? extends V> function);
-
-    /**
-     * Returns the maximum elements out of this container based on the natural order of the attribute returned by Function.
-     *
-     * @throws NoSuchElementException if the RichIterable is empty
-     * @since 1.0
-     */
-    <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function);
-
-    /**
-     * Returns the minimum elements out of this container based on the natural order of the attribute returned by Function as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws NullPointerException if the minimum element is null
-     * @since 8.2
-     */
-    default <V extends Comparable<? super V>> Optional<T> minByOptional(Function<? super T, ? extends V> function)
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.minBy(function));
-    }
-
-    /**
-     * Returns the maximum elements out of this container based on the natural order of the attribute returned by Function as an Optional.
-     * If the container is empty {@link Optional#empty()} is returned.
-     *
-     * @throws NullPointerException if the maximum element is null
-     * @since 8.2
-     */
-    default <V extends Comparable<? super V>> Optional<T> maxByOptional(Function<? super T, ? extends V> function)
-    {
-        if (this.isEmpty())
-        {
-            return Optional.empty();
-        }
-        return Optional.of(this.maxBy(function));
-    }
-
-    /**
-     * Returns the final long result of evaluating function for each element of the iterable and adding the results
-     * together.
-     *
-     * @since 2.0
-     */
-    long sumOfInt(IntFunction<? super T> function);
-
-    /**
-     * Returns the final double result of evaluating function for each element of the iterable and adding the results
-     * together. It uses Kahan summation algorithm to reduce numerical error.
-     *
-     * @since 2.0
-     */
-    double sumOfFloat(FloatFunction<? super T> function);
-
-    /**
-     * Returns the final long result of evaluating function for each element of the iterable and adding the results
-     * together.
-     *
-     * @since 2.0
-     */
-    long sumOfLong(LongFunction<? super T> function);
-
-    /**
-     * Returns the final double result of evaluating function for each element of the iterable and adding the results
-     * together. It uses Kahan summation algorithm to reduce numerical error.
-     *
-     * @since 2.0
-     */
-    double sumOfDouble(DoubleFunction<? super T> function);
-
-    /**
-     * Returns the result of summarizing the value returned from applying the IntFunction to
-     * each element of the iterable.
+     * Returns a string with the elements of this iterable separated by commas with spaces and
+     * enclosed in square brackets.
      *
      * <pre>
-     * IntSummaryStatistics stats =
-     *     Lists.mutable.with(1, 2, 3).summarizeInt(Integer::intValue);
+     * Assert.assertEquals("[]", Lists.mutable.empty().toString());
+     * Assert.assertEquals("[1]", Lists.mutable.with(1).toString());
+     * Assert.assertEquals("[1, 2, 3]", Lists.mutable.with(1, 2, 3).toString());
      * </pre>
      *
-     * @since 8.0
+     * @return a string representation of this RichIterable
+     * @see java.util.AbstractCollection#toString()
+     * @since 1.0
      */
-    default IntSummaryStatistics summarizeInt(IntFunction<? super T> function)
-    {
-        IntSummaryStatistics stats = new IntSummaryStatistics();
-        this.each(each -> stats.accept(function.intValueOf(each)));
-        return stats;
-    }
-
-    /**
-     * Returns the result of summarizing the value returned from applying the FloatFunction to
-     * each element of the iterable.
-     *
-     * <pre>
-     * DoubleSummaryStatistics stats =
-     *     Lists.mutable.with(1, 2, 3).summarizeFloat(Integer::floatValue);
-     * </pre>
-     *
-     * @since 8.0
-     */
-    default DoubleSummaryStatistics summarizeFloat(FloatFunction<? super T> function)
-    {
-        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
-        this.each(each -> stats.accept(function.floatValueOf(each)));
-        return stats;
-    }
-
-    /**
-     * Returns the result of summarizing the value returned from applying the LongFunction to
-     * each element of the iterable.
-     *
-     * <pre>
-     * LongSummaryStatistics stats =
-     *     Lists.mutable.with(1, 2, 3).summarizeLong(Integer::longValue);
-     * </pre>
-     *
-     * @since 8.0
-     */
-    default LongSummaryStatistics summarizeLong(LongFunction<? super T> function)
-    {
-        LongSummaryStatistics stats = new LongSummaryStatistics();
-        this.each(each -> stats.accept(function.longValueOf(each)));
-        return stats;
-    }
-
-    /**
-     * Returns the result of summarizing the value returned from applying the DoubleFunction to
-     * each element of the iterable.
-     *
-     * <pre>
-     * DoubleSummaryStatistics stats =
-     *     Lists.mutable.with(1, 2, 3).summarizeDouble(Integer::doubleValue);
-     * </pre>
-     *
-     * @since 8.0
-     */
-    default DoubleSummaryStatistics summarizeDouble(DoubleFunction<? super T> function)
-    {
-        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
-        this.each(each -> stats.accept(function.doubleValueOf(each)));
-        return stats;
-    }
-
-    /**
-     * This method produces the equivalent result as {@link Stream#collect(Collector)}.
-     *
-     * <pre>
-     * MutableObjectLongMap&lt;Integer&gt; map2 =
-     *     Lists.mutable.with(1, 2, 3, 4, 5).reduceInPlace(Collectors2.sumByInt(i -&gt; Integer.valueOf(i % 2), Integer::intValue));
-     * </pre>
-     *
-     * @since 8.0
-     */
-    default <R, A> R reduceInPlace(Collector<? super T, A, R> collector)
-    {
-        A mutableResult = collector.supplier().get();
-        BiConsumer<A, ? super T> accumulator = collector.accumulator();
-        this.each(each -> accumulator.accept(mutableResult, each));
-        return collector.finisher().apply(mutableResult);
-    }
-
-    /**
-     * This method produces the equivalent result as {@link Stream#collect(Supplier, BiConsumer, BiConsumer)}.
-     * The combiner used in collect is unnecessary in the serial case, so is not included in the API.
-     *
-     * @since 8.0
-     */
-    default <R> R reduceInPlace(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator)
-    {
-        R result = supplier.get();
-        this.each(each -> accumulator.accept(result, each));
-        return result;
-    }
-
-    /**
-     * This method produces the equivalent result as {@link Stream#reduce(BinaryOperator)}.
-     *
-     * @since 8.0
-     */
-    default Optional<T> reduce(BinaryOperator<T> accumulator)
-    {
-        boolean[] seenOne = new boolean[1];
-        T[] result = (T[]) new Object[1];
-        this.each(each ->
-        {
-            if (seenOne[0])
-            {
-                result[0] = accumulator.apply(result[0], each);
-            }
-            else
-            {
-                seenOne[0] = true;
-                result[0] = each;
-            }
-        });
-        return seenOne[0] ? Optional.of(result[0]) : Optional.empty();
-    }
-
-    /**
-     * Groups and sums the values using the two specified functions.
-     *
-     * @since 6.0
-     */
-    <V> ObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
-
-    /**
-     * Groups and sums the values using the two specified functions.
-     *
-     * @since 6.0
-     */
-    <V> ObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
-
-    /**
-     * Groups and sums the values using the two specified functions.
-     *
-     * @since 6.0
-     */
-    <V> ObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
-
-    /**
-     * Groups and sums the values using the two specified functions.
-     *
-     * @since 6.0
-     */
-    <V> ObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
+    @Override
+    String toString();
 
     /**
      * Returns a string representation of this collection by delegating to {@link #makeString(String)} and defaulting
@@ -2097,333 +2549,5 @@ public interface RichIterable<T>
      */
     void appendString(Appendable appendable, String start, String separator, String end);
 
-    /**
-     * For each element of the iterable, the function is evaluated and the results of these evaluations are collected
-     * into a new multimap, where the transformed value is the key and the original values are added to the same (or similar)
-     * species of collection as the source iterable.
-     * <p>
-     * Example using a Java 8 method reference:
-     * <pre>
-     * Multimap&lt;String, Person&gt; peopleByLastName =
-     *     people.groupBy(Person::getLastName);
-     * </pre>
-     *
-     * @since 1.0
-     */
-    <V> Multimap<V, T> groupBy(Function<? super T, ? extends V> function);
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection.
-     *
-     * @since 9.0
-     */
-    default <V> Bag<V> countBy(Function<? super T, ? extends V> function)
-    {
-        return this.countBy(function, Bags.mutable.empty());
-    }
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection.
-     *
-     * @since 9.0
-     */
-    default <V, R extends MutableBagIterable<V>> R countBy(Function<? super T, ? extends V> function, R target)
-    {
-        return this.collect(function, target);
-    }
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection with the specified parameter as the second argument.
-     *
-     * @since 9.0
-     */
-    default <V, P> Bag<V> countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter)
-    {
-        return this.countByWith(function, parameter, Bags.mutable.empty());
-    }
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection with the specified parameter as the second argument.
-     *
-     * @since 9.0
-     */
-    default <V, P, R extends MutableBagIterable<V>> R countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter, R target)
-    {
-        return this.collectWith(function, parameter, target);
-    }
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection.
-     *
-     * @since 10.0.0
-     */
-    default <V> Bag<V> countByEach(Function<? super T, ? extends Iterable<V>> function)
-    {
-        return this.asLazy().flatCollect(function).toBag();
-    }
-
-    /**
-     * This method will count the number of occurrences of each value calculated by applying the
-     * function to each element of the collection.
-     *
-     * @since 10.0.0
-     */
-    default <V, R extends MutableBagIterable<V>> R countByEach(Function<? super T, ? extends Iterable<V>> function, R target)
-    {
-        return this.flatCollect(function, target);
-    }
-
-    /**
-     * Same as {@link #groupBy(Function)}, except that the results are gathered into the specified {@code target}
-     * multimap.
-     * <p>
-     * Example using a Java 8 method reference:
-     * <pre>
-     * FastListMultimap&lt;String, Person&gt; peopleByLastName =
-     *     people.groupBy(Person::getLastName, new FastListMultimap&lt;String, Person&gt;());
-     * </pre>
-     *
-     * @since 1.0
-     */
-    <V, R extends MutableMultimap<V, T>> R groupBy(Function<? super T, ? extends V> function, R target);
-
-    /**
-     * Similar to {@link #groupBy(Function)}, except the result of evaluating function will return a collection of keys
-     * for each value.
-     *
-     * @since 1.0
-     */
-    <V> Multimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
-
-    /**
-     * Same as {@link #groupByEach(Function)}, except that the results are gathered into the specified {@code target}
-     * multimap.
-     *
-     * @since 1.0
-     */
-    <V, R extends MutableMultimap<V, T>> R groupByEach(
-            Function<? super T, ? extends Iterable<V>> function,
-            R target);
-
-    /**
-     * For each element of the iterable, the function is evaluated, and the results of these evaluations are collected
-     * into a new map, where the transformed value is the key. The generated keys must each be unique, or else an
-     * exception is thrown.
-     *
-     * @throws IllegalStateException if the keys returned by the function are not unique
-     * @see #groupBy(Function)
-     * @since 5.0
-     */
-    <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
-
-    /**
-     * Same as {@link #groupByUniqueKey(Function)}, except that the results are gathered into the specified {@code target}
-     * map.
-     *
-     * @throws IllegalStateException if the keys returned by the function are not unique
-     * @see #groupByUniqueKey(Function)
-     * @since 6.0
-     */
-    <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
-            Function<? super T, ? extends V> function,
-            R target);
-
-    /**
-     * Returns a string with the elements of this iterable separated by commas with spaces and
-     * enclosed in square brackets.
-     *
-     * <pre>
-     * Assert.assertEquals("[]", Lists.mutable.empty().toString());
-     * Assert.assertEquals("[1]", Lists.mutable.with(1).toString());
-     * Assert.assertEquals("[1, 2, 3]", Lists.mutable.with(1, 2, 3).toString());
-     * </pre>
-     *
-     * @return a string representation of this RichIterable
-     * @see java.util.AbstractCollection#toString()
-     * @since 1.0
-     */
-    @Override
-    String toString();
-
-    /**
-     * Returns a {@code RichIterable} formed from this {@code RichIterable} and another {@code RichIterable} by
-     * combining corresponding elements in pairs. If one of the two {@code RichIterable}s is longer than the other, its
-     * remaining elements are ignored.
-     *
-     * @param that The {@code RichIterable} providing the second half of each result pair
-     * @param <S>  the type of the second half of the returned pairs
-     * @return A new {@code RichIterable} containing pairs consisting of corresponding elements of this {@code
-     * RichIterable} and that. The length of the returned {@code RichIterable} is the minimum of the lengths of
-     * this {@code RichIterable} and that.
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.
-     */
-    @Deprecated
-    <S> RichIterable<Pair<T, S>> zip(Iterable<S> that);
-
-    /**
-     * Same as {@link #zip(Iterable)} but uses {@code target} for output.
-     *
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable, Collection)} instead;
-     */
-    @Deprecated
-    <S, R extends Collection<Pair<T, S>>> R zip(Iterable<S> that, R target);
-
-    /**
-     * Zips this {@code RichIterable} with its indices.
-     *
-     * @return A new {@code RichIterable} containing pairs consisting of all elements of this {@code RichIterable}
-     * paired with their index. Indices start at 0.
-     * @see #zip(Iterable)
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex()} instead.
-     */
-    @Deprecated
-    RichIterable<Pair<T, Integer>> zipWithIndex();
-
-    /**
-     * Same as {@link #zipWithIndex()} but uses {@code target} for output.
-     *
-     * @since 1.0
-     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex(Collection)} instead.
-     */
-    @Deprecated
-    <R extends Collection<Pair<T, Integer>>> R zipWithIndex(R target);
-
-    /**
-     * Partitions elements in fixed size chunks.
-     *
-     * @param size the number of elements per chunk
-     * @return A {@code RichIterable} containing {@code RichIterable}s of size {@code size}, except the last will be
-     * truncated if the elements don't divide evenly.
-     * @since 1.0
-     */
-    RichIterable<RichIterable<T>> chunk(int size);
-
-    /**
-     * Applies an aggregate procedure over the iterable grouping results into a Map based on the specific groupBy function.
-     * Aggregate results are required to be mutable as they will be changed in place by the procedure. A second function
-     * specifies the initial "zero" aggregate value to work with (i.e. new AtomicInteger(0)).
-     *
-     * @since 3.0
-     */
-    default <K, V> MapIterable<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = Maps.mutable.empty();
-        this.forEach(each ->
-        {
-            K key = groupBy.valueOf(each);
-            V value = map.getIfAbsentPut(key, zeroValueFactory);
-            mutatingAggregator.value(value, each);
-        });
-        return map;
-    }
-
-    /**
-     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
-     * Aggregate results are allowed to be immutable as they will be replaced in place in the map. A second function
-     * specifies the initial "zero" aggregate value to work with (i.e. Integer.valueOf(0)).
-     *
-     * @since 3.0
-     */
-    default <K, V> MapIterable<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        return this.aggregateBy(
-                groupBy,
-                zeroValueFactory,
-                nonMutatingAggregator,
-                Maps.mutable.empty());
-    }
-
-    /**
-     * Applies an aggregate function over the iterable grouping results into the target map based on the specific
-     * groupBy function. Aggregate results are allowed to be immutable as they will be replaced in place in the map. A
-     * second function specifies the initial "zero" aggregate value to work with (i.e. Integer.valueOf(0)).
-     *
-     * @since 10.3
-     */
-    default <K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator,
-            R target)
-    {
-        this.forEach(each ->
-        {
-            K key = groupBy.valueOf(each);
-            target.updateValueWith(key, zeroValueFactory, nonMutatingAggregator, each);
-        });
-        return target;
-    }
-
-    /**
-     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
-     * Aggregate results are allowed to be immutable as they will be replaced in place in the map.
-     *
-     * @since 12.0
-     *
-     */
-    default <K> MapIterable<K, T> reduceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function2<? super T, ? super T, ? extends T> reduceFunction)
-    {
-        return this.reduceBy(
-                groupBy,
-                reduceFunction,
-                Maps.mutable.empty());
-    }
-
-    /**
-     * Applies an aggregate function over the iterable grouping results into a map based on the specific groupBy function.
-     * Aggregate results are allowed to be immutable as they will be replaced in place in the map.
-     *
-     * @since 12.0
-     */
-    default <K, R extends MutableMapIterable<K, T>> R reduceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function2<? super T, ? super T, ? extends T> reduceFunction,
-            R target)
-    {
-        this.forEach(each ->
-        {
-            K key = groupBy.valueOf(each);
-            target.merge(key, each, reduceFunction);
-        });
-        return target;
-    }
-
-    /**
-     * Applies a groupBy function over the iterable, followed by a collect function.
-     *
-     * @param groupByFunction a {@link Function} to use as the groupBy transformation function
-     * @param collectFunction a {@link Function} to use as the collect transformation function
-     *
-     * @return The {@code target} collection where the key is the transformed result from applying the groupBy function
-     * and the value is the transformed result from applying the collect function.
-     *
-     * @see #groupBy(Function)
-     * @see Multimap#collectValues(Function)
-     *
-     * @since 10.1.0
-     */
-    default <K, V, R extends MutableMultimap<K, V>> R groupByAndCollect(
-            Function<? super T, ? extends K> groupByFunction,
-            Function<? super T, ? extends V> collectFunction,
-            R target)
-    {
-        this.forEach(each -> target.put(groupByFunction.apply(each), collectFunction.apply(each)));
-        return target;
-    }
+    //endregion [Category: Converting Methods]
 }


### PR DESCRIPTION
- Updated top of RichIterable javadoc to include method categories with links to methods
- Created region/endregion sections to correspond to method categories