### PR TITLE
Use interfaces instead of implementations where possible without breaking backward compatibility.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
@@ -495,7 +495,7 @@ public class ImmutableArrayBag<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            HashBag<Pair<T, S>> target = HashBag.newBag(Math.min(this.size(), thatSize));
+            MutableBag<Pair<T, S>> target = HashBag.newBag(Math.min(this.size(), thatSize));
             return this.zip(that, target).toImmutable();
         }
         return this.zip(that, HashBag.newBag()).toImmutable();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
@@ -110,7 +110,7 @@ public class ImmutableHashBag<T>
     @Override
     public ImmutableBag<T> newWithout(T element)
     {
-        HashBag<T> hashBag = HashBag.newBag(this.delegate);
+        MutableBag<T> hashBag = HashBag.newBag(this.delegate);
         hashBag.remove(element);
         return hashBag.toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBag.java
@@ -189,7 +189,7 @@ public abstract class AbstractMutableBag<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            HashBag<Pair<T, S>> target = HashBag.newBag(Math.min(this.size(), thatSize));
+            MutableBag<Pair<T, S>> target = HashBag.newBag(Math.min(this.size(), thatSize));
             return this.zip(that, target);
         }
         return this.zip(that, HashBag.newBag());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBag.java
@@ -803,7 +803,7 @@ public final class BooleanHashBag implements MutableBooleanBag, Externalizable
     @Override
     public <V> MutableBag<V> collect(BooleanToObjectFunction<? extends V> function)
     {
-        HashBag<V> result = HashBag.newBag();
+        MutableBag<V> result = HashBag.newBag();
         if (this.containsFalse())
         {
             result.addOccurrences(function.valueOf(false), this.falseCount);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBag.java
@@ -61,6 +61,7 @@ import org.eclipse.collections.api.multimap.sortedbag.ImmutableSortedBagMultimap
 import org.eclipse.collections.api.partition.bag.sorted.PartitionImmutableSortedBag;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionMutableSortedBag;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
+import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.bag.immutable.AbstractImmutableBagIterable;
@@ -375,7 +376,7 @@ abstract class AbstractImmutableSortedBag<T>
         Comparator<? super T> comparator = this.comparator() == null
                 ? Comparators.naturalOrder()
                 : this.comparator();
-        TreeSortedSet<Pair<T, Integer>> pairs = TreeSortedSet.newSet(
+        MutableSortedSet<Pair<T, Integer>> pairs = TreeSortedSet.newSet(
                 Comparators.<Pair<T, Integer>>chain(
                         Comparators.byFunction(Functions.firstOfPair(), comparator),
                         Comparators.byFunction(Functions.secondOfPair())));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBag.java
@@ -326,7 +326,7 @@ public abstract class AbstractMutableSortedBag<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            FastList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
+            MutableList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
             return this.zip(that, target);
         }
         return this.zip(that, FastList.newList());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMap.java
@@ -397,7 +397,7 @@ public abstract class AbstractImmutableBiMap<K, V> extends AbstractBiMap<K, V> i
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            UnifiedSet<Pair<V, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
+            MutableSet<Pair<V, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
             return this.delegate.zip(that, target).toImmutable();
         }
         return this.delegate.zip(that, Sets.mutable.empty()).toImmutable();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMap.java
@@ -590,7 +590,7 @@ abstract class AbstractMutableBiMap<K, V> extends AbstractBiMap<K, V> implements
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            UnifiedSet<Pair<V, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
+            MutableSet<Pair<V, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
             return this.delegate.zip(that, target);
         }
         return this.delegate.zip(that, Sets.mutable.empty());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
@@ -728,7 +728,7 @@ public abstract class AbstractCollectionAdapter<T>
             Function<? super T, ? extends K> keyFunction,
             Function<? super T, ? extends V> valueFunction)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this.size());
+        MutableMap<K, V> map = UnifiedMap.newMap(this.size());
         map.collectKeysAndValues(this.getDelegate(), keyFunction, valueFunction);
         return map;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
