### PR TITLE
Add missing @Test annotations and fix broken assertion.

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -278,7 +278,9 @@ public interface IterableTestCase
         assertThrows(NoSuchElementException.class, iterator3::next);
     }
 
+    @Test
     void Iterable_remove();
 
+    @Test
     void Iterable_toString();
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableOrderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableOrderedIterableTestCase.java
@@ -18,8 +18,8 @@ import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual
 
 public interface MutableOrderedIterableTestCase extends OrderedIterableTestCase
 {
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         Iterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedNaturalOrderTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedNaturalOrderTestCase.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public interface MutableSortedNaturalOrderTestCase extends SortedNaturalOrderTestCase, MutableOrderedIterableTestCase, MutableCollectionTestCase
 {
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         Iterable<Integer> iterable = this.newWith(1, 1, 1, 2, 2, 3);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableUnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableUnorderedIterableTestCase.java
@@ -21,8 +21,8 @@ import static org.hamcrest.Matchers.isOneOf;
 
 public interface MutableUnorderedIterableTestCase extends UnorderedIterableTestCase
 {
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         Iterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoDetectOptionalNullTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoDetectOptionalNullTestCase.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 public interface NoDetectOptionalNullTestCase extends RichIterableTestCase
 {
-    @Test
     @Override
+    @Test
     default void RichIterable_detectOptionalNull()
     {
         // Not applicable

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
@@ -2076,6 +2076,7 @@ public interface RichIterableTestCase extends IterableTestCase
                 builder3.toString());
     }
 
+    @Override
     @Test
     default void Iterable_toString()
     {

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
@@ -119,6 +119,7 @@ public interface RichIterableUniqueTestCase
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
@@ -841,6 +842,7 @@ public interface RichIterableUniqueTestCase
     }
 
     @Override
+    @Test
     default void RichIterable_sumByPrimitive()
     {
         RichIterable<String> iterable = this.newWith("4", "3", "2", "1");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedIterableTestCase.java
@@ -29,6 +29,7 @@ public interface SortedIterableTestCase extends OrderedIterableTestCase, NoDetec
     }
 
     @Override
+    @Test
     default void RichIterable_min_max_non_comparable()
     {
         assertThrows(ClassCastException.class, () -> this.newWith(new Object()));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("UnnecessaryCodeBlock")
 public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
 {
+    @Override
     @Test
     default void Iterable_toString()
     {
@@ -226,6 +227,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     }
 
     @Override
+    @Test
     default void RichIterable_flatCollect_primitive()
     {
         {

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnmodifiableMutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnmodifiableMutableCollectionTestCase.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface UnmodifiableMutableCollectionTestCase extends FixedSizeCollectionTestCase, MutableCollectionTestCase
 {
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         FixedSizeCollectionTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnorderedIterableTestCase.java
@@ -51,6 +51,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         assertThat(this.newWith(2, 2, 1).toString(), isOneOf("[2, 2, 1]", "[1, 2, 2]"));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/BagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/BagTestCase.java
@@ -46,6 +46,7 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
     }
 
     @Override
+    @Test
     default void RichIterable_iterator_iterationOrder()
     {
         MutableCollection<Integer> iterationOrder = this.newMutableForFilter();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
@@ -96,6 +96,7 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
     }
 
     @Override
+    @Test
     default void SortedIterable_comparator()
     {
         MutableSortedNaturalOrderTestCase.super.SortedIterable_comparator();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/OrderedIterableNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/OrderedIterableNoIteratorTest.java
@@ -12,10 +12,12 @@ package org.eclipse.collections.test.bag.mutable.sorted;
 
 import org.eclipse.collections.test.NoIteratorTestCase;
 import org.eclipse.collections.test.OrderedIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface OrderedIterableNoIteratorTest extends NoIteratorTestCase, OrderedIterableTestCase
 {
     @Override
+    @Test
     default void OrderedIterable_next()
     {
         // Not applicable

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/UnmodifiableSortedBagTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/UnmodifiableSortedBagTest.java
@@ -16,10 +16,12 @@ import org.eclipse.collections.impl.bag.sorted.mutable.UnmodifiableSortedBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.bag.mutable.UnmodifiableBagIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public class UnmodifiableSortedBagTest implements MutableSortedBagTestCase, UnmodifiableBagIterableTestCase
 {
     @Override
+    @Test
     public void Iterable_remove()
     {
         UnmodifiableBagIterableTestCase.super.Iterable_remove();
@@ -35,12 +37,14 @@ public class UnmodifiableSortedBagTest implements MutableSortedBagTestCase, Unmo
     }
 
     @Override
+    @Test
     public void MutableBagIterable_addOccurrences()
     {
         UnmodifiableBagIterableTestCase.super.MutableBagIterable_addOccurrences();
     }
 
     @Override
+    @Test
     public void MutableBagIterable_removeOccurrences()
     {
         UnmodifiableBagIterableTestCase.super.MutableBagIterable_removeOccurrences();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/BiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/BiMapTestCase.java
@@ -35,6 +35,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         return false;
     }
 
+    @Override
     @Test
     default void Iterable_sanity_check()
     {
@@ -42,6 +43,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         RichIterableUniqueTestCase.super.Iterable_toString();
@@ -68,6 +70,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
     }
 
     @Override
+    @Test
     default void MapIterable_forEachKeyValue()
     {
         BiMap<Object, Integer> bimap = this.newWith(3, 2, 1);
@@ -90,6 +93,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
     }
 
     @Override
+    @Test
     default void MapIterable_flipUniqueValues()
     {
         BiMap<String, Integer> bimap = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);
@@ -101,14 +105,16 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
     }
 
     @Override
+    @Test
     default void RichIterable_size()
     {
         RichIterableUniqueTestCase.super.RichIterable_size();
     }
 
+    @Test
     default void BiMap_toList()
     {
-        BiMap<Object, Integer> iterable = this.newWith(4, 3, 2, 1);
+        BiMap<Object, Integer> iterable = this.newWithKeysValues(4, 4, 3, 3, 2, 2, 1, 1);
 
         {
             MutableList<Integer> target = Lists.mutable.empty();
@@ -126,6 +132,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
     }
 
     @Override
+    @Test
     default void MapIterable_forEach()
     {
         BiMap<Object, Integer> bimap = this.newWith(3, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/UnsortedBiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/UnsortedBiMapTestCase.java
@@ -29,6 +29,7 @@ public interface UnsortedBiMapTestCase extends BiMapTestCase, TransformsToBagTra
     <T> BiMap<Object, T> newWith(T... elements);
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         BiMap<String, Integer> bimap = this.newWithKeysValues("Two", 2, "One", 1);
@@ -40,8 +41,8 @@ public interface UnsortedBiMapTestCase extends BiMapTestCase, TransformsToBagTra
         assertThat(bimap.asLazy().toString(), isOneOf("[1, 2]", "[2, 1]"));
     }
 
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         BiMap<Object, Integer> iterable = this.newWith(3, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/immutable/ImmutableUnsortedBiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/immutable/ImmutableUnsortedBiMapTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.bimap.immutable;
 import org.eclipse.collections.api.bimap.ImmutableBiMap;
 import org.eclipse.collections.test.ImmutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.bimap.UnsortedBiMapTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface ImmutableUnsortedBiMapTestCase extends UnsortedBiMapTestCase, ImmutableUnorderedIterableTestCase
 {
@@ -20,12 +21,14 @@ public interface ImmutableUnsortedBiMapTestCase extends UnsortedBiMapTestCase, I
     <T> ImmutableBiMap<Object, T> newWith(T... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         ImmutableUnorderedIterableTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     default void RichIterable_toArray()
     {
         UnsortedBiMapTestCase.super.RichIterable_toArray();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/mutable/MutableUnsortedBiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/mutable/MutableUnsortedBiMapTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.bimap.mutable;
 import org.eclipse.collections.api.bimap.MutableBiMap;
 import org.eclipse.collections.test.MutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.bimap.UnsortedBiMapTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
@@ -26,6 +27,7 @@ public interface MutableUnsortedBiMapTestCase extends UnsortedBiMapTestCase, Mut
     <K, V> MutableBiMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         UnsortedBiMapTestCase.super.Iterable_toString();
@@ -37,12 +39,14 @@ public interface MutableUnsortedBiMapTestCase extends UnsortedBiMapTestCase, Mut
     }
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         UnsortedBiMapTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     default void RichIterable_toArray()
     {
         UnsortedBiMapTestCase.super.RichIterable_toArray();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
@@ -26,43 +26,43 @@ public interface MultiReaderMutableCollectionTestCase extends MutableCollectionT
         assertThrows(UnsupportedOperationException.class, () -> this.newWith(3, 2, 1).iterator());
     }
 
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         // Multi-reader collections don't support iterator()
     }
 
-    @Test
     @Override
+    @Test
     default void Iterable_next()
     {
         // Multi-reader collections don't support iterator()
     }
 
-    @Test
     @Override
+    @Test
     default void Iterable_hasNext()
     {
         // Multi-reader collections don't support iterator()
     }
 
-    @Test
     @Override
+    @Test
     default void RichIterable_getFirst()
     {
         // Does not support iterator outside withReadLockAndDelegate
     }
 
-    @Test
     @Override
+    @Test
     default void RichIterable_getLast()
     {
         // Does not support iterator outside withReadLockAndDelegate
     }
 
-    @Test
     @Override
+    @Test
     default void RichIterable_getOnly()
     {
         // Does not support iterator outside withReadLockAndDelegate

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/FixedSizeListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/FixedSizeListTestCase.java
@@ -15,6 +15,7 @@ import java.util.ListIterator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.test.FixedSizeCollectionTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,12 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, ListTestCase
 {
     @Override
+    @Test
     default void Iterable_remove()
     {
         FixedSizeCollectionTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     default void List_subList_subList_remove()
     {
         List<String> list = this.newWith("A", "B", "C", "D");
@@ -44,6 +47,7 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
     }
 
     @Override
+    @Test
     default void List_subList_subList_iterator_add_remove()
     {
         List<String> list = this.newWith("A", "B", "C", "D");
@@ -67,6 +71,7 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
     }
 
     @Override
+    @Test
     default void List_subList_subList_addAll()
     {
         List<String> list = this.newWith("A", "B", "C", "D");
@@ -87,6 +92,7 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
     }
 
     @Override
+    @Test
     default void List_subList_subList_clear()
     {
         List<String> list = this.newWith("A", "B", "C", "D", "E", "F");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
@@ -34,8 +34,8 @@ public interface ListTestCase extends CollectionTestCase
         return true;
     }
 
-    @Test
     @Override
+    @Test
     default void Iterable_remove()
     {
         List<Integer> list = this.newWith(3, 3, 3, 2, 2, 1);
@@ -46,6 +46,7 @@ public interface ListTestCase extends CollectionTestCase
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         Iterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MutableListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MutableListTestCase.java
@@ -34,18 +34,20 @@ public interface MutableListTestCase extends MutableCollectionTestCase, ListTest
     <T> MutableList<T> newWith(T... elements);
 
     @Override
-    default void Iterable_toString()
-    {
-        ListTestCase.super.Iterable_toString();
-    }
-
-    @Override
     default boolean allowsDuplicates()
     {
         return true;
     }
 
     @Override
+    @Test
+    default void Iterable_toString()
+    {
+        ListTestCase.super.Iterable_toString();
+    }
+
+    @Override
+    @Test
     default void Iterable_remove()
     {
         ListTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapIterableTestCase.java
@@ -60,6 +60,7 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Two", 2, "One", 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/OrderedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/OrderedMapIterableTestCase.java
@@ -69,6 +69,7 @@ public interface OrderedMapIterableTestCase extends MapIterableTestCase, Ordered
     }
 
     @Override
+    @Test
     default void MapIterable_flipUniqueValues()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
@@ -45,6 +45,7 @@ public interface UnsortedMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Two", 2, "One", 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
@@ -33,11 +33,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTestCase
 {
+    @Override
     default boolean supportsNullKeys()
     {
         return true;
     }
 
+    @Override
     default boolean supportsNullValues()
     {
         return true;
@@ -50,6 +52,7 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
     <K, V> MutableMapIterable<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         MapTestCase.super.Iterable_toString();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapTestCase.java
@@ -16,6 +16,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.test.MutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.map.UnsortedMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,6 +31,7 @@ public interface MutableMapTestCase extends UnsortedMapIterableTestCase, Mutable
     <K, V> MutableMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         UnsortedMapIterableTestCase.super.Iterable_toString();
@@ -41,6 +43,7 @@ public interface MutableMapTestCase extends UnsortedMapIterableTestCase, Mutable
     }
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         MutableMap<Object, Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapIterableTestCase.java
@@ -28,6 +28,7 @@ public interface UnmodifiableMutableMapIterableTestCase
         extends MutableMapIterableTestCase, FixedSizeIterableTestCase
 {
     @Override
+    @Test
     default void MutableMapIterable_removeKey()
     {
         MutableMapIterable<Object, Object> map = this.newWith();
@@ -43,6 +44,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void MutableMapIterable_removeIf()
     {
         MutableMapIterable<Object, Object> map1 = this.newWith();
@@ -53,6 +55,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Map_remove()
     {
         MutableMapIterable<Object, Object> map = this.newWith();
@@ -60,6 +63,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Map_entrySet_remove()
     {
         MutableMapIterable<Object, Object> map = this.newWithKeysValues();
@@ -67,6 +71,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Map_clear()
     {
         MutableMapIterable<Object, String> map = this.newWith("Three", "Two", "One");
@@ -74,6 +79,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         FixedSizeIterableTestCase.super.Iterable_remove();
@@ -91,8 +97,8 @@ public interface UnmodifiableMutableMapIterableTestCase
         assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "One"), map);
     }
 
-    @Test
     @Override
+    @Test
     default void Map_putAll()
     {
         MutableMapIterable<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "2");
@@ -142,6 +148,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void MutableMapIterable_updateValue()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("One", 1);
@@ -169,6 +176,7 @@ public interface UnmodifiableMutableMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Map_merge()
     {
         MutableMapIterable<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
@@ -66,6 +66,7 @@ public interface SetTestCase extends CollectionTestCase
         assertNotEquals(this.newWith(3, 2, 1), this.newWith(4, 2, 1));
     }
 
+    @Override
     @Test
     default void Iterable_toString()
     {

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/UnsortedSetLikeTestTrait.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/UnsortedSetLikeTestTrait.java
@@ -45,6 +45,7 @@ public interface UnsortedSetLikeTestTrait extends RichIterableUniqueTestCase, Un
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         assertThat(this.newWith(2, 1).toString(), isOneOf("[1, 2]", "[2, 1]"));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/ImmutableSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/ImmutableSetTestCase.java
@@ -37,6 +37,7 @@ public interface ImmutableSetTestCase extends ImmutableCollectionUniqueTestCase,
     }
 
     @Override
+    @Test
     default void ImmutableCollection_newWith()
     {
         ImmutableCollection<Integer> immutableCollection = this.newWith(3, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
@@ -30,24 +30,28 @@ public interface MutableSetTestCase extends SetTestCase, UnsortedSetIterableTest
     }
 
     @Override
+    @Test
     default void Object_PostSerializedEqualsAndHashCode()
     {
         UnsortedSetIterableTestCase.super.Object_PostSerializedEqualsAndHashCode();
     }
 
     @Override
+    @Test
     default void Object_equalsAndHashCode()
     {
         UnsortedSetIterableTestCase.super.Object_equalsAndHashCode();
     }
 
     @Override
+    @Test
     default void Iterable_toString()
     {
         SetTestCase.super.Iterable_toString();
     }
 
     @Override
+    @Test
     default void Iterable_next()
     {
         UnsortedSetIterableTestCase.super.Iterable_next();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/sorted/MutableSortedSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/sorted/MutableSortedSetTestCase.java
@@ -15,6 +15,7 @@ import org.eclipse.collections.test.MutableSortedIterableTestCase;
 import org.eclipse.collections.test.collection.mutable.MutableCollectionUniqueTestCase;
 import org.eclipse.collections.test.set.sorted.SortedSetIterableTestCase;
 import org.eclipse.collections.test.set.sorted.SortedSetTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface MutableSortedSetTestCase extends SortedSetIterableTestCase, MutableCollectionUniqueTestCase, SortedSetTestCase, MutableSortedIterableTestCase
 {
@@ -22,6 +23,7 @@ public interface MutableSortedSetTestCase extends SortedSetIterableTestCase, Mut
     <T> MutableSortedSet<T> newWith(T... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         // Both implementations are the same

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
@@ -91,6 +91,7 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     }
 
     @Override
+    @Test
     default void OrderedIterable_getFirst()
     {
         assertIterablesEqual(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
@@ -104,6 +105,7 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     }
 
     @Override
+    @Test
     default void OrderedIterable_getLast()
     {
         assertIterablesEqual(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
@@ -117,36 +119,42 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     }
 
     @Override
+    @Test
     default void RichIterable_getFirst()
     {
         assertIterablesEqual(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
     }
 
     @Override
+    @Test
     default void RichIterable_getLast()
     {
         assertIterablesEqual(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
     }
 
     @Override
+    @Test
     default void OrderedIterable_min()
     {
         // Cannot contain duplicates
     }
 
     @Override
+    @Test
     default void OrderedIterable_max()
     {
         // Cannot contain duplicates
     }
 
     @Override
+    @Test
     default void OrderedIterable_min_comparator()
     {
         // Cannot contain duplicates
     }
 
     @Override
+    @Test
     default void OrderedIterable_max_comparator()
     {
         // Cannot contain duplicates

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
@@ -32,6 +32,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
     <T> StackIterable<T> newWith(T... elements);
 
     @Override
+    @Test
     default void newMutable_sanity()
     {
         // Cannot treat an ArrayStack as a MutableCollection
@@ -72,6 +73,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
     }
 
     @Override
+    @Test
     default void InternalIterable_forEachWith()
     {
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);


### PR DESCRIPTION
I just learned that a missing `@Test` annotation on an `@Override` method causes the test to not be run, probably only in IntelliJ. I'm not sure if this is related to the JUnit 5 refactoring, but I'm looping in @Desislav-Petrov just in case.

I added a bunch of missing annotations. Along the way, I found one that wasn't an Override, and it was broken. I fixed its assertion.