### PR TITLE
Migrate test templates to junit5

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/abstractImmutablePrimitiveBagTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/abstractImmutablePrimitiveBagTestCase.stg
@@ -38,13 +38,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>Bag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
@@ -24,13 +24,13 @@ import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyBag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveHashBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveHashBagTest.stg
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>HashBag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveSingletonBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveSingletonBagTest.stg
@@ -24,8 +24,8 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>SingletonBag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
@@ -34,16 +34,16 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Mutable<name>Bag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/primitiveHashBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/primitiveHashBagTest.stg
@@ -21,8 +21,8 @@ package org.eclipse.collections.impl.bag.mutable.primitive;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link <name>HashBag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/synchronizedPrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/synchronizedPrimitiveBagTest.stg
@@ -19,9 +19,9 @@ package org.eclipse.collections.impl.bag.mutable.primitive;
 
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>Bag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
@@ -26,13 +26,13 @@ import org.eclipse.collections.api.tuple.primitive.<name>IntPair;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>Bag}.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/factory/primitivePredicatesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/factory/primitivePredicatesTest.stg
@@ -18,9 +18,9 @@ package org.eclipse.collections.impl.block.factory.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Provides a set of common tests of predicates for <type> values.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/function/primitiveCaseFunctionTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/function/primitiveCaseFunctionTest.stg
@@ -23,10 +23,10 @@ import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * This file was automatically generated from template file primitiveCaseFunctionTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedObjectPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedObjectPrimitiveProcedureTest.stg
@@ -18,9 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Test;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for Object and <type> values.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveObjectProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveObjectProcedureTest.stg
@@ -18,9 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Test;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type> and Object values.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitivePrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitivePrimitiveProcedureTest.stg
@@ -21,9 +21,9 @@ body(type1, type2, name1, name2) ::= <<
 package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
-import org.junit.Test;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type1> and <type2> values.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/checked/checkedPrimitiveProcedureTest.stg
@@ -18,9 +18,9 @@ package org.eclipse.collections.impl.block.procedure.checked.primitive;
 
 import java.io.IOException;
 
-import org.junit.Test;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provides a set of common tests of checked procedures for <type> values.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/collectPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/collectPrimitiveProcedureTest.stg
@@ -22,8 +22,8 @@ import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This file was automatically generated from template file CollectPrimitiveProcedureTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/primitiveCaseProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/primitiveCaseProcedureTest.stg
@@ -24,8 +24,8 @@ import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This file was automatically generated from template file primitiveCaseProcedureTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/block/procedure/sumOfPrimitiveProcedureTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/block/procedure/sumOfPrimitiveProcedureTest.stg
@@ -21,8 +21,8 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.function.primitive.<name>Function;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SumOf<name>Procedure}.

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/immutable/abstractImmutablePrimitiveCollectionTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/immutable/abstractImmutablePrimitiveCollectionTestCase.stg
@@ -22,9 +22,9 @@ import org.eclipse.collections.api.collection.primitive.Immutable<name>Collectio
 import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Abstract<name>IterableTestCase;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Collection}s.

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
@@ -27,13 +27,13 @@ import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Collection}s

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -58,16 +58,16 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link <name>Iterable}s
@@ -1026,27 +1026,23 @@ public void sumConsistentRounding()
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.toString(),
                 iterable1.toString().equals("[<["0", "31"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable1.toString());
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.toString(),
                 iterable2.toString().equals("[<["31", "32"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"), iterable2.toString());
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.toString(),
                 iterable3.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"), iterable3.toString());
 
         <name>Iterable iterable4 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable4.toString(),
                 iterable4.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable4.toString());
     }
 
     @Test
@@ -1063,21 +1059,18 @@ public void sumConsistentRounding()
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable1.makeString());
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"), iterable3.makeString("/"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
@@ -1089,17 +1082,14 @@ public void sumConsistentRounding()
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Test
@@ -1140,34 +1130,34 @@ public void sumConsistentRounding()
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Test
@@ -1202,7 +1192,7 @@ public void sumConsistentRounding()
 
         result
                 .collectBoolean(e -> e % 2 == 0, BooleanLists.mutable.of())
-                .forEachWithIndex((e, i) -> assertEquals("index " + i, i \< 5, e));
+                .forEachWithIndex((e, i) -> assertEquals(i \< 5, e, "index " + i));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
@@ -30,11 +30,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.primitive.Synchronized<name>Iterable;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name>Iterable}s

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveHashingStrategyMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveHashingStrategyMapsTest.stg
@@ -28,8 +28,8 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link Object<name>HashingStrategyMaps}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/objectPrimitiveMapsTest.stg
@@ -28,9 +28,9 @@ import org.eclipse.collections.impl.block.factory.StringFunctions;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Junit test for {@link Object<name>Maps}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveBagsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveBagsTest.stg
@@ -25,9 +25,9 @@ import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Junit test for {@link <name>Bags}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveListsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveListsTest.stg
@@ -25,9 +25,9 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link <name>Lists}.

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMapsTest.stg
@@ -22,9 +22,9 @@ import org.eclipse.collections.api.factory.map.primitive.Immutable<name>ObjectMa
 import org.eclipse.collections.api.factory.map.primitive.Mutable<name>ObjectMapFactory;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file primitiveObjectMapsTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
@@ -22,8 +22,8 @@ package org.eclipse.collections.api.factory.map.primitive;
 import org.eclipse.collections.api.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link Mutable<name>ObjectMapFactory}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMapsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMapsTest.stg
@@ -26,9 +26,9 @@ import org.eclipse.collections.api.factory.map.primitive.Immutable<name1><name2>
 import org.eclipse.collections.api.factory.map.primitive.Mutable<name1><name2>MapFactory;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Junit test for {@link <name1><name2>Maps}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMutableMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitivePrimitiveMutableMapFactoryTest.stg
@@ -25,8 +25,8 @@ package org.eclipse.collections.api.factory.map.primitive;
 import org.eclipse.collections.api.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link Mutable<name1><name2>MapFactory}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveSetsTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveSetsTest.stg
@@ -31,9 +31,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Junit test for {@link <name>Sets}

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveStacksTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveStacksTest.stg
@@ -25,9 +25,9 @@ import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Junit test for {@link <name>Stacks}

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
@@ -41,14 +41,14 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Lazy<name>Iterable}.
@@ -375,27 +375,23 @@ public abstract class AbstractLazy<name>IterableTestCase
 
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.toString(),
                 iterable1.toString().equals("[<["0", "31"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable1.toString().equals("[<["31", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable1.toString());
 
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.toString(),
                 iterable2.toString().equals("[<["31", "32"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable2.toString().equals("[<["32", "31"]:(toStringLiteral.(type))(); separator=", ">]"), iterable2.toString());
 
         Lazy<name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.toString(),
                 iterable3.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable3.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"), iterable3.toString());
 
         Lazy<name>Iterable iterable4 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable4.toString(),
                 iterable4.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable4.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable4.toString());
     }
 
     @Test
@@ -403,21 +399,18 @@ public abstract class AbstractLazy<name>IterableTestCase
     {
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable1.makeString());
 
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         Lazy<name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"), iterable3.makeString("/"));
 
         Lazy<name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
@@ -429,17 +422,14 @@ public abstract class AbstractLazy<name>IterableTestCase
 
         Lazy<name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Test
@@ -461,34 +451,34 @@ public abstract class AbstractLazy<name>IterableTestCase
         StringBuilder appendable7 = new StringBuilder();
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         Lazy<name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         Lazy<name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         Lazy<name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
@@ -35,13 +35,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * This file was automatically generated from template file collectPrimitiveIterableTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
@@ -29,11 +29,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This file was automatically generated from template file collectPrimitiveToObjectIterableTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
@@ -31,13 +31,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * This file was automatically generated from template file flatCollectPrimitiveToObjectIterableTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/lazyPrimitiveIterableAdapterTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/lazyPrimitiveIterableAdapterTest.stg
@@ -23,9 +23,9 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.primitive.Lazy<name>Iterate;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link Lazy<name>IterableAdapter}.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
@@ -30,14 +30,14 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link Select<name>Iterable}.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
@@ -31,14 +31,14 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link Tap<name>Iterable}.

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
@@ -29,13 +29,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link Reverse<name>Iterable}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
@@ -36,18 +36,18 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 <if(primitive.specializedStream)>
 import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.Collections;<endif>
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>List}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>ArrayList}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
@@ -27,14 +27,14 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyList}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
@@ -22,11 +22,11 @@ import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Immutable<name>SingletonList}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -37,19 +37,19 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 <if(primitive.specializedStream)>
 import java.util.stream.Collectors;
 import java.util.Arrays;
 <endif>
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>List}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
@@ -24,9 +24,9 @@ import java.util.stream.StreamSupport;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link BoxedMutable<name>List}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
@@ -26,12 +26,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.internal.primitive.<name>IterableIterate;
 import org.eclipse.collections.impl.utility.internal.primitive.<name>IteratorIterate;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link <name>ArrayList}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/synchronizedPrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/synchronizedPrimitiveListTest.stg
