### PR TITLE
Fix SortedSetIterable getFirst/getLast to return null on empty sets.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSet.java
@@ -157,13 +157,13 @@ abstract class AbstractImmutableSortedSet<T> extends AbstractImmutableCollection
     @Override
     public T getFirst()
     {
-        return this.first();
+        return this.isEmpty() ? null : this.first();
     }
 
     @Override
     public T getLast()
     {
-        return this.last();
+        return this.isEmpty() ? null : this.last();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapter.java
@@ -654,13 +654,13 @@ public final class SortedSetAdapter<T>
     @Override
     public T getFirst()
     {
-        return this.first();
+        return this.isEmpty() ? null : this.first();
     }
 
     @Override
     public T getLast()
     {
-        return this.last();
+        return this.isEmpty() ? null : this.last();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSet.java
@@ -667,13 +667,13 @@ public class TreeSortedSet<T> extends AbstractMutableCollection<T>
     @Override
     public T getFirst()
     {
-        return this.first();
+        return this.isEmpty() ? null : this.first();
     }
 
     @Override
     public T getLast()
     {
-        return this.last();
+        return this.isEmpty() ? null : this.last();
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
@@ -10,8 +10,6 @@
 
 package org.eclipse.collections.test.set.sorted;
 
-import java.util.NoSuchElementException;
-
 import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.set.sorted.SortedSetIterable;
@@ -27,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIterableTestCase, TransformsToListTrait
 {
@@ -90,14 +87,16 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     @Test
     default void RichIterable_getFirst_empty_null()
     {
-        assertThrows(NoSuchElementException.class, () -> this.newWith().getFirst());
+        SetIterableTestCase.super.RichIterable_getFirst_empty_null();
+        SortedIterableTestCase.super.RichIterable_getFirst_empty_null();
     }
 
     @Override
     @Test
     default void RichIterable_getLast_empty_null()
     {
-        assertThrows(NoSuchElementException.class, () -> this.newWith().getLast());
+        SetIterableTestCase.super.RichIterable_getLast_empty_null();
+        SortedIterableTestCase.super.RichIterable_getLast_empty_null();
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -1193,6 +1193,7 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void getFirst()
     {
+        assertNull(this.newWith().getFirst());
         assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
         assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
     }
@@ -1200,6 +1201,7 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void getLast()
     {
+        assertNull(this.newWith().getLast());
         assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
         assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
@@ -220,26 +220,6 @@ public class ArrayAdapterTest extends AbstractListTestCase
 
     @Override
     @Test
-    public void getFirst()
-    {
-        super.getFirst();
-
-        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
-        assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
-    }
-
-    @Override
-    @Test
-    public void getLast()
-    {
-        super.getLast();
-
-        assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
-        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
-    }
-
-    @Override
-    @Test
     public void isEmpty()
     {
         super.isEmpty();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -421,24 +421,6 @@ public class FastListTest extends AbstractListTestCase
 
     @Override
     @Test
-    public void getFirst()
-    {
-        assertNull(FastList.<Integer>newList().getFirst());
-        assertEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getFirst());
-        assertNotEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getFirst());
-    }
-
-    @Override
-    @Test
-    public void getLast()
-    {
-        assertNull(FastList.<Integer>newList().getLast());
-        assertNotEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getLast());
-        assertEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getLast());
-    }
-
-    @Override
-    @Test
     public void isEmpty()
     {
         Verify.assertEmpty(FastList.<Integer>newList());

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
@@ -353,23 +353,6 @@ public class MultiReaderFastListTest extends AbstractListTestCase
 
     @Override
     @Test
-    public void getFirst()
-    {
-        assertNull(MultiReaderFastList.newList().getFirst());
-        assertEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getFirst());
-    }
-
-    @Override
-    @Test
-    public void getLast()
-    {
-        assertNull(MultiReaderFastList.newList().getLast());
-        assertNotEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getLast());
-        assertEquals(Integer.valueOf(3), MultiReaderFastList.newListWith(1, 2, 3).getLast());
-    }
-
-    @Override
-    @Test
     public void isEmpty()
     {
         Verify.assertEmpty(MultiReaderFastList.newList());

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
@@ -47,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -283,24 +282,6 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         Verify.assertContainsAll(
                 this.newWith(1, 2, 3, 4).reject(Predicates.lessThan(3),
                         FastList.newList()), 3, 4);
-    }
-
-    @Override
-    @Test
-    public void getFirst()
-    {
-        super.getFirst();
-
-        assertNotNull(this.newWith(1, 2, 3).getFirst());
-        assertNull(this.newWith().getFirst());
-    }
-
-    @Override
-    @Test
-    public void getLast()
-    {
-        assertNotNull(this.newWith(1, 2, 3).getLast());
-        assertNull(this.newWith().getLast());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
@@ -176,14 +176,14 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void getFirst()
     {
-        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().getFirst());
+        assertNull(this.classUnderTest().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().getLast());
+        assertNull(this.classUnderTest().getLast());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
@@ -13,7 +13,6 @@ package org.eclipse.collections.impl.set.sorted.mutable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -33,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -172,7 +172,7 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
         super.getFirst();
         assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
         assertEquals(Integer.valueOf(3), this.newWith(Collections.reverseOrder(), 1, 2, 3).getFirst());
-        assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getFirst());
+        assertNull(new SortedSetAdapter<>(new TreeSet<>()).getFirst());
     }
 
     @Override
@@ -183,7 +183,7 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
         assertNotNull(this.newWith(1, 2, 3).getLast());
         assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
         assertEquals(Integer.valueOf(1), this.newWith(Collections.reverseOrder(), 1, 2, 3).getLast());
-        assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getLast());
+        assertNull(new SortedSetAdapter<>(new TreeSet<>()).getLast());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -280,24 +278,6 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
         assertEquals(collection.toString(), '[' + builder.toString() + ']');
-    }
-
-    @Override
-    @Test
-    public void getFirst()
-    {
-        super.getFirst();
-        assertNotNull(this.newWith(1, 2, 3).getFirst());
-        assertThrows(NoSuchElementException.class, () -> assertNull(this.newWith().getFirst()));
-    }
-
-    @Override
-    @Test
-    public void getLast()
-    {
-        super.getLast();
-        assertNotNull(this.newWith(1, 2, 3).getLast());
-        assertThrows(NoSuchElementException.class, () -> assertNull(this.newWith().getLast()));
     }
 
     @Override


### PR DESCRIPTION
The sorted set implementations (TreeSortedSet, SortedSetAdapter, AbstractImmutableSortedSet) previously delegated getFirst() and getLast() to java.util.SortedSet's first() and last() methods, which throw NoSuchElementException when the set is empty. This violated the RichIterable/OrderedIterable contract which specifies that getFirst() and getLast() should return null for empty collections.

Changed to check isEmpty() before calling first()/last(), returning null for empty sets. Updated SortedSetIterableTestCase to remove the assertThrows tests that verified the incorrect exception behavior.