### PR TITLE
Fix ImmutableArrayBag and ImmutableArrayStack to return size-optimized types.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
@@ -255,7 +255,7 @@ public class ImmutableArrayBag<T>
                 result.addOccurrences((S) each, index);
             }
         });
-        return ImmutableArrayBag.copyFrom(result);
+        return result.toImmutable();
     }
 
     @Override
@@ -314,7 +314,7 @@ public class ImmutableArrayBag<T>
     public <V> ImmutableBag<V> collect(Function<? super T, ? extends V> function)
     {
         MutableBag<V> result = this.collect(function, HashBag.newBag());
-        return ImmutableArrayBag.copyFrom(result);
+        return result.toImmutable();
     }
 
     @Override
@@ -323,7 +323,7 @@ public class ImmutableArrayBag<T>
             Function<? super T, ? extends V> function)
     {
         MutableBag<V> result = this.collectIf(predicate, function, HashBag.newBag());
-        return ImmutableArrayBag.copyFrom(result);
+        return result.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -64,6 +64,7 @@ import org.eclipse.collections.api.collection.primitive.MutableFloatCollection;
 import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
+import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.factory.primitive.BooleanStacks;
 import org.eclipse.collections.api.factory.primitive.ByteStacks;
 import org.eclipse.collections.api.factory.primitive.CharStacks;
@@ -381,7 +382,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     @Override
     public <S> ImmutableStack<S> selectInstancesOf(Class<S> clazz)
     {
-        return ImmutableArrayStack.newStackFromTopToBottom(this.delegate.asReversed().selectInstancesOf(clazz).toList());
+        return Stacks.immutable.withAllReversed(this.delegate.asReversed().selectInstancesOf(clazz).toList());
     }
 
     @Override


### PR DESCRIPTION
I'm working on pulling up more tests to super classes to improve test coverage. They'll be in the next commit. One of them includes assertSame/assertNotSame assertions that caught this performance bug. If these methods were filtering down to empty/singleton range, we were still building array-backed data structures.