@@ -21,9 +21,9 @@ import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>List}.

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -26,12 +26,12 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 <if(!primitive.booleanPrimitive)>import org.eclipse.collections.impl.block.factory.Comparators;<endif>
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>List}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
@@ -75,12 +75,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Abstract JUnit test for {@link Object<name>Map#keyValuesView()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeysViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeysViewTestCase.stg
@@ -28,11 +28,11 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link Object<name>Map#keysView()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
@@ -41,14 +41,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * This file was automatically generated from template file abstractObjectPrimitiveMapTestCase.stg.
@@ -224,15 +224,13 @@ public abstract class AbstractObject<name>MapTestCase
 
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
         assertTrue(
-                map1.toString(),
                 "{0=<(toStringLiteral.(type))("0")>, 1=<(toStringLiteral.(type))("1")>}".equals(map1.toString())
-                        || "{1=<(toStringLiteral.(type))("1")>, 0=<(toStringLiteral.(type))("0")>}".equals(map1.toString()));
+                        || "{1=<(toStringLiteral.(type))("1")>, 0=<(toStringLiteral.(type))("0")>}".equals(map1.toString()), map1.toString());
 
         Object<name>Map\<Integer> map2 = this.newWithKeysValues(1, <(literal.(type))("1")>, null, <(literal.(type))("0")>);
         assertTrue(
-                map2.toString(),
                 "{1=<(toStringLiteral.(type))("1")>, null=<(toStringLiteral.(type))("0")>}".equals(map2.toString())
-                        || "{null=<(toStringLiteral.(type))("0")>, 1=<(toStringLiteral.(type))("1")>}".equals(map2.toString()));
+                        || "{null=<(toStringLiteral.(type))("0")>, 1=<(toStringLiteral.(type))("1")>}".equals(map2.toString()), map2.toString());
     }
 
     @Test
@@ -348,7 +346,7 @@ public abstract class AbstractObject<name>MapTestCase
         Object<name>Map\<String> map0 = this.newWithKeysValues("2", <(literal.(type))("3")>, "4", <(literal.(type))("5")>);
 
         String result0 = map0.injectIntoKeyValue(new String("1"), (result, eachKey, eachValue) -> result + eachKey + String.valueOf(eachValue));
-        assertTrue(result0, "12<(toStringLiteral.(type))("3")>4<(toStringLiteral.(type))("5")>".equals(result0) || "14<(toStringLiteral.(type))("5")>2<(toStringLiteral.(type))("3")>".equals(result0));
+        assertTrue("12<(toStringLiteral.(type))("3")>4<(toStringLiteral.(type))("5")>".equals(result0) || "14<(toStringLiteral.(type))("5")>2<(toStringLiteral.(type))("3")>".equals(result0), result0);
 
         Object<name>Map copy = map0.injectIntoKeyValue(Object<name>Maps.mutable.empty(), MutableObject<name>Map::withKeyValue);
         assertEquals(map0, copy);
@@ -364,14 +362,12 @@ public abstract class AbstractObject<name>MapTestCase
 
         Object<name>Map\<Integer> map2 = this.newWithKeysValues(1, <(literal.(type))("1")>, 32, <(literal.(type))("32")>);
         assertTrue(
-                map2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("32")>]".equals(map2.makeString("[", "/", "]"))
-                        || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>]".equals(map2.makeString("[", "/", "]")));
+                        || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>]".equals(map2.makeString("[", "/", "]")), map2.makeString("[", "/", "]"));
 
         assertTrue(
-                map2.makeString("/"),
                 "<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("32")>".equals(map2.makeString("/"))
-                        || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>".equals(map2.makeString("/")));
+                        || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("1")>".equals(map2.makeString("/")), map2.makeString("/"));
     }
 
     @Test
@@ -397,23 +393,20 @@ public abstract class AbstractObject<name>MapTestCase
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
         map1.appendString(appendable3);
         assertTrue(
-                appendable3.toString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("1")>".equals(appendable3.toString())
-                        || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(appendable3.toString()));
+                        || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(appendable3.toString()), appendable3.toString());
 
         Appendable appendable4 = new StringBuilder();
         map1.appendString(appendable4, "/");
         assertTrue(
-                appendable4.toString(),
                 "<(toStringLiteral.(type))("0")>/<(toStringLiteral.(type))("1")>".equals(appendable4.toString())
-                        || "<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>".equals(appendable4.toString()));
+                        || "<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>".equals(appendable4.toString()), appendable4.toString());
 
         Appendable appendable5 = new StringBuilder();
         map1.appendString(appendable5, "[", "/", "]");
         assertTrue(
-                appendable5.toString(),
                 "[<(toStringLiteral.(type))("0")>/<(toStringLiteral.(type))("1")>]".equals(appendable5.toString())
-                        || "[<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>]".equals(appendable5.toString()));
+                        || "[<(toStringLiteral.(type))("1")>/<(toStringLiteral.(type))("0")>]".equals(appendable5.toString()), appendable5.toString());
     }
 
     @Test
@@ -515,8 +508,8 @@ public abstract class AbstractObject<name>MapTestCase
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
         Object<name>Map\<Integer> map1 = this.newWithKeysValues(0, <(literal.(type))("0")>, 1, <(literal.(type))("1")>);
-        assertTrue(map1.collect(toString).toString(), FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("0")>").equals(map1.collect(toString))
-                || FastList.newListWith("<(toStringLiteral.(type))("0")>", "<(toStringLiteral.(type))("1")>").equals(map1.collect(toString)));
+        assertTrue(FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("0")>").equals(map1.collect(toString))
+                || FastList.newListWith("<(toStringLiteral.(type))("0")>", "<(toStringLiteral.(type))("1")>").equals(map1.collect(toString)), map1.collect(toString).toString());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
@@ -79,12 +79,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name>BooleanMap#keyValuesView()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
@@ -46,12 +46,12 @@ import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This file was automatically generated from template file abstractPrimitiveBooleanMapTestCase.stg.
@@ -222,27 +222,23 @@ public abstract class Abstract<name>BooleanMapTestCase
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
         assertTrue(
-                map1.toString(),
                 "{<(toStringLiteral.(type))("0")>=true, <(toStringLiteral.(type))("1")>=false}".equals(map1.toString())
-                        || "{<(toStringLiteral.(type))("1")>=false, <(toStringLiteral.(type))("0")>=true}".equals(map1.toString()));
+                        || "{<(toStringLiteral.(type))("1")>=false, <(toStringLiteral.(type))("0")>=true}".equals(map1.toString()), map1.toString());
 
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         assertTrue(
-                map2.toString(),
                 "{<(toStringLiteral.(type))("1")>=false, <(toStringLiteral.(type))("32")>=true}".equals(map2.toString())
-                        || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("1")>=false}".equals(map2.toString()));
+                        || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("1")>=false}".equals(map2.toString()), map2.toString());
 
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true);
         assertTrue(
-                map3.toString(),
                 "{<(toStringLiteral.(type))("0")>=true, <(toStringLiteral.(type))("32")>=true}".equals(map3.toString())
-                        || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("0")>=true}".equals(map3.toString()));
+                        || "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("0")>=true}".equals(map3.toString()), map3.toString());
 
         <name>BooleanMap map4 = this.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false);
         assertTrue(
-                map4.toString(),
                 "{<(toStringLiteral.(type))("32")>=true, <(toStringLiteral.(type))("33")>=false}".equals(map4.toString())
-                        || "{<(toStringLiteral.(type))("33")>=false, <(toStringLiteral.(type))("32")>=true}".equals(map4.toString()));
+                        || "{<(toStringLiteral.(type))("33")>=false, <(toStringLiteral.(type))("32")>=true}".equals(map4.toString()), map4.toString());
     }
 
     @Test