@@ -475,8 +475,8 @@ public abstract class AbstractParallelIterable<T, B extends Batch<T>> implements
     @Override
     public MutableList<T> toList()
     {
-        Function<Batch<T>, FastList<T>> map = batch -> {
-            FastList<T> list = FastList.newList();
+        Function<Batch<T>, MutableList<T>> map = batch -> {
+            MutableList<T> list = FastList.newList();
             batch.forEach(CollectionAddProcedure.on(list));
             return list;
         };

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
@@ -925,7 +925,7 @@ public final class Interval
     @Override
     public MutableList<Integer> toList()
     {
-        FastList<Integer> list = FastList.newList(this.size());
+        MutableList<Integer> list = FastList.newList(this.size());
         this.forEach(CollectionAddProcedure.on(list));
         return list;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
@@ -211,7 +211,7 @@ abstract class AbstractImmutableList<T>
     @Override
     public ImmutableList<T> newWithoutAll(Iterable<? extends T> elements)
     {
-        FastList<T> result = FastList.newListWith((T[]) this.toArray());
+        MutableList<T> result = FastList.newListWith((T[]) this.toArray());
         this.removeAllFrom(elements, result);
         return result.toImmutable();
     }
@@ -289,7 +289,7 @@ abstract class AbstractImmutableList<T>
     @Override
     public <S> ImmutableList<S> selectInstancesOf(Class<S> clazz)
     {
-        FastList<S> result = FastList.newList(this.size());
+        MutableList<S> result = FastList.newList(this.size());
         this.forEach(new SelectInstancesOfProcedure<>(clazz, result));
         return result.toImmutable();
     }
@@ -778,7 +778,7 @@ abstract class AbstractImmutableList<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            FastList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
+            MutableList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
             return this.zip(that, target).toImmutable();
         }
         return this.zip(that, FastList.newList()).toImmutable();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
@@ -278,7 +278,7 @@ final class ImmutableBooleanArrayList
     @Override
     public <V> ImmutableList<V> collect(BooleanToObjectFunction<? extends V> function)
     {
-        FastList<V> target = FastList.newList(this.size);
+        MutableList<V> target = FastList.newList(this.size);
         for (int i = 0; i < this.size; i++)
         {
             target.add(function.valueOf(this.items.get(i)));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
@@ -631,7 +631,7 @@ public final class CompositeFastList<E>
         private Iterator<E> currentIterator;
         private int currentIndex;
 
-        private CompositeIterator(FastList<FastList<E>> newLists)
+        private CompositeIterator(MutableList<FastList<E>> newLists)
         {
             this.iterators = new Iterator[newLists.size()];
             for (int i = 0; i < newLists.size(); ++i)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
@@ -786,7 +786,7 @@ public final class BooleanArrayList
     @Override
     public <V> MutableList<V> collect(BooleanToObjectFunction<? extends V> function)
     {
-        FastList<V> target = FastList.newList(this.size);
+        MutableList<V> target = FastList.newList(this.size);
         for (int i = 0; i < this.size; i++)
         {
             target.add(function.valueOf(this.items.get(i)));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
@@ -146,7 +146,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public ImmutableMap<K, V> newWithKeyValue(K key, V value)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this);
+        MutableMap<K, V> map = UnifiedMap.newMap(this);
         map.put(key, value);
         return map.toImmutable();
     }
@@ -154,7 +154,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public ImmutableMap<K, V> newWithAllKeyValues(Iterable<? extends Pair<? extends K, ? extends V>> keyValues)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this);
+        MutableMap<K, V> map = UnifiedMap.newMap(this);
         for (Pair<? extends K, ? extends V> keyValuePair : keyValues)
         {
             map.put(keyValuePair.getOne(), keyValuePair.getTwo());
@@ -181,7 +181,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public ImmutableMap<K, V> newWithAllKeyValueArguments(Pair<? extends K, ? extends V>... keyValuePairs)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this);
+        MutableMap<K, V> map = UnifiedMap.newMap(this);
         for (Pair<? extends K, ? extends V> keyValuePair : keyValuePairs)
         {
             map.put(keyValuePair.getOne(), keyValuePair.getTwo());
@@ -192,7 +192,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public ImmutableMap<K, V> newWithoutKey(K key)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this);
+        MutableMap<K, V> map = UnifiedMap.newMap(this);
         map.removeKey(key);
         return map.toImmutable();
     }
@@ -200,7 +200,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public ImmutableMap<K, V> newWithoutAllKeys(Iterable<? extends K> keys)
     {
-        UnifiedMap<K, V> map = UnifiedMap.newMap(this);
+        MutableMap<K, V> map = UnifiedMap.newMap(this);
         for (K key : keys)
         {
             map.removeKey(key);
@@ -229,28 +229,28 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public <K2, V2> ImmutableMap<K2, V2> collect(Function2<? super K, ? super V, Pair<K2, V2>> function)
     {
-        UnifiedMap<K2, V2> result = MapIterate.collect(this, function, UnifiedMap.newMap());
+        MutableMap<K2, V2> result = MapIterate.collect(this, function, UnifiedMap.newMap());
         return result.toImmutable();
     }
 
     @Override
     public <R> ImmutableMap<K, R> collectValues(Function2<? super K, ? super V, ? extends R> function)
     {
-        UnifiedMap<K, R> result = MapIterate.collectValues(this, function, UnifiedMap.newMap(this.size()));
+        MutableMap<K, R> result = MapIterate.collectValues(this, function, UnifiedMap.newMap(this.size()));
         return result.toImmutable();
     }
 
     @Override
     public ImmutableMap<K, V> select(Predicate2<? super K, ? super V> predicate)
     {
-        UnifiedMap<K, V> result = MapIterate.selectMapOnEntry(this, predicate, UnifiedMap.newMap());
+        MutableMap<K, V> result = MapIterate.selectMapOnEntry(this, predicate, UnifiedMap.newMap());
         return result.toImmutable();
     }
 
     @Override
     public ImmutableMap<K, V> reject(Predicate2<? super K, ? super V> predicate)
     {
-        UnifiedMap<K, V> result = MapIterate.rejectMapOnEntry(this, predicate, UnifiedMap.newMap());
+        MutableMap<K, V> result = MapIterate.rejectMapOnEntry(this, predicate, UnifiedMap.newMap());
         return result.toImmutable();
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -37,9 +37,11 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.UnsortedMapIterable;
+import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
@@ -2474,7 +2476,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
 
         protected Object writeReplace()
         {
-            UnifiedSet<K> replace = UnifiedSet.newSet(UnifiedMap.this.size());
+            MutableSet<K> replace = UnifiedSet.newSet(UnifiedMap.this.size());
             for (int i = 0; i < UnifiedMap.this.table.length; i += 2)
             {
                 Object cur = UnifiedMap.this.table[i];
@@ -2490,7 +2492,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             return replace;
         }
 
-        private void chainedAddToSet(Object[] chain, UnifiedSet<K> replace)
+        private void chainedAddToSet(Object[] chain, MutableSet<K> replace)
         {
             for (int i = 0; i < chain.length; i += 2)
             {
@@ -3304,7 +3306,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
 
         protected Object writeReplace()
         {
-            FastList<V> replace = FastList.newList(UnifiedMap.this.size());
+            MutableList<V> replace = FastList.newList(UnifiedMap.this.size());
             for (int i = 0; i < UnifiedMap.this.table.length; i += 2)
             {
                 Object cur = UnifiedMap.this.table[i];
@@ -3320,7 +3322,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             return replace;
         }
 
-        private void chainedAddToList(Object[] chain, FastList<V> replace)
+        private void chainedAddToList(Object[] chain, MutableList<V> replace)
         {
             for (int i = 0; i < chain.length; i += 2)
             {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
@@ -47,6 +47,7 @@ import org.eclipse.collections.api.factory.primitive.ObjectDoubleMaps;
 import org.eclipse.collections.api.factory.primitive.ObjectLongMaps;
 import org.eclipse.collections.api.factory.primitive.ShortLists;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
 import org.eclipse.collections.api.list.primitive.ImmutableCharList;
@@ -300,7 +301,7 @@ public abstract class AbstractImmutableSortedMap<K, V>
     @Override
     public <S> ImmutableList<S> selectInstancesOf(Class<S> clazz)
     {
-        FastList<S> result = FastList.newList(this.size());
+        MutableList<S> result = FastList.newList(this.size());
         this.forEach(new SelectInstancesOfProcedure<>(clazz, result));
         return result.toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategy.java
@@ -183,7 +183,7 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public ImmutableMap<K, V> newWithKeyValue(K key, V value)
     {
-        UnifiedMapWithHashingStrategy<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
+        MutableMap<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
         result.put(key, value);
         return result.toImmutable();
     }
@@ -191,7 +191,7 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public ImmutableMap<K, V> newWithAllKeyValues(Iterable<? extends Pair<? extends K, ? extends V>> keyValues)
     {
-        UnifiedMapWithHashingStrategy<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
+        MutableMap<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
         for (Pair<? extends K, ? extends V> pair : keyValues)
         {
             result.put(pair.getOne(), pair.getTwo());
@@ -218,7 +218,7 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public ImmutableMap<K, V> newWithAllKeyValueArguments(Pair<? extends K, ? extends V>... keyValuePairs)
     {
-        UnifiedMapWithHashingStrategy<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
+        MutableMap<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
         for (Pair<? extends K, ? extends V> keyValuePair : keyValuePairs)
         {
             result.put(keyValuePair.getOne(), keyValuePair.getTwo());
@@ -229,7 +229,7 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public ImmutableMap<K, V> newWithoutKey(K key)
     {
-        UnifiedMapWithHashingStrategy<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
+        MutableMap<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
         result.remove(key);
         return result.toImmutable();
     }
@@ -237,7 +237,7 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public ImmutableMap<K, V> newWithoutAllKeys(Iterable<? extends K> keys)
     {
-        UnifiedMapWithHashingStrategy<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
+        MutableMap<K, V> result = UnifiedMapWithHashingStrategy.newMap(this.delegate);
         for (K key : keys)
         {
             result.remove(key);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -38,10 +38,12 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.UnsortedMapIterable;
+import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
@@ -2532,7 +2534,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
 
         protected Object writeReplace()
         {
-            UnifiedSetWithHashingStrategy<K> replace = UnifiedSetWithHashingStrategy.newSet(
+            MutableSet<K> replace = UnifiedSetWithHashingStrategy.newSet(
                     UnifiedMapWithHashingStrategy.this.hashingStrategy, UnifiedMapWithHashingStrategy.this.size());
             for (int i = 0; i < UnifiedMapWithHashingStrategy.this.table.length; i += 2)
             {
@@ -2549,7 +2551,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             return replace;
         }
 
-        private void chainedAddToSet(Object[] chain, UnifiedSetWithHashingStrategy<K> replace)
+        private void chainedAddToSet(Object[] chain, MutableSet<K> replace)
         {
             for (int i = 0; i < chain.length; i += 2)
             {
@@ -3373,7 +3375,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
 
         protected Object writeReplace()
         {
-            FastList<V> replace = FastList.newList(UnifiedMapWithHashingStrategy.this.size());
+            MutableList<V> replace = FastList.newList(UnifiedMapWithHashingStrategy.this.size());
             for (int i = 0; i < UnifiedMapWithHashingStrategy.this.table.length; i += 2)
             {
                 Object cur = UnifiedMapWithHashingStrategy.this.table[i];
@@ -3389,7 +3391,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             return replace;
         }
 
-        private void chainedAddToList(Object[] chain, FastList<V> replace)
+        private void chainedAddToList(Object[] chain, MutableList<V> replace)
         {
             for (int i = 0; i < chain.length; i += 2)
             {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
@@ -261,7 +261,7 @@ public abstract class AbstractUnifiedSet<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            UnifiedSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
+            MutableSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
             return this.zip(that, target);
         }
         return this.zip(that, UnifiedSet.newSet());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryImpl.java
@@ -141,7 +141,7 @@ public class FixedSizeSetFactoryImpl implements FixedSizeSetFactory
     @Override
     public <T> MutableSet<T> withAll(Iterable<? extends T> items)
     {
-        UnifiedSet<T> set = UnifiedSet.newSet(items);
+        MutableSet<T> set = UnifiedSet.newSet(items);
         T[] itemArray;
         switch (set.size())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSet.java
@@ -361,7 +361,7 @@ public abstract class AbstractImmutableSet<T> extends AbstractImmutableCollectio
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            UnifiedSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
+            MutableSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
             return this.zip(that, target).toImmutable();
         }
         return this.zip(that, Sets.mutable.empty()).toImmutable();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/SetAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/SetAdapter.java
@@ -296,7 +296,7 @@ public final class SetAdapter<T>
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            UnifiedSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
+            MutableSet<Pair<T, S>> target = UnifiedSet.newSet(Math.min(this.size(), thatSize));
             return Iterate.zip(this, that, target);
         }
         return Iterate.zip(this, that, Sets.mutable.empty());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.java
@@ -579,7 +579,7 @@ public class BooleanHashSet implements MutableBooleanSet, Externalizable
     @Override
     public <V> MutableSet<V> collect(BooleanToObjectFunction<? extends V> function)
     {
-        UnifiedSet<V> target = UnifiedSet.newSet(this.size());
+        MutableSet<V> target = UnifiedSet.newSet(this.size());
         switch (this.state)
         {
             case 0:

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSet.java
@@ -124,7 +124,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     {
         if (this.contains(element))
         {
-            TreeSortedSet<T> result = TreeSortedSet.newSet(this);
+            MutableSortedSet<T> result = TreeSortedSet.newSet(this);
             result.remove(element);
             return result.toImmutable();
         }
@@ -134,7 +134,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public ImmutableSortedSet<T> newWithAll(Iterable<? extends T> elements)
     {
-        TreeSortedSet<T> result = TreeSortedSet.newSet(this);
+        MutableSortedSet<T> result = TreeSortedSet.newSet(this);
         result.addAllIterable(elements);
         return result.toImmutable();
     }
@@ -142,7 +142,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public ImmutableSortedSet<T> newWithoutAll(Iterable<? extends T> elements)
     {
-        TreeSortedSet<T> result = TreeSortedSet.newSet(this);
+        MutableSortedSet<T> result = TreeSortedSet.newSet(this);
         this.removeAllFrom(elements, result);
         return result.toImmutable();
     }
@@ -237,7 +237,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public ImmutableSortedSet<T> select(Predicate<? super T> predicate)
     {
-        TreeSortedSet<T> result = TreeSortedSet.newSet(this.comparator());
+        MutableSortedSet<T> result = TreeSortedSet.newSet(this.comparator());
         this.forEach(new SelectProcedure<>(predicate, result));
         return result.toImmutable();
     }
@@ -251,7 +251,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public ImmutableSortedSet<T> reject(Predicate<? super T> predicate)
     {
-        TreeSortedSet<T> result = TreeSortedSet.newSet(this.comparator());
+        MutableSortedSet<T> result = TreeSortedSet.newSet(this.comparator());
         this.forEach(new RejectProcedure<>(predicate, result));
         return result.toImmutable();
     }
@@ -288,7 +288,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public <S> ImmutableSortedSet<S> selectInstancesOf(Class<S> clazz)
     {
-        TreeSortedSet<S> result = TreeSortedSet.newSet((Comparator<? super S>) this.comparator());
+        MutableSortedSet<S> result = TreeSortedSet.newSet((Comparator<? super S>) this.comparator());
         this.forEach(new SelectInstancesOfProcedure<>(clazz, result));
         return result.toImmutable();
     }
@@ -347,7 +347,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
         if (that instanceof Collection || that instanceof RichIterable)
         {
             int thatSize = Iterate.sizeOf(that);
-            FastList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
+            MutableList<Pair<T, S>> target = FastList.newList(Math.min(this.size(), thatSize));
             return Iterate.zip(this, that, target).toImmutable();
         }
         return Iterate.zip(this, that, FastList.newList()).toImmutable();
@@ -359,7 +359,7 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
         Comparator<? super T> comparator = this.comparator();
         if (comparator == null)
         {
-            TreeSortedSet<Pair<T, Integer>> pairs = TreeSortedSet.newSet(Comparators.byFunction(Functions.firstOfPair(), Comparators.naturalOrder()));
+            MutableSortedSet<Pair<T, Integer>> pairs = TreeSortedSet.newSet(Comparators.byFunction(Functions.firstOfPair(), Comparators.naturalOrder()));
             return Iterate.zipWithIndex(this, pairs).toImmutable();
         }
         return Iterate.zipWithIndex(this, TreeSortedSet.newSet(Comparators.byFirstOfPair(comparator))).toImmutable();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSet.java
@@ -28,6 +28,7 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.multimap.sortedset.ImmutableSortedSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -219,7 +220,7 @@ final class ImmutableTreeSet<T>
     @Override
     public <V> ImmutableList<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function)
     {
-        FastList<V> result = FastList.newList(this.size());
+        MutableList<V> result = FastList.newList(this.size());
         int index = 0;
         for (T t : this.delegate)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -120,14 +120,14 @@ import org.eclipse.collections.impl.utility.LazyIterate;
 final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
 {
     private static final long serialVersionUID = 1L;
-    private final FastList<T> delegate;
+    private final MutableList<T> delegate;
 
     private ImmutableArrayStack(T[] newElements)
     {
         this.delegate = FastList.newListWith(newElements);
     }
 
-    private ImmutableArrayStack(FastList<T> newElements)
+    private ImmutableArrayStack(MutableList<T> newElements)
     {
         this.delegate = newElements;
     }
@@ -160,7 +160,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     @Override
     public ImmutableStack<T> push(T item)
     {
-        FastList<T> newDelegate = FastList.newList(this.delegate);
+        MutableList<T> newDelegate = FastList.newList(this.delegate);
         newDelegate.add(item);
         return new ImmutableArrayStack<>(newDelegate);
     }
@@ -169,7 +169,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     public ImmutableStack<T> pop()
     {
         this.checkEmptyStack();
-        FastList<T> newDelegate = FastList.newList(this.delegate);
+        MutableList<T> newDelegate = FastList.newList(this.delegate);
         newDelegate.remove(this.delegate.size() - 1);
         return new ImmutableArrayStack<>(newDelegate);
     }
@@ -184,7 +184,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
         }
         this.checkEmptyStack();
         this.checkSizeLessThanCount(count);
-        FastList<T> newDelegate = this.delegate.clone();
+        MutableList<T> newDelegate = this.delegate.clone();
         while (count > 0)
         {
             newDelegate.remove(this.delegate.size() - 1);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -115,7 +115,7 @@ import org.eclipse.collections.impl.utility.LazyIterate;
 public class ArrayStack<T> implements MutableStack<T>, Externalizable
 {
     private static final long serialVersionUID = 1L;
-    private FastList<T> delegate;
+    private MutableList<T> delegate;
 
     public ArrayStack()
     {
@@ -165,7 +165,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
     public static <T> ArrayStack<T> newStackFromTopToBottom(Iterable<? extends T> items)
     {
         ArrayStack<T> stack = ArrayStack.newStack();
-        FastList<T> list = FastList.newList(items);
+        MutableList<T> list = FastList.newList(items);
         stack.delegate = list.reverseThis();
         return stack;
     }
@@ -275,7 +275,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
         this.checkEmptyStack();
         this.checkSizeLessThanCount(count);
 
-        FastList<T> result = FastList.newList(count);
+        MutableList<T> result = FastList.newList(count);
         for (int i = 0; i < count; i++)
         {
             result.add(this.delegate.get(this.delegate.size() - (i + 1)));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/MutableStackFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/MutableStackFactoryImpl.java
@@ -41,7 +41,7 @@ public class MutableStackFactoryImpl implements MutableStackFactory
     @Override
     public <T> MutableStack<T> fromStream(Stream<? extends T> stream)
     {
-        ArrayStack<T> stack = ArrayStack.newStack();
+        MutableStack<T> stack = ArrayStack.newStack();
         stream.forEach(stack::push);
         return stack;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
@@ -332,7 +332,7 @@ public class CharAdapter
     public <V> ImmutableList<V> collect(CharToObjectFunction<? extends V> function)
     {
         int size = this.size();
-        FastList<V> list = FastList.newList(size);
+        MutableList<V> list = FastList.newList(size);
         for (int i = 0; i < size; i++)
         {
             list.add(function.valueOf(this.get(i)));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
@@ -387,7 +387,7 @@ public class CodePointAdapter
     @Override
     public <V> ImmutableList<V> collect(IntToObjectFunction<? extends V> function)
     {
-        FastList<V> list = FastList.newList(this.adapted.length());
+        MutableList<V> list = FastList.newList(this.adapted.length());
         for (int i = 0; i < this.adapted.length(); )
         {
             int codePoint = this.adapted.codePointAt(i);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
@@ -1586,7 +1586,7 @@ public final class ArrayListIterate
     public static <T> ArrayList<T> distinct(ArrayList<T> list, HashingStrategy<? super T> hashingStrategy)
     {
         int size = list.size();
-        MutableSet<T> seenSoFar = UnifiedSetWithHashingStrategy.newSet(hashingStrategy);
+        MutableSet<T> seenSoFar = new UnifiedSetWithHashingStrategy<>(hashingStrategy);
         ArrayList<T> result = new ArrayList<>();
         if (ArrayListIterate.isOptimizableArrayList(list, size))
         {
@@ -1863,7 +1863,7 @@ public final class ArrayListIterate
         {
             int xSize = xs.size();
             int ySize = Iterate.sizeOf(ys);
-            FastList<Pair<X, Y>> target = FastList.newList(Math.min(xSize, ySize));
+            MutableList<Pair<X, Y>> target = FastList.newList(Math.min(xSize, ySize));
             return ArrayListIterate.zip(xs, ys, target);
         }
         return ArrayListIterate.zip(xs, ys, FastList.newList());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
@@ -1689,7 +1689,7 @@ public final class ListIterate
         {
             int listSize = list.size();
             int iterableSize = Iterate.sizeOf(iterable);
-            FastList<Pair<X, Y>> target = FastList.newList(Math.min(listSize, iterableSize));
+            MutableList<Pair<X, Y>> target = FastList.newList(Math.min(listSize, iterableSize));
             return ListIterate.zip(list, iterable, target);
         }
         return ListIterate.zip(list, iterable, FastList.newList());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
@@ -1117,7 +1117,7 @@ public final class IteratorIterate
     public static <T> MutableList<T> distinct(Iterator<T> iterator, HashingStrategy<? super T> hashingStrategy)
     {
         Set<T> seenSoFar = UnifiedSetWithHashingStrategy.newSet(hashingStrategy);
-        FastList<T> result = FastList.newList();
+        MutableList<T> result = FastList.newList();
         while (iterator.hasNext())
         {
             T item = iterator.next();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
@@ -1282,7 +1282,7 @@ public final class RandomAccessListIterate
     public static <T> MutableList<T> distinct(List<T> list, HashingStrategy<? super T> hashingStrategy)
     {
         MutableSet<T> seenSoFar = UnifiedSetWithHashingStrategy.newSet(hashingStrategy);
-        FastList<T> result = FastList.newList();
+        MutableList<T> result = FastList.newList();
         int size = list.size();
         for (int i = 0; i < size; i++)
         {
@@ -1599,7 +1599,7 @@ public final class RandomAccessListIterate
         {
             int listSize = list.size();
             int iterableSize = Iterate.sizeOf(iterable);
-            FastList<Pair<X, Y>> target = FastList.newList(Math.min(listSize, iterableSize));
+            MutableList<Pair<X, Y>> target = FastList.newList(Math.min(listSize, iterableSize));
             return RandomAccessListIterate.zip(list, iterable, target);
         }
         return RandomAccessListIterate.zip(list, iterable, FastList.newList());

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/SortedSetIterables.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/SortedSetIterables.java
@@ -35,7 +35,7 @@ public final class SortedSetIterables
     {
         Comparator<? super T> comparator = set.comparator();
         MutableSortedSet<T> innerTree = TreeSortedSet.newSet(comparator);
-        TreeSortedSet<MutableSortedSet<T>> sortedSetIterables = TreeSortedSet.newSet(Comparators.powerSet());
+        MutableSortedSet<MutableSortedSet<T>> sortedSetIterables = TreeSortedSet.newSet(Comparators.powerSet());
         MutableSortedSet<MutableSortedSet<T>> seed = sortedSetIterables.with(innerTree);
 
         return Iterate.injectInto(seed, set, (accumulator, element) -> accumulator.union(accumulator.collect(set1 -> {


### PR DESCRIPTION
Last time the change was in tests. This time it's in the main library, but only inside method bodies and in the signatures of private methods.