### PR TITLE
Fix static analysis violations.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triple.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triple.java
@@ -44,4 +44,3 @@ public interface Triple<T1, T2, T3>
         return this.getOne() == this.getTwo() && this.getOne() == this.getThree();
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfDoubleProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfDoubleProcedure.java
@@ -52,4 +52,3 @@ public class SumOfDoubleProcedure<T> implements Procedure<T>, DoubleSumResultHol
         this.result = nextSum;
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfFloatProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfFloatProcedure.java
@@ -52,4 +52,3 @@ public class SumOfFloatProcedure<T> implements Procedure<T>, DoubleSumResultHold
         this.result = nextSum;
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfIntProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfIntProcedure.java
@@ -41,4 +41,3 @@ public class SumOfIntProcedure<T> implements Procedure<T>
         this.result += this.function.intValueOf(each);
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfLongProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/SumOfLongProcedure.java
@@ -41,4 +41,3 @@ public class SumOfLongProcedure<T> implements Procedure<T>
         this.result += this.function.longValueOf(each);
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/Batch.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/Batch.java
@@ -53,4 +53,3 @@ public interface Batch<T>
 
     DoubleSumResultHolder sumOfDouble(DoubleFunction<? super T> function);
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/IntervalUtils.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/IntervalUtils.java
@@ -120,4 +120,3 @@ public final class IntervalUtils
         return direction == 0 ? stepBy : direction * stepBy;
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMap.java
@@ -430,4 +430,3 @@ public class ImmutableTreeMap<K, V>
         }
     }
 }
-

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplSerializationTest.java
@@ -31,4 +31,3 @@ public class ImmutableSortedBagMultimapImplSerializationTest extends ImmutableMu
                 + "A3EAfgACdAABQnEAfgADcQB+AAN3BAAAAAFxAH4AAng=";
     }
 }
-

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link BooleanIterable}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
@@ -23,10 +23,10 @@ import org.eclipse.collections.impl.block.factory.primitive.BytePredicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableByteCollectionTestCase;
 import org.eclipse.collections.impl.factory.primitive.ByteSets;
 import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
+import org.eclipse.collections.impl.map.mutable.primitive.CollisionGeneratorUtil;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.eclipse.collections.impl.map.mutable.primitive.CollisionGeneratorUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;


### PR DESCRIPTION
Another example based on #1687.

This was created with the command:

`mvn spotless:apply --activate-profiles 'spotless-apply,spotless-java-sort-imports'`

I was using this command to fix up the imports in my own changes, but it found a few older examples of files with unsorted imports, and files that don't end with a newline.