@@ -375,27 +371,23 @@ public abstract class Abstract<name>BooleanMapTestCase
 
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
         assertTrue(
-                map1.makeString(),
                 "true, false".equals(map1.makeString())
-                        || "false, true".equals(map1.makeString()));
+                        || "false, true".equals(map1.makeString()), map1.makeString());
 
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         assertTrue(
-                map2.makeString("[", "/", "]"),
                 "[false/true]".equals(map2.makeString("[", "/", "]"))
-                        || "true/false]".equals(map2.makeString("[", "/", "]")));
+                        || "true/false]".equals(map2.makeString("[", "/", "]")), map2.makeString("[", "/", "]"));
 
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true);
         assertTrue(
-                map3.makeString("~"),
                 "true~true".equals(map3.makeString("~"))
-                        || "true~true".equals(map3.makeString("~")));
+                        || "true~true".equals(map3.makeString("~")), map3.makeString("~"));
 
         <name>BooleanMap map4 = this.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false);
         assertTrue(
-                map4.makeString("[", ", ", "]"),
                 "[true, false]".equals(map4.makeString("[", ", ", "]"))
-                        || "[false, true]".equals(map4.makeString("[", ", ", "]")));
+                        || "[false, true]".equals(map4.makeString("[", ", ", "]")), map4.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -421,32 +413,28 @@ public abstract class Abstract<name>BooleanMapTestCase
         <name>BooleanMap map1 = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false);
         map1.appendString(appendable3);
         assertTrue(
-                appendable3.toString(),
                 "true, false".equals(appendable3.toString())
-                        || "false, true".equals(appendable3.toString()));
+                        || "false, true".equals(appendable3.toString()), appendable3.toString());
 
         Appendable appendable4 = new StringBuilder();
         <name>BooleanMap map2 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         map2.appendString(appendable4, "[", "/", "]");
         assertTrue(
-                appendable4.toString(),
                 "[false/true]".equals(appendable4.toString())
-                        || "[true/false]".equals(appendable4.toString()));
+                        || "[true/false]".equals(appendable4.toString()), appendable4.toString());
 
         Appendable appendable5 = new StringBuilder();
         <name>BooleanMap map3 = this.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true);
         map3.appendString(appendable5, "[", "/", "]");
         assertTrue(
-                appendable5.toString(),
                 "[false/true]".equals(appendable5.toString())
-                        || "[true/false]".equals(appendable5.toString()));
+                        || "[true/false]".equals(appendable5.toString()), appendable5.toString());
 
         Appendable appendable6 = new StringBuilder();
         map1.appendString(appendable6, "/");
         assertTrue(
-                appendable6.toString(),
                 "true/false".equals(appendable6.toString())
-                        || "false/true".equals(appendable6.toString()));
+                        || "false/true".equals(appendable6.toString()), appendable6.toString());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
@@ -77,12 +77,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name>ObjectMap#keyValuesView()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
@@ -88,14 +88,14 @@ import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * This file was automatically generated from template file abstractPrimitiveObjectMapTestCase.stg.
@@ -637,12 +637,12 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toList())
-                || FastList.newListWith("nine", "zero").equals(map1.toList()));
-        assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toList())
-                || FastList.newListWith("nine", "one").equals(map2.toList()));
-        assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toList())
-                || FastList.newListWith("nine", "five").equals(map3.toList()));
+        assertTrue(FastList.newListWith("zero", "nine").equals(map1.toList())
+                || FastList.newListWith("nine", "zero").equals(map1.toList()), map1.toList().toString());
+        assertTrue(FastList.newListWith("one", "nine").equals(map2.toList())
+                || FastList.newListWith("nine", "one").equals(map2.toList()), map2.toList().toString());
+        assertTrue(FastList.newListWith("five", "nine").equals(map3.toList())
+                || FastList.newListWith("nine", "five").equals(map3.toList()), map3.toList().toString());
     }
 
     @Test
@@ -652,25 +652,25 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertEquals(map1.toSortedList().toString(),
-                FastList.newListWith("nine", "zero"), map1.toSortedList());
-        assertEquals(map2.toSortedList().toString(),
-                FastList.newListWith("nine", "one"), map2.toSortedList());
-        assertEquals(map3.toSortedList().toString(), FastList.newListWith("five", "nine"), map3.toSortedList());
+        assertEquals(
+                FastList.newListWith("nine", "zero"), map1.toSortedList(), map1.toSortedList().toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toSortedList(), map2.toSortedList().toString());
+        assertEquals(FastList.newListWith("five", "nine"), map3.toSortedList(), map3.toSortedList().toString());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        assertEquals(map1.toSortedList(comparator).toString(),
-                FastList.newListWith("zero", "nine"), map1.toSortedList(comparator));
-        assertEquals(map2.toSortedList(comparator).toString(),
-                FastList.newListWith("nine", "one"), map2.toSortedList(comparator));
-        assertEquals(map3.toSortedList(comparator).toString(), FastList.newListWith("nine", "five"), map3.toSortedList(comparator));
+        assertEquals(
+                FastList.newListWith("zero", "nine"), map1.toSortedList(comparator), map1.toSortedList(comparator).toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toSortedList(comparator), map2.toSortedList(comparator).toString());
+        assertEquals(FastList.newListWith("nine", "five"), map3.toSortedList(comparator), map3.toSortedList(comparator).toString());
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        assertEquals(map1.toSortedListBy(substring).toString(),
-                FastList.newListWith("zero", "nine"), map1.toSortedListBy(substring));
-        assertEquals(map2.toSortedListBy(substring).toString(),
-                FastList.newListWith("nine", "one"), map2.toSortedListBy(substring));
-        assertEquals(map3.toSortedListBy(substring).toString(), FastList.newListWith("nine", "five"), map3.toSortedListBy(substring));
+        assertEquals(
+                FastList.newListWith("zero", "nine"), map1.toSortedListBy(substring), map1.toSortedListBy(substring).toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toSortedListBy(substring), map2.toSortedListBy(substring).toString());
+        assertEquals(FastList.newListWith("nine", "five"), map3.toSortedListBy(substring), map3.toSortedListBy(substring).toString());
     }
 
     @Test
@@ -680,9 +680,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toSet());
-        assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toSet());
-        assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toSet());
+        assertEquals(UnifiedSet.newSetWith("zero", "nine"), map1.toSet(), map1.toSet().toString());
+        assertEquals(UnifiedSet.newSetWith("one", "nine"), map2.toSet(), map2.toSet().toString());
+        assertEquals(UnifiedSet.newSetWith("five", "nine"), map3.toSet(), map3.toSet().toString());
     }
 
     @Test
@@ -693,20 +693,20 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
         assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toSortedSet());
-        assertEquals(map2.toSortedSet().toString(),
-                TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet());
+        assertEquals(
+                TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet(), map2.toSortedSet().toString());
         assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toSortedSet());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
         assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSet(comparator));
-        assertEquals(map2.toSortedSet(comparator).toString(),
-                TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet(comparator));
+        assertEquals(
+                TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSet(comparator), map2.toSortedSet(comparator).toString());
         assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSet(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
         assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toSortedSetBy(substring));
         assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toSortedSetBy(substring));
-        assertEquals(map3.toSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toSortedSetBy(substring), map3.toSortedSetBy(substring).toString());
     }
 
     @Test
@@ -780,12 +780,12 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertTrue(map1.toList().toString(), FastList.newListWith("zero", "nine").equals(map1.toImmutableList())
-                || FastList.newListWith("nine", "zero").equals(map1.toList()));
-        assertTrue(map2.toList().toString(), FastList.newListWith("one", "nine").equals(map2.toImmutableList())
-                || FastList.newListWith("nine", "one").equals(map2.toList()));
-        assertTrue(map3.toList().toString(), FastList.newListWith("five", "nine").equals(map3.toImmutableList())
-                || FastList.newListWith("nine", "five").equals(map3.toList()));
+        assertTrue(FastList.newListWith("zero", "nine").equals(map1.toImmutableList())
+                || FastList.newListWith("nine", "zero").equals(map1.toList()), map1.toList().toString());
+        assertTrue(FastList.newListWith("one", "nine").equals(map2.toImmutableList())
+                || FastList.newListWith("nine", "one").equals(map2.toList()), map2.toList().toString());
+        assertTrue(FastList.newListWith("five", "nine").equals(map3.toImmutableList())
+                || FastList.newListWith("nine", "five").equals(map3.toList()), map3.toList().toString());
     }
 
     @Test
@@ -795,28 +795,28 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertEquals(map1.toSortedList().toString(),
-                FastList.newListWith("nine", "zero"), map1.toImmutableSortedList());
-        assertEquals(map2.toSortedList().toString(),
-                FastList.newListWith("nine", "one"), map2.toImmutableSortedList());
-        assertEquals(map3.toSortedList().toString(),
-                FastList.newListWith("five", "nine"), map3.toImmutableSortedList());
+        assertEquals(
+                FastList.newListWith("nine", "zero"), map1.toImmutableSortedList(), map1.toSortedList().toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toImmutableSortedList(), map2.toSortedList().toString());
+        assertEquals(
+                FastList.newListWith("five", "nine"), map3.toImmutableSortedList(), map3.toSortedList().toString());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
-        assertEquals(map1.toSortedList(comparator).toString(),
-                FastList.newListWith("zero", "nine"), map1.toImmutableSortedList(comparator));
-        assertEquals(map2.toSortedList(comparator).toString(),
-                FastList.newListWith("nine", "one"), map2.toImmutableSortedList(comparator));
-        assertEquals(map3.toSortedList(comparator).toString(),
-                FastList.newListWith("nine", "five"), map3.toImmutableSortedList(comparator));
+        assertEquals(
+                FastList.newListWith("zero", "nine"), map1.toImmutableSortedList(comparator), map1.toSortedList(comparator).toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toImmutableSortedList(comparator), map2.toSortedList(comparator).toString());
+        assertEquals(
+                FastList.newListWith("nine", "five"), map3.toImmutableSortedList(comparator), map3.toSortedList(comparator).toString());
 
         Function\<String, String> substring = (String object) -> object.substring(1);
-        assertEquals(map1.toSortedListBy(substring).toString(),
-                FastList.newListWith("zero", "nine"), map1.toImmutableSortedListBy(substring));
-        assertEquals(map2.toSortedListBy(substring).toString(),
-                FastList.newListWith("nine", "one"), map2.toImmutableSortedListBy(substring));
-        assertEquals(map3.toSortedListBy(substring).toString(),
-                FastList.newListWith("nine", "five"), map3.toImmutableSortedListBy(substring));
+        assertEquals(
+                FastList.newListWith("zero", "nine"), map1.toImmutableSortedListBy(substring), map1.toSortedListBy(substring).toString());
+        assertEquals(
+                FastList.newListWith("nine", "one"), map2.toImmutableSortedListBy(substring), map2.toSortedListBy(substring).toString());
+        assertEquals(
+                FastList.newListWith("nine", "five"), map3.toImmutableSortedListBy(substring), map3.toSortedListBy(substring).toString());
     }
 
     @Test
