### PR TITLE
Add job forbid-merge-commits to .github/workflows/pull-request.yml.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -298,3 +298,9 @@ jobs:
           MAVEN_OPTS: '-Xmx2g'
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
+
+  forbid-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Forbid Merge Commits Action
+        uses: motlin/forbid-merge-commits-action@main


### PR DESCRIPTION
We recently had a ["backwards" merge commit](https://github.com/eclipse/eclipse-collections/commit/cb4f64274e905492f0c70f9981a6097c718fad97) land on the master branch.

It's visible in the git history as the white arrow here.

<img width="404" alt="Screenshot 2024-09-01 at 9 35 17 AM" src="https://github.com/user-attachments/assets/4ab59c52-0686-4733-8f5d-f1563647d5f2">

I wrote and open sourced [a GitHub Action](https://github.com/marketplace/actions/forbid-merge-commits) to prevent this sort of thing. Its README has more details about why this is a problem and how folks get into this situation. When it happens, the error message is pretty helpful about how to fix up git history.