### PR TITLE
Add slim and primitive artifacts

### DIFF
--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -97,6 +97,42 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <id>slim-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/primitive/**/*</exclude>
+                            </excludes>
+                            <classifier>slim</classifier>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <id>primitive-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/primitive/**/*</include>
+                            </includes>
+                            <classifier>primitive</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
I have been experimenting with EC and concerned about the size of the jar. My use cases currently only require the object-based classes. So I started wondering and chatting with @donraab about what might be required to split the primitive specializations out into a separate jar.

This PR is mainly intended to start a conversation about that possibility.

The first attempt here essentially just adds two additional jars to the build:

* a "slim" jar that does not include any of the primitive packages
* a "package" jar that includes only those packages

The slim jar is about 75% smaller than the full release jar, and the very few collections I have tested appear to still work. As long as you don't stumble into the primitive APIs, the JVM doesn't care that the primitive implementations aren't there.

More generally, though, I would like to discuss a realistic path toward a smaller or more modular release. I can't be the only one that wants just a few classes from this library but can't afford to add a large jar to my project.