@@ -826,9 +826,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
-        assertEquals(map1.toSet().toString(), UnifiedSet.newSetWith("zero", "nine"), map1.toImmutableSet());
-        assertEquals(map2.toSet().toString(), UnifiedSet.newSetWith("one", "nine"), map2.toImmutableSet());
-        assertEquals(map3.toSet().toString(), UnifiedSet.newSetWith("five", "nine"), map3.toImmutableSet());
+        assertEquals(UnifiedSet.newSetWith("zero", "nine"), map1.toImmutableSet(), map1.toSet().toString());
+        assertEquals(UnifiedSet.newSetWith("one", "nine"), map2.toImmutableSet(), map2.toSet().toString());
+        assertEquals(UnifiedSet.newSetWith("five", "nine"), map3.toImmutableSet(), map3.toSet().toString());
     }
 
     @Test
@@ -839,20 +839,20 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("6")>, "five", <(literal.(type))("9")>, "nine");
 
         assertEquals(TreeSortedSet.newSetWith("nine", "zero"), map1.toImmutableSortedSet());
-        assertEquals(map2.toImmutableSortedSet().toString(),
-                TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet());
+        assertEquals(
+                TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet(), map2.toImmutableSortedSet().toString());
         assertEquals(TreeSortedSet.newSetWith("five", "nine"), map3.toImmutableSortedSet());
 
         Comparator\<String> comparator = (String o1, String o2) -> o1.substring(1).compareTo(o2.substring(1));
         assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSet(comparator));
-        assertEquals(map2.toImmutableSortedSet(comparator).toString(),
-                TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet(comparator));
+        assertEquals(
+                TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSet(comparator), map2.toImmutableSortedSet(comparator).toString());
         assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSet(comparator));
 
         Function\<String, String> substring = (String object) -> object.substring(1);
         assertEquals(TreeSortedSet.newSetWith("zero", "nine"), map1.toImmutableSortedSetBy(substring));
         assertEquals(TreeSortedSet.newSetWith("nine", "one"), map2.toImmutableSortedSetBy(substring));
-        assertEquals(map3.toImmutableSortedSetBy(substring).toString(), TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSetBy(substring));
+        assertEquals(TreeSortedSet.newSetWith("nine", "five"), map3.toImmutableSortedSetBy(substring), map3.toImmutableSortedSetBy(substring).toString());
     }
 
     @Test
@@ -892,19 +892,19 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "ab", <(literal.(type))("9")>, "abcd");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "zyx", <(literal.(type))("9")>, "abcd");
 
-        assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray())
-                || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()));
-        assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray())
-                || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()));
-        assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray())
-                || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()));
+        assertTrue(Arrays.equals(new String[]{"abcd", "z"}, map1.toArray())
+                || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()), map1.asLazy().toString());
+        assertTrue(Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray())
+                || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()), map2.asLazy().toString());
+        assertTrue(Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray())
+                || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()), map3.asLazy().toString());
 
-        assertTrue(map1.asLazy().toString(), Arrays.equals(new String[]{"abcd", "z"}, map1.toArray(new String[2]))
-                || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()));
-        assertTrue(map2.asLazy().toString(), Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray(new String[4]))
-                || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()));
-        assertTrue(map3.asLazy().toString(), Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray(new String[2]))
-                || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()));
+        assertTrue(Arrays.equals(new String[]{"abcd", "z"}, map1.toArray(new String[2]))
+                || Arrays.equals(new String[]{"z", "abcd"}, map1.toArray()), map1.asLazy().toString());
+        assertTrue(Arrays.equals(new String[]{"abcd", "ab"}, map2.toArray(new String[4]))
+                || Arrays.equals(new String[]{"ab", "abcd"}, map2.toArray()), map2.asLazy().toString());
+        assertTrue(Arrays.equals(new String[]{"abcd", "zyx"}, map3.toArray(new String[2]))
+                || Arrays.equals(new String[]{"zyx", "abcd"}, map3.toArray()), map3.asLazy().toString());
     }
 
     @Test
@@ -1210,10 +1210,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         map3.forEachValue((String each) -> concat[2] += each);
         map4.forEachValue((String each) -> concat[3] += each);
 
-        assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
-        assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
-        assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
-        assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
+        assertTrue("onefive".equals(concat[0]) || "fiveone".equals(concat[0]), concat[0]);
+        assertTrue("onezero".equals(concat[1]) || "zeroone".equals(concat[1]), concat[1]);
+        assertTrue("twofive".equals(concat[2]) || "fivetwo".equals(concat[2]), concat[2]);
+        assertTrue("zerofive".equals(concat[3]) || "fivezero".equals(concat[3]), concat[3]);
     }
 
     @Test
@@ -1266,10 +1266,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += parameter;
         });
 
-        assertTrue(concat[0], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("5")>five".equals(concat[0]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("1")>one".equals(concat[0]));
-        assertTrue(concat[1], "<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("0")>zero".equals(concat[1]) || "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("1")>one".equals(concat[1]));
-        assertTrue(concat[2], "<(toStringLiteral.(type))("2")>two<(toStringLiteral.(type))("5")>five".equals(concat[2]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("2")>two".equals(concat[2]));
-        assertTrue(concat[3], "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("5")>five".equals(concat[3]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("0")>zero".equals(concat[3]));
+        assertTrue("<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("5")>five".equals(concat[0]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("1")>one".equals(concat[0]), concat[0]);
+        assertTrue("<(toStringLiteral.(type))("1")>one<(toStringLiteral.(type))("0")>zero".equals(concat[1]) || "<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("1")>one".equals(concat[1]), concat[1]);
+        assertTrue("<(toStringLiteral.(type))("2")>two<(toStringLiteral.(type))("5")>five".equals(concat[2]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("2")>two".equals(concat[2]), concat[2]);
+        assertTrue("<(toStringLiteral.(type))("0")>zero<(toStringLiteral.(type))("5")>five".equals(concat[3]) || "<(toStringLiteral.(type))("5")>five<(toStringLiteral.(type))("0")>zero".equals(concat[3]), concat[3]);
     }
 
     @Test
@@ -1278,7 +1278,7 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map0 = this.newWithKeysValues(<(literal.(type))("2")>, "3", <(literal.(type))("4")>, "5");
 
         String result0 = map0.injectIntoKeyValue(new String("1"), (result, eachKey, eachValue) -> result + String.valueOf(eachKey) + eachValue);
-        assertTrue(result0, "1<(toStringLiteral.(type))("2")>3<(toStringLiteral.(type))("4")>5".equals(result0) || "1<(toStringLiteral.(type))("4")>5<(toStringLiteral.(type))("2")>3".equals(result0));
+        assertTrue("1<(toStringLiteral.(type))("2")>3<(toStringLiteral.(type))("4")>5".equals(result0) || "1<(toStringLiteral.(type))("4")>5<(toStringLiteral.(type))("2")>3".equals(result0), result0);
 
         <name>ObjectMap copy = map0.injectIntoKeyValue(<name>ObjectMaps.mutable.empty(), Mutable<name>ObjectMap::withKeyValue);
         assertEquals(map0, copy);
@@ -1322,10 +1322,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("2")>, "two", <(literal.(type))("5")>, "five");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five");
 
-        assertTrue(map1.getFirst(), "one".equals(map1.getFirst()) || "five".equals(map1.getFirst()));
-        assertTrue(map2.getFirst(), "one".equals(map2.getFirst()) || "zero".equals(map2.getFirst()));
-        assertTrue(map3.getFirst(), "two".equals(map3.getFirst()) || "five".equals(map3.getFirst()));
-        assertTrue(map4.getFirst(), "zero".equals(map4.getFirst()) || "five".equals(map4.getFirst()));
+        assertTrue("one".equals(map1.getFirst()) || "five".equals(map1.getFirst()), map1.getFirst());
+        assertTrue("one".equals(map2.getFirst()) || "zero".equals(map2.getFirst()), map2.getFirst());
+        assertTrue("two".equals(map3.getFirst()) || "five".equals(map3.getFirst()), map3.getFirst());
+        assertTrue("zero".equals(map4.getFirst()) || "five".equals(map4.getFirst()), map4.getFirst());
         assertNull(<name>ObjectHashMap.newMap().getFirst());
     }
 
@@ -1337,10 +1337,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("2")>, "two", <(literal.(type))("5")>, "five");
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five");
 
-        assertTrue(map1.getLast(), "one".equals(map1.getLast()) || "five".equals(map1.getLast()));
-        assertTrue(map2.getLast(), "one".equals(map2.getLast()) || "zero".equals(map2.getLast()));
-        assertTrue(map3.getLast(), "two".equals(map3.getLast()) || "five".equals(map3.getLast()));
-        assertTrue(map4.getLast(), "zero".equals(map4.getLast()) || "five".equals(map4.getLast()));
+        assertTrue("one".equals(map1.getLast()) || "five".equals(map1.getLast()), map1.getLast());
+        assertTrue("one".equals(map2.getLast()) || "zero".equals(map2.getLast()), map2.getLast());
+        assertTrue("two".equals(map3.getLast()) || "five".equals(map3.getLast()), map3.getLast());
+        assertTrue("zero".equals(map4.getLast()) || "five".equals(map4.getLast()), map4.getLast());
         assertEquals("zero", this.newWithKeysValues(<(literal.(type))("0")>, "zero").getLast());
         assertNull(<name>ObjectHashMap.newMap().getLast());
     }
@@ -1490,27 +1490,23 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         assertTrue(
-                map1.toString(),
                 "{<(toStringLiteral.(type))("0")>=zero, <(toStringLiteral.(type))("1")>=one}".equals(map1.toString())
-                        || "{<(toStringLiteral.(type))("1")>=one, <(toStringLiteral.(type))("0")>=zero}".equals(map1.toString()));
+                        || "{<(toStringLiteral.(type))("1")>=one, <(toStringLiteral.(type))("0")>=zero}".equals(map1.toString()), map1.toString());
 
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         assertTrue(
-                map2.toString(),
                 "{<(toStringLiteral.(type))("1")>=one, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map2.toString())
-                        || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("1")>=one}".equals(map2.toString()));
+                        || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("1")>=one}".equals(map2.toString()), map2.toString());
 
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("32")>, "thirtyTwo");
         assertTrue(
-                map3.toString(),
                 "{<(toStringLiteral.(type))("0")>=zero, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map3.toString())
-                        || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("0")>=zero}".equals(map3.toString()));
+                        || "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("0")>=zero}".equals(map3.toString()), map3.toString());
 
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("33")>, "thirtyThree");
         assertTrue(
-                map4.toString(),
                 "{<(toStringLiteral.(type))("32")>=thirtyTwo, <(toStringLiteral.(type))("33")>=thirtyThree}".equals(map4.toString())
-                        || "{<(toStringLiteral.(type))("33")>=thirtyThree, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map4.toString()));
+                        || "{<(toStringLiteral.(type))("33")>=thirtyThree, <(toStringLiteral.(type))("32")>=thirtyTwo}".equals(map4.toString()), map4.toString());
     }
 
     @Test
@@ -1733,27 +1729,23 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         assertTrue(
-                map1.makeString(),
                 "zero, one".equals(map1.makeString())
-                        || "one, zero".equals(map1.makeString()));
+                        || "one, zero".equals(map1.makeString()), map1.makeString());
 
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         assertTrue(
-                map2.makeString("[", "/", "]"),
                 "[one/thirtyTwo]".equals(map2.makeString("[", "/", "]"))
-                        || "[thirtyTwo/one]".equals(map2.makeString("[", "/", "]")));
+                        || "[thirtyTwo/one]".equals(map2.makeString("[", "/", "]")), map2.makeString("[", "/", "]"));
 
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("32")>, "thirtyTwo");
         assertTrue(
-                map3.makeString("~"),
                 "zero~thirtyTwo".equals(map3.makeString("~"))
-                        || "thirtyTwo~zero".equals(map3.makeString("~")));
+                        || "thirtyTwo~zero".equals(map3.makeString("~")), map3.makeString("~"));
 
         <name>ObjectMap\<String> map4 = this.newWithKeysValues(<(literal.(type))("32")>, "thirtyTwo", <(literal.(type))("33")>, "thirtyThree");
         assertTrue(
-                map4.makeString("[", ", ", "]"),
                 "[thirtyTwo, thirtyThree]".equals(map4.makeString("[", ", ", "]"))
-                        || "[thirtyThree, thirtyTwo]".equals(map4.makeString("[", ", ", "]")));
+                        || "[thirtyThree, thirtyTwo]".equals(map4.makeString("[", ", ", "]")), map4.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -1779,32 +1771,28 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         map1.appendString(appendable3);
         assertTrue(
-                appendable3.toString(),
                 "zero, one".equals(appendable3.toString())
-                        || "one, zero".equals(appendable3.toString()));
+                        || "one, zero".equals(appendable3.toString()), appendable3.toString());
 
         Appendable appendable4 = new StringBuilder();
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         map2.appendString(appendable4, "[", "/", "]");
         assertTrue(
-                appendable4.toString(),
                 "[one/thirtyTwo]".equals(appendable4.toString())
-                        || "[thirtyTwo/one]".equals(appendable4.toString()));
+                        || "[thirtyTwo/one]".equals(appendable4.toString()), appendable4.toString());
 
         Appendable appendable5 = new StringBuilder();
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("32")>, "thirtyTwo");
         map3.appendString(appendable5, "[", "/", "]");
         assertTrue(
-                appendable5.toString(),
                 "[one/thirtyTwo]".equals(appendable5.toString())
-                        || "[thirtyTwo/one]".equals(appendable5.toString()));
+                        || "[thirtyTwo/one]".equals(appendable5.toString()), appendable5.toString());
 
         Appendable appendable6 = new StringBuilder();
         map3.appendString(appendable6, "/");
         assertTrue(
-                appendable6.toString(),
                 "one/thirtyTwo".equals(appendable6.toString())
-                        || "thirtyTwo/one".equals(appendable6.toString()));
+                        || "thirtyTwo/one".equals(appendable6.toString()), appendable6.toString());
     }
 
     @Test
@@ -1826,10 +1814,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         assertSame(map3, map3.tap(concat[2]::append));
         assertSame(map4, map4.tap(concat[3]::append));
 
-        assertTrue(concat[0].toString(), "onefive".equals(concat[0].toString()) || "fiveone".equals(concat[0].toString()));
-        assertTrue(concat[1].toString(), "onezero".equals(concat[1].toString()) || "zeroone".equals(concat[1].toString()));
-        assertTrue(concat[2].toString(), "twofive".equals(concat[2].toString()) || "fivetwo".equals(concat[2].toString()));
-        assertTrue(concat[3].toString(), "zerofive".equals(concat[3].toString()) || "fivezero".equals(concat[3].toString()));
+        assertTrue("onefive".equals(concat[0].toString()) || "fiveone".equals(concat[0].toString()), concat[0].toString());
+        assertTrue("onezero".equals(concat[1].toString()) || "zeroone".equals(concat[1].toString()), concat[1].toString());
+        assertTrue("twofive".equals(concat[2].toString()) || "fivetwo".equals(concat[2].toString()), concat[2].toString());
+        assertTrue("zerofive".equals(concat[3].toString()) || "fivezero".equals(concat[3].toString()), concat[3].toString());
     }
 
     @Test
@@ -1846,10 +1834,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         map3.forEach(Procedures.cast(each -> concat[2] += each));
         map4.forEach(Procedures.cast(each -> concat[3] += each));
 
-        assertTrue(concat[0], "onefive".equals(concat[0]) || "fiveone".equals(concat[0]));
-        assertTrue(concat[1], "onezero".equals(concat[1]) || "zeroone".equals(concat[1]));
-        assertTrue(concat[2], "twofive".equals(concat[2]) || "fivetwo".equals(concat[2]));
-        assertTrue(concat[3], "zerofive".equals(concat[3]) || "fivezero".equals(concat[3]));
+        assertTrue("onefive".equals(concat[0]) || "fiveone".equals(concat[0]), concat[0]);
+        assertTrue("onezero".equals(concat[1]) || "zeroone".equals(concat[1]), concat[1]);
+        assertTrue("twofive".equals(concat[2]) || "fivetwo".equals(concat[2]), concat[2]);
+        assertTrue("zerofive".equals(concat[3]) || "fivezero".equals(concat[3]), concat[3]);
     }
 
     @Test
@@ -1882,10 +1870,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += parameter;
         });
 
-        assertTrue(concat[0], "one0five1".equals(concat[0]) || "five0one1".equals(concat[0]));
-        assertTrue(concat[1], "one0zero1".equals(concat[1]) || "zero0one1".equals(concat[1]));
-        assertTrue(concat[2], "two0five1".equals(concat[2]) || "five0two1".equals(concat[2]));
-        assertTrue(concat[3], "zero0five1".equals(concat[3]) || "five0zero1".equals(concat[3]));
+        assertTrue("one0five1".equals(concat[0]) || "five0one1".equals(concat[0]), concat[0]);
+        assertTrue("one0zero1".equals(concat[1]) || "zero0one1".equals(concat[1]), concat[1]);
+        assertTrue("two0five1".equals(concat[2]) || "five0two1".equals(concat[2]), concat[2]);
+        assertTrue("zero0five1".equals(concat[3]) || "five0zero1".equals(concat[3]), concat[3]);
     }
 
     @Test
@@ -1918,10 +1906,10 @@ public abstract class Abstract<name>ObjectMapTestCase
             concat[3] += argument2;
         }, "-");
 
-        assertTrue(concat[0], "one-five-".equals(concat[0]) || "five-one-".equals(concat[0]));
-        assertTrue(concat[1], "one-zero-".equals(concat[1]) || "zero-one-".equals(concat[1]));
-        assertTrue(concat[2], "two-five-".equals(concat[2]) || "five-two-".equals(concat[2]));
-        assertTrue(concat[3], "zero-five-".equals(concat[3]) || "five-zero-".equals(concat[3]));
+        assertTrue("one-five-".equals(concat[0]) || "five-one-".equals(concat[0]), concat[0]);
+        assertTrue("one-zero-".equals(concat[1]) || "zero-one-".equals(concat[1]), concat[1]);
+        assertTrue("two-five-".equals(concat[2]) || "five-two-".equals(concat[2]), concat[2]);
+        assertTrue("zero-five-".equals(concat[3]) || "five-zero-".equals(concat[3]), concat[3]);
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
@@ -79,12 +79,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Abstract JUnit test for {@link <name1><name2>Map#keyValuesView()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -50,12 +50,12 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name2>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This file was automatically generated from template file abstractPrimitivePrimitiveMapTestCase.stg.
@@ -262,27 +262,23 @@ public abstract class Abstract<name1><name2>MapTestCase
 
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
         assertTrue(
-                map1.toString(),
                 "{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}".equals(map1.toString())
-                        || "{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map1.toString()));
+                        || "{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map1.toString()), map1.toString());
 
         <name1><name2>Map map2 = this.newWithKeysValues(<["1", "32"]:keyValue(); separator=", ">);
         assertTrue(
-                map2.toString(),
                 "{<(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map2.toString())
-                        || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}".equals(map2.toString()));
+                        || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("1")>=<(toStringLiteral.(type2))("1")>}".equals(map2.toString()), map2.toString());
 
         <name1><name2>Map map3 = this.newWithKeysValues(<["0", "32"]:keyValue(); separator=", ">);
         assertTrue(
-                map3.toString(),
                 "{<(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map3.toString())
-                        || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map3.toString()));
+                        || "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("0")>=<(toStringLiteral.(type2))("0")>}".equals(map3.toString()), map3.toString());
 
         <name1><name2>Map map4 = this.newWithKeysValues(<["32", "33"]:keyValue(); separator=", ">);
         assertTrue(
-                map4.toString(),
                 "{<(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type1))("33")>=<(toStringLiteral.(type2))("33")>}".equals(map4.toString())
-                        || "{<(toStringLiteral.(type1))("33")>=<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map4.toString()));
+                        || "{<(toStringLiteral.(type1))("33")>=<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type1))("32")>=<(toStringLiteral.(type2))("32")>}".equals(map4.toString()), map4.toString());
     }
 
     @Test
@@ -486,27 +482,23 @@ public abstract class Abstract<name1><name2>MapTestCase
 
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
         assertTrue(
-                map1.makeString(),
                 "<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type2))("1")>".equals(map1.makeString())
-                        || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(map1.makeString()));
+                        || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(map1.makeString()), map1.makeString());
 
         <name1><name2>Map map2 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         assertTrue(
-                map2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(map2.makeString("[", "/", "]"))
-                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(map2.makeString("[", "/", "]")));
+                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(map2.makeString("[", "/", "]")), map2.makeString("[", "/", "]"));
 
         <name1><name2>Map map3 = this.newWithKeysValues(<keyValue("0")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         assertTrue(
-                map3.makeString("~"),
                 "<(toStringLiteral.(type2))("0")>~<(toStringLiteral.(type2))("32")>".equals(map3.makeString("~"))
-                        || "<(toStringLiteral.(type2))("32")>~<(toStringLiteral.(type2))("0")>".equals(map3.makeString("~")));
+                        || "<(toStringLiteral.(type2))("32")>~<(toStringLiteral.(type2))("0")>".equals(map3.makeString("~")), map3.makeString("~"));
 
         <name1><name2>Map map4 = this.newWithKeysValues(<(literal.(type1))("32")>, <(literal.(type2))("32")>, <(literal.(type1))("33")>, <(literal.(type2))("33")>);
         assertTrue(
-                map4.makeString("[", ", ", "]"),
                 "[<(toStringLiteral.(type2))("32")>, <(toStringLiteral.(type2))("33")>]".equals(map4.makeString("[", ", ", "]"))
-                        || "[<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type2))("32")>]".equals(map4.makeString("[", ", ", "]")));
+                        || "[<(toStringLiteral.(type2))("33")>, <(toStringLiteral.(type2))("32")>]".equals(map4.makeString("[", ", ", "]")), map4.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -546,32 +538,28 @@ public abstract class Abstract<name1><name2>MapTestCase
         <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1"]:keyValue(); separator=", ">);
         map1.appendString(appendable3);
         assertTrue(
-                appendable3.toString(),
                 "<(toStringLiteral.(type2))("0")>, <(toStringLiteral.(type2))("1")>".equals(appendable3.toString())
-                        || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(appendable3.toString()));
+                        || "<(toStringLiteral.(type2))("1")>, <(toStringLiteral.(type2))("0")>".equals(appendable3.toString()), appendable3.toString());
 
         Appendable appendable4 = new StringBuilder();
         <name1><name2>Map map2 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         map2.appendString(appendable4, "[", "/", "]");
         assertTrue(
-                appendable4.toString(),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(appendable4.toString())
-                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable4.toString()));
+                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable4.toString()), appendable4.toString());
 
         Appendable appendable5 = new StringBuilder();
         <name1><name2>Map map3 = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("32")>, <(literal.(type2))("32")>);
         map3.appendString(appendable5, "[", "/", "]");
         assertTrue(
-                appendable5.toString(),
                 "[<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("32")>]".equals(appendable5.toString())
-                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable5.toString()));
+                        || "[<(toStringLiteral.(type2))("32")>/<(toStringLiteral.(type2))("1")>]".equals(appendable5.toString()), appendable5.toString());
 
         Appendable appendable6 = new StringBuilder();
         map1.appendString(appendable6, "/");
         assertTrue(
-                appendable6.toString(),
                 "<(toStringLiteral.(type2))("0")>/<(toStringLiteral.(type2))("1")>".equals(appendable6.toString())
-                        || "<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("0")>".equals(appendable6.toString()));
+                        || "<(toStringLiteral.(type2))("1")>/<(toStringLiteral.(type2))("0")>".equals(appendable6.toString()), appendable6.toString());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutableObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutableObjectPrimitiveMapTestCase.stg
@@ -28,10 +28,10 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.map.primitive.AbstractObject<name>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Abstract JUnit test for {@link ImmutableObject<name>HashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveBooleanMapTestCase.stg
@@ -27,8 +27,8 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 import org.eclipse.collections.impl.map.primitive.Abstract<name>BooleanMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>BooleanMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitiveObjectMapTestCase.stg
@@ -29,10 +29,10 @@ import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.map.primitive.Abstract<name>ObjectMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>ObjectMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/abstractImmutablePrimitivePrimitiveMapTestCase.stg
@@ -31,10 +31,10 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.map.primitive.Abstract<name1><name2>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link Immutable<name1><name2>Map}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
@@ -33,14 +33,14 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>EmptyMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveHashMapTest.stg
@@ -25,9 +25,9 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>HashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveSingletonMapTest.stg
@@ -33,13 +33,13 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObject<name>SingletonMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
@@ -31,13 +31,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanEmptyMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanHashMapTest.stg
@@ -23,10 +23,10 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.Immutable<name>BooleanMap;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanHashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
@@ -33,13 +33,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>BooleanSingletonMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
@@ -59,14 +59,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectEmptyMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectHashMapTest.stg
@@ -23,9 +23,9 @@ import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectHashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
@@ -59,13 +59,13 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * JUnit test for {@link Immutable<name>ObjectSingletonMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
@@ -33,13 +33,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName2>;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>EmptyMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveHashMapTest.stg
@@ -27,10 +27,10 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.math.Mutable<primitive2.wrapperName>;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>HashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
@@ -37,13 +37,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.math.Mutable<primitive2.wrapperName>;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name1><name2>SingletonMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
@@ -33,12 +33,12 @@ import org.eclipse.collections.impl.map.primitive.AbstractObject<name>MapTestCas
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutableObjectPrimitiveMapTestCase.stg.
@@ -532,7 +532,7 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         IntInterval.zeroTo(10).forEachWithIndex((each, index) ->
         {
             <type> v = <(castIntToNarrowTypeWithParens.(type))("each + index")>;
-            assertEquals("Key:" + each, v, map3.addToValue(String.valueOf(each), v)<delta.(type)>);
+            assertEquals(v, map3.addToValue(String.valueOf(each), v)<delta.(type)>, "Key:" + each);
         });
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveBooleanMapTestCase.stg
@@ -36,12 +36,12 @@ import org.eclipse.collections.impl.map.primitive.Abstract<name>BooleanMapTestCa
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitiveBooleanMapTestCase.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitiveObjectMapTestCase.stg
@@ -40,13 +40,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitiveObjectMapTestCase.stg.
@@ -809,8 +809,8 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one").equals(map1));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one").equals(map1), map1.toString());
         iterator1.next();
         iterator1.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map1);
@@ -821,8 +821,8 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map2)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map2)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2), map2.toString());
         iterator2.next();
         iterator2.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map2);
@@ -832,8 +832,8 @@ public abstract class AbstractMutable<name>ObjectMapTestCase extends Abstract<na
         assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map3));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map3), map3.toString());
         iterator3.next();
         iterator3.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map3);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
@@ -42,12 +42,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file abstractMutablePrimitivePrimitiveMapTestCase.stg.
@@ -495,7 +495,7 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         {
             <type1> k = <(castLongToNarrowType.(type1))("each")>;
             <type2> v = <(castLongToNarrowTypeWithParens.(type2))("each + index")>;
-            assertEquals("Key:" + k, v, map2.addToValue(k, v)<(wideDelta.(type2))>);
+            assertEquals(v, map2.addToValue(k, v)<(wideDelta.(type2))>, "Key:" + k);
         });
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class Object<name>HashMapKeySetTestCase
 {

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
@@ -30,11 +30,11 @@ import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<name>MapTestCase
 {

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
@@ -40,11 +40,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This file was automatically generated from template file objectPrimitiveHashMapValuesTestCase.stg.
@@ -422,21 +422,18 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable1.makeString());
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"), iterable3.makeString("/"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
@@ -448,17 +445,14 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -497,34 +491,34 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyKeySetTest.stg
@@ -28,10 +28,10 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link Object<name>HashMapWithHashingStrategy#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyTest.stg
@@ -31,11 +31,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Object<name>HashMapWithHashingStrategy}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
@@ -33,12 +33,12 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#keysView}.
@@ -324,27 +324,23 @@ public class <name>BooleanHashMapKeysViewTest
 
         Lazy<name>Iterable iterable1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView();
         assertTrue(
-                iterable1.toString(),
                 iterable1.toString().equals("[<["0", "1"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable1.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable1.toString().equals("[<["1", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable1.toString());
 
         Lazy<name>Iterable iterable2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, false, <(literal.(type))("32")>, true).keysView();
         assertTrue(
-                iterable2.toString(),
                 iterable2.toString().equals("[<["1", "32"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable2.toString().equals("[<["32", "1"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable2.toString().equals("[<["32", "1"]:(toStringLiteral.(type))(); separator=", ">]"), iterable2.toString());
 
         Lazy<name>Iterable iterable3 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("32")>, true).keysView();
         assertTrue(
-                iterable3.toString(),
                 iterable3.toString().equals("[<["0", "32"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable3.toString().equals("[<["32", "0"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable3.toString().equals("[<["32", "0"]:(toStringLiteral.(type))(); separator=", ">]"), iterable3.toString());
 
         Lazy<name>Iterable iterable4 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, false).keysView();
         assertTrue(
-                iterable4.toString(),
                 iterable4.toString().equals("[<["32", "33"]:(toStringLiteral.(type))(); separator=", ">]")
-                        || iterable4.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"));
+                        || iterable4.toString().equals("[<["33", "32"]:(toStringLiteral.(type))(); separator=", ">]"), iterable4.toString());
     }
 
     @Test
@@ -356,27 +352,23 @@ public class <name>BooleanHashMapKeysViewTest
 
         Lazy<name>Iterable iterable0 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView();
         assertTrue(
-                iterable0.makeString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("1")>".equals(iterable0.makeString())
-                        || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(iterable0.makeString()));
+                        || "<(toStringLiteral.(type))("1")>, <(toStringLiteral.(type))("0")>".equals(iterable0.makeString()), iterable0.makeString());
 
         Lazy<name>Iterable iterable1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView();
         assertTrue(
-                iterable1.makeString(),
                 "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(iterable1.makeString())
-                        || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(iterable1.makeString()));
+                        || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(iterable1.makeString()), iterable1.makeString());
 
         Lazy<name>Iterable iterable2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView();
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 "[<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>]".equals(iterable2.makeString("[", "/", "]"))
-                        || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>]".equals(iterable2.makeString("[", "/", "]")));
+                        || "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>]".equals(iterable2.makeString("[", "/", "]")), iterable2.makeString("[", "/", "]"));
 
         Lazy<name>Iterable iterable3 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView();
         assertTrue(
-                iterable3.makeString("/"),
                 "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>".equals(iterable3.makeString("/"))
-                        || "<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>".equals(iterable3.makeString("/")));
+                        || "<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>".equals(iterable3.makeString("/")), iterable3.makeString("/"));
     }
 
     @Test
@@ -397,20 +389,20 @@ public class <name>BooleanHashMapKeysViewTest
         StringBuilder appendable2 = new StringBuilder();
         Lazy<name>Iterable set1 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("31")>, false).keysView();
         set1.appendString(appendable2);
-        assertTrue(appendable2.toString(), "<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(appendable2.toString())
-                || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(appendable2.toString()));
+        assertTrue("<(toStringLiteral.(type))("0")>, <(toStringLiteral.(type))("31")>".equals(appendable2.toString())
+                || "<(toStringLiteral.(type))("31")>, <(toStringLiteral.(type))("0")>".equals(appendable2.toString()), appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         Lazy<name>Iterable set2 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("31")>, true, <(literal.(type))("32")>, true).keysView();
         set2.appendString(appendable3, "/");
-        assertTrue(appendable3.toString(), "<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>".equals(appendable3.toString())
-                || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>".equals(appendable3.toString()));
+        assertTrue("<(toStringLiteral.(type))("31")>/<(toStringLiteral.(type))("32")>".equals(appendable3.toString())
+                || "<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("31")>".equals(appendable3.toString()), appendable3.toString());
 
         StringBuilder appendable4 = new StringBuilder();
         Lazy<name>Iterable set4 = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("32")>, true, <(literal.(type))("33")>, true).keysView();
         set4.appendString(appendable4, "[", "/", "]");
-        assertTrue(appendable4.toString(), "[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>]".equals(appendable4.toString())
-                || "[<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>]".equals(appendable4.toString()));
+        assertTrue("[<(toStringLiteral.(type))("32")>/<(toStringLiteral.(type))("33")>]".equals(appendable4.toString())
+                || "[<(toStringLiteral.(type))("33")>/<(toStringLiteral.(type))("32")>]".equals(appendable4.toString()), appendable4.toString());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.api.block.function.primitive.<name>ToBooleanFunct
 import org.eclipse.collections.api.map.primitive.Mutable<name>BooleanMap;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap}.
@@ -158,7 +158,7 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
 
         for (<type> i = 11; i \< 75; i++)
         {
-            assertFalse(String.valueOf(i), hashMap.containsKey(i));
+            assertFalse(hashMap.containsKey(i), String.valueOf(i));
             hashMap.put(i, (<(castRealTypeToInt.(type))("i")> & 1) == <(literal.(type))("0")>);
         }
         assertEquals(256L, ((<type>[]) keys.get(hashMap)).length);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
@@ -37,11 +37,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBoo
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>BooleanHashMap#values()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
@@ -35,12 +35,12 @@ import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
@@ -31,11 +31,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>ObjectHashMap#values()}.
@@ -170,8 +170,8 @@ public class <name>ObjectHashMapValuesTest
         assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1), map1.toString());
         iterator1.next();
         iterator1.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map1);
@@ -182,8 +182,8 @@ public class <name>ObjectHashMapValuesTest
         assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2), map2.toString());
         iterator2.next();
         iterator2.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map2);
@@ -193,8 +193,8 @@ public class <name>ObjectHashMapValuesTest
         assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3), map3.toString());
         iterator3.next();
         iterator3.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map3);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
@@ -28,11 +28,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
@@ -32,12 +32,12 @@ import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.api.map.primitive.Mutable<name1><name2>Map;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
@@ -41,11 +41,11 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap#values()}.
@@ -492,21 +492,18 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable1.makeString());
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"), iterable3.makeString("/"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
@@ -518,17 +515,14 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -567,34 +561,34 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
@@ -29,12 +29,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapTest.stg
@@ -20,8 +20,8 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
@@ -38,12 +38,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedObject<name>Map#values()}.
@@ -404,21 +404,18 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable1.makeString());
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"), iterable3.makeString("/"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
@@ -430,17 +427,14 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -479,34 +473,34 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
@@ -30,13 +30,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapTest.stg
@@ -20,8 +20,8 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
@@ -34,12 +34,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBoo
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap#values()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
@@ -26,12 +26,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapTest.stg
@@ -19,8 +19,8 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
@@ -31,11 +31,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap#values()}.
@@ -170,8 +170,8 @@ public class Synchronized<name>ObjectMapValuesTest
         assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        assertTrue(map1.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, "zero").equals(map1)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, null).equals(map1), map1.toString());
         iterator1.next();
         iterator1.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map1);
@@ -182,8 +182,8 @@ public class Synchronized<name>ObjectMapValuesTest
         assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        assertTrue(map2.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("0")>, null).equals(map2)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, "nine").equals(map2), map2.toString());
         iterator2.next();
         iterator2.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map2);
@@ -193,8 +193,8 @@ public class Synchronized<name>ObjectMapValuesTest
         assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        assertTrue(map3.toString(), <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
-                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3));
+        assertTrue(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("8")>, "eight").equals(map3)
+                || <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("9")>, null).equals(map3), map3.toString());
         iterator3.next();
         iterator3.remove();
         assertEquals(<name>ObjectHashMap.newMap(), map3);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
@@ -28,12 +28,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapTest.stg
@@ -22,8 +22,8 @@ body(type1, type2, name1, name2) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
@@ -41,12 +41,12 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#values()}.
@@ -428,21 +428,18 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable1.makeString());
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"), iterable3.makeString("/"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
@@ -454,17 +451,14 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -503,34 +497,34 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
@@ -29,12 +29,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
@@ -29,12 +29,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
@@ -39,11 +39,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map#values()}.
@@ -264,21 +264,18 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable1.makeString());
 
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type))(); separator="/">"), iterable3.makeString("/"));
 
         <name>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type))(); separator=", ">".equals(iterable4.makeString())
@@ -290,17 +287,14 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
 
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -339,34 +333,34 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
@@ -31,12 +31,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
@@ -31,11 +31,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
@@ -38,11 +38,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBoo
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap#values()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
@@ -27,12 +27,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
@@ -38,13 +38,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
@@ -30,11 +30,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap#values()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#keySet()}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
@@ -35,12 +35,12 @@ import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map}.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
@@ -42,11 +42,11 @@ import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#values()}.
@@ -310,21 +310,18 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable1.makeString(),
                 iterable1.makeString().equals("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable1.makeString().equals("<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable1.makeString());
 
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable2.makeString("[", "/", "]"),
                 iterable2.makeString("[", "/", "]").equals("[<["31", "32"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable2.makeString("[", "/", "]").equals("[<["32", "31"]:(toStringLiteral.(type2))(); separator="/">]"), iterable2.makeString("[", "/", "]"));
 
         <name2>Iterable iterable3 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable3.makeString("/"),
                 iterable3.makeString("/").equals("<["32", "33"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable3.makeString("/").equals("<["33", "32"]:(toStringLiteral.(type2))(); separator="/">"), iterable3.makeString("/"));
 
         <name2>Iterable iterable4 = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
         assertTrue("<["1", "2"]:(toStringLiteral.(type2))(); separator=", ">".equals(iterable4.makeString())
@@ -336,17 +333,14 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         assertTrue(
-                iterable5.makeString(),
                 iterable5.makeString().equals("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">")
-                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"));
+                        || iterable5.makeString().equals("<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">"), iterable5.makeString());
         assertTrue(
-                iterable5.makeString("[", "/", "]"),
                 iterable5.makeString("[", "/", "]").equals("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]")
-                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"));
+                        || iterable5.makeString("[", "/", "]").equals("[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]"), iterable5.makeString("[", "/", "]"));
         assertTrue(
-                iterable5.makeString("/"),
                 iterable5.makeString("/").equals("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">")
-                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"));
+                        || iterable5.makeString("/").equals("<["1", "0"]:(toStringLiteral.(type2))(); separator="/">"), iterable5.makeString("/"));
     }
 
     @Override
@@ -385,34 +379,34 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         iterable1.appendString(appendable7);
-        assertTrue(appendable7.toString(), "<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
-                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()));
+        assertTrue("<["0", "31"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString())
+                || "<["31", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable7.toString()), appendable7.toString());
 
         StringBuilder appendable8 = new StringBuilder();
         <name2>Iterable iterable2 = this.newWith(<["31", "32"]:(literal.(type2))(); separator=", ">);
         iterable2.appendString(appendable8, "/");
-        assertTrue(appendable8.toString(), "<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
-                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()));
+        assertTrue("<["31", "32"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString())
+                || "<["32", "31"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable8.toString()), appendable8.toString());
 
         StringBuilder appendable9 = new StringBuilder();
         <name2>Iterable iterable4 = this.newWith(<["32", "33"]:(literal.(type2))(); separator=", ">);
         iterable4.appendString(appendable9, "[", "/", "]");
-        assertTrue(appendable9.toString(), "[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
-                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()));
+        assertTrue("[<["32", "33"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString())
+                || "[<["33", "32"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable9.toString()), appendable9.toString());
 
         StringBuilder appendable10 = new StringBuilder();
         <name2>Iterable iterable5 = this.newWith(<["0", "1"]:(literal.(type2))(); separator=", ">);
         iterable5.appendString(appendable10);
-        assertTrue(appendable10.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator=", ">".equals(appendable10.toString()), appendable10.toString());
         StringBuilder appendable11 = new StringBuilder();
         iterable5.appendString(appendable11, "/");
-        assertTrue(appendable11.toString(), "<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
-                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()));
+        assertTrue("<["0", "1"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString())
+                || "<["1", "0"]:(toStringLiteral.(type2))(); separator="/">".equals(appendable11.toString()), appendable11.toString());
         StringBuilder appendable12 = new StringBuilder();
         iterable5.appendString(appendable12, "[", "/", "]");
-        assertTrue(appendable12.toString(), "[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
-                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()));
+        assertTrue("[<["0", "1"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString())
+                || "[<["1", "0"]:(toStringLiteral.(type2))(); separator="/">]".equals(appendable12.toString()), appendable12.toString());
     }
 
     <if(primitive2.floatPrimitive)><(sumMethodFloat.(type1))()>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/objectPrimitiveMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/objectPrimitiveMapFactoryTest.stg
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.Object<name>HashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file objectPrimitiveMapFactoryTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitiveBooleanMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitiveBooleanMapFactoryTest.stg
@@ -24,9 +24,9 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This file was automatically generated from template file primitiveBooleanMapFactoryTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitiveObjectMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitiveObjectMapFactoryTest.stg
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file primitiveObjectMapFactoryTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/map/primitivePrimitiveMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/primitivePrimitiveMapFactoryTest.stg
@@ -37,9 +37,9 @@ import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This file was automatically generated from template file primitivePrimitiveMapFactoryTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/abstractImmutablePrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/abstractImmutablePrimitiveSetTestCase.stg
@@ -38,13 +38,13 @@ import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.impl.factory.Sets;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Set}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>EmptySet}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
@@ -22,8 +22,8 @@ import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ByteHashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutable<name>HashSetTestCase;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Immutable<name>Set} created from the freeze() method.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
@@ -22,8 +22,8 @@ import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.impl.map.mutable.primitive.<primitive.name><primitive.name>HashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutable<name>HashSetTestCase;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link Immutable<name>Set} created from the freeze() method.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveSetFactoryImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveSetFactoryImplTest.stg
@@ -23,8 +23,8 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link Immutable<name>SetFactoryImpl}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
@@ -35,12 +35,12 @@ import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.impl.factory.Sets;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Set}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
@@ -24,11 +24,11 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link BoxedMutable<name>Set}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
@@ -24,11 +24,11 @@ import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>HashSet}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/synchronizedPrimitiveSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/synchronizedPrimitiveSetTest.stg
@@ -19,9 +19,9 @@ package org.eclipse.collections.impl.set.mutable.primitive;
 
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Synchronized<name>Set}.

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
@@ -23,12 +23,12 @@ import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Unmodifiable<name>Set}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
@@ -30,11 +30,11 @@ import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>Stack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
@@ -26,9 +26,9 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link Immutable<name>ArrayStack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link Immutable<name>EmptyStack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveSingletonStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveSingletonStackTest.stg
@@ -29,12 +29,12 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link Immutable<name>SingletonStack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
@@ -27,11 +27,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNotSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Abstract JUnit test for {@link Mutable<name>Stack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
@@ -42,11 +42,11 @@ import org.eclipse.collections.impl.stack.mutable.primitive.<name>ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link <name>Stack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/primitiveArrayStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/primitiveArrayStackTest.stg
@@ -25,8 +25,8 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link <name>ArrayStack}.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/synchronizedPrimitiveStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/synchronizedPrimitiveStackTest.stg
@@ -21,9 +21,9 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file synchronizedPrimitiveStackTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
@@ -23,11 +23,11 @@ import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.stack.primitive.Abstract<name>StackTestCase;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This file was automatically generated from template file unmodifiablePrimitiveStackTest.stg.

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/booleanPrimitivePairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/booleanPrimitivePairImplTest.stg
@@ -23,11 +23,11 @@ package org.eclipse.collections.impl.tuple.primitive;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link Boolean<name>PairImpl}.

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/primitiveBooleanPairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/primitiveBooleanPairImplTest.stg
@@ -23,11 +23,11 @@ package org.eclipse.collections.impl.tuple.primitive;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link <name>BooleanPairImpl}.

--- a/eclipse-collections-code-generator/src/main/resources/test/tuple/primitivePrimitivePairImplTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/tuple/primitivePrimitivePairImplTest.stg
@@ -25,9 +25,9 @@ package org.eclipse.collections.impl.tuple.primitive;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * JUnit test for {@link <name1><name2>PairImpl}.

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIterableIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIterableIterateTest.stg
@@ -26,8 +26,8 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link <name>IterableIterate}.

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIteratorIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/internal/primitiveIteratorIterateTest.stg
@@ -28,9 +28,9 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link <name>IteratorIterate}.

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/lazyPrimitiveIterateTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/lazyPrimitiveIterateTest.stg
@@ -22,9 +22,9 @@ import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link Lazy<name>Iterate}.

--- a/eclipse-collections-code-generator/src/main/resources/test/utility/singletonPrimitiveIteratorTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/utility/singletonPrimitiveIteratorTest.stg
@@ -19,11 +19,11 @@ package org.eclipse.collections.impl.iterator;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This file was automatically generated from template file singletonPrimitiveIterator.stg.

--- a/unit-tests/pom.xml
+++ b/unit-tests/pom.xml
@@ -53,11 +53,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
1. Migrates junit4 to junit5 for all test templates
2. Uplifts the assertX syntax as the signature between juni4 and 5 isn't compatible (assertion description now always goes at the end of the assertion method)


@motlin i'm back :-)
