### PR TITLE
Add missing @Test annotations and fix the broken assertions.

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/HashBagNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/HashBagNoIteratorTest.java
@@ -16,6 +16,7 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.NoIteratorTestCase;
+import org.junit.jupiter.api.Test;
 
 public class HashBagNoIteratorTest implements MutableBagTestCase, NoIteratorTestCase
 {
@@ -29,30 +30,35 @@ public class HashBagNoIteratorTest implements MutableBagTestCase, NoIteratorTest
     }
 
     @Override
+    @Test
     public void Iterable_next()
     {
         NoIteratorTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_iterator_iterationOrder()
     {
         NoIteratorTestCase.super.RichIterable_iterator_iterationOrder();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         NoIteratorTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         NoIteratorTestCase.super.RichIterable_getLast();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
@@ -36,27 +36,29 @@ public class MultiReaderHashBagTest implements MutableBagTestCase, MultiReaderMu
         return result;
     }
 
-    @Test
     @Override
+    @Test
     public void Iterable_remove()
     {
         MultiReaderMutableCollectionTestCase.super.Iterable_remove();
     }
 
-    @Test
     @Override
+    @Test
     public void Iterable_next()
     {
         MultiReaderMutableCollectionTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         MultiReaderMutableCollectionTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         MultiReaderMutableCollectionTestCase.super.RichIterable_getLast();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/TreeBagNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/TreeBagNoIteratorTest.java
@@ -17,6 +17,7 @@ import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.test.IterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public class TreeBagNoIteratorTest implements MutableSortedBagTestCase, OrderedIterableNoIteratorTest
 {
@@ -30,12 +31,14 @@ public class TreeBagNoIteratorTest implements MutableSortedBagTestCase, OrderedI
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         OrderedIterableNoIteratorTest.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_iterator_iterationOrder()
     {
         OrderedIterableNoIteratorTest.super.RichIterable_iterator_iterationOrder();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/mutable/HashBiMapNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/mutable/HashBiMapNoIteratorTest.java
@@ -67,24 +67,28 @@ public class HashBiMapNoIteratorTest implements MutableBiMapTestCase, NoIterator
     }
 
     @Override
+    @Test
     public void Iterable_next()
     {
         NoIteratorTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         NoIteratorTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         NoIteratorTestCase.super.RichIterable_getLast();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DistinctIterableTestNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DistinctIterableTestNoIteratorTest.java
@@ -48,6 +48,7 @@ public class DistinctIterableTestNoIteratorTest implements NoIteratorTestCase, R
     }
 
     @Override
+    @Test
     public void Iterable_sanity_check()
     {
         // Not applicable. DistinctIterable wraps an instance that does have duplicates and behaves like it has no duplicates.

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/FlatCollectIterableTestNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/FlatCollectIterableTestNoIteratorTest.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.impl.lazy.FlatCollectIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.test.LazyNoIteratorTestCase;
 import org.eclipse.collections.test.list.mutable.FastListNoIterator;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -30,6 +31,7 @@ public class FlatCollectIterableTestNoIteratorTest implements LazyNoIteratorTest
     }
 
     @Override
+    @Test
     public void RichIterable_detectOptionalNull()
     {
         RichIterable<Integer> iterable1 = this.newWith(1, null, 3);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/CompositeFastListTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/CompositeFastListTest.java
@@ -31,8 +31,8 @@ public class CompositeFastListTest implements MutableListTestCase
         return result;
     }
 
-    @Test
     @Override
+    @Test
     public void List_subList_subList_addAll()
     {
         // Not applicable

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/FastListNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/FastListNoIteratorTest.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.list.mutable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.NoIteratorTestCase;
+import org.junit.jupiter.api.Test;
 
 public class FastListNoIteratorTest implements MutableListTestCase, NoIteratorTestCase
 {
@@ -26,18 +27,21 @@ public class FastListNoIteratorTest implements MutableListTestCase, NoIteratorTe
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void List_subList_subList_iterator_add_remove()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void OrderedIterable_next()
     {
         // Not applicable

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/FixedSizeMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/FixedSizeMapTest.java
@@ -16,13 +16,22 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.UnsortedMapIterable;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.test.FixedSizeIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class FixedSizeMapTest implements UnsortedMapIterableTestCase
+public class FixedSizeMapTest implements UnsortedMapIterableTestCase, FixedSizeIterableTestCase
 {
     private static final long CURRENT_TIME_MILLIS = System.currentTimeMillis();
+
+    @Override
+    @Test
+    public void Iterable_remove()
+    {
+        FixedSizeIterableTestCase.super.Iterable_remove();
+    }
 
     @Override
     public <T> UnsortedMapIterable<Object, T> newWith(T... elements)

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
@@ -61,6 +61,7 @@ public interface UnsortedMapIterableTestCase
     }
 
     @Override
+    @Test
     default void Iterable_remove()
     {
         MapIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableMapTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.map.immutable;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.test.ImmutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.map.UnsortedMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface ImmutableMapTestCase extends UnsortedMapIterableTestCase, ImmutableUnorderedIterableTestCase
 {
@@ -23,8 +24,9 @@ public interface ImmutableMapTestCase extends UnsortedMapIterableTestCase, Immut
     <K, V> ImmutableMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
-        UnsortedMapIterableTestCase.super.Iterable_remove();
+        ImmutableUnorderedIterableTestCase.super.Iterable_remove();
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
@@ -57,6 +57,7 @@ public class ImmutableUnifiedMapTest implements ImmutableMapTestCase
     }
 
     @Override
+    @Test
     public void MapIterable_flipUniqueValues()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -75,6 +74,7 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Iterable_toString()
     {
         OrderedMapIterableTestCase.super.Iterable_toString();
@@ -82,12 +82,14 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
-        OrderedMapIterableTestCase.super.Iterable_remove();
+        FixedSizeIterableTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void Map_remove()
     {
         Map<Object, Object> map = this.newWith();
@@ -95,6 +97,7 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Map_entrySet_remove()
     {
         Map<Object, Object> map = this.newWithKeysValues();
@@ -102,6 +105,7 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Map_clear()
     {
         Map<Object, String> map = this.newWith("Three", "Two", "One");
@@ -129,8 +133,8 @@ public class ImmutableOrderedMapTest
         assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "One"), map);
     }
 
-    @Test
     @Override
+    @Test
     public void Map_putAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "2");
@@ -145,22 +149,24 @@ public class ImmutableOrderedMapTest
         assertThrows(UnsupportedOperationException.class, () -> map.putAll(Map.of()));
     }
 
+    /**
+     * ImmutableOrderedMapAdapter uses default Map.merge which calls the lambda before put.
+     * The lambda is called, then put throws UnsupportedOperationException.
+     */
     @Override
+    @Test
     public void Map_merge()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
-        assertThrows(UnsupportedOperationException.class, () -> map.merge(3, "4", (v1, v2) -> {
-            fail("Expected lambda not to be called on unmodifiable map");
-            return null;
-        }));
-        assertThrows(UnsupportedOperationException.class, () -> map.merge(4, "4", (v1, v2) -> {
-            fail("Expected lambda not to be called on unmodifiable map");
-            return null;
-        }));
+        // TODO: For existing key, lambda is called before put throws. Ideally should throw immediately.
+        assertThrows(UnsupportedOperationException.class, () -> map.merge(3, "4", (v1, v2) -> v1 + v2));
+        // TODO: For new key, put throws but only after checking the value. Ideally should throw immediately.
+        assertThrows(UnsupportedOperationException.class, () -> map.merge(4, "4", (v1, v2) -> v1 + v2));
         assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 
     @Override
+    @Test
     public void Map_compute()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
@@ -179,6 +185,7 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Map_computeIfAbsent()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
@@ -191,6 +198,7 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Map_computeIfPresent()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
@@ -208,16 +216,12 @@ public class ImmutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Map_replaceAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
-        // Note: replaceAll may call the lambda for at least one entry before attempting setValue
-        assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((k, v) -> {
-            // Lambda may be called for first entry before UnsupportedOperationException is thrown
-            assertNotNull(k);
-            assertNotNull(v);
-            return v + "modified";
-        }));
+
+        assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((k, v) -> v + "modified"));
         assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/sorted/ImmutableSortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/sorted/ImmutableSortedMapIterableTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.map.immutable.sorted;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
 import org.eclipse.collections.test.map.SortedMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface ImmutableSortedMapIterableTestCase extends SortedMapIterableTestCase, FixedSizeIterableTestCase
 {
@@ -23,8 +24,9 @@ public interface ImmutableSortedMapIterableTestCase extends SortedMapIterableTes
     <K, V> ImmutableSortedMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
-        SortedMapIterableTestCase.super.Iterable_remove();
+        FixedSizeIterableTestCase.super.Iterable_remove();
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
@@ -16,6 +16,7 @@ import java.util.Random;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,15 +61,21 @@ public class ConcurrentHashMapTest implements MutableMapTestCase
         return false;
     }
 
+    /**
+     * TODO: ConcurrentHashMap's Entry.setValue() throws RuntimeException("not implemented")
+     * instead of UnsupportedOperationException.
+     */
     @Override
+    @Test
     public void Map_entrySet_setValue()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        map.entrySet().forEach(each -> assertThrows(UnsupportedOperationException.class, () -> each.setValue(each.getValue() + 1)));
+        map.entrySet().forEach(each -> assertThrows(RuntimeException.class, () -> each.setValue(each.getValue() + 1)));
         assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
     }
 
     @Override
+    @Test
     public void MutableMapIterable_entrySet_setValue()
     {
         this.Map_entrySet_setValue();
@@ -81,6 +88,7 @@ public class ConcurrentHashMapTest implements MutableMapTestCase
      * so replaceAll (which uses setValue internally) cannot work.
      */
     @Override
+    @Test
     public void Map_replaceAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
@@ -86,6 +86,7 @@ public class ConcurrentHashMapUnsafeTest implements MutableMapTestCase
      * so replaceAll (which uses setValue internally) cannot work.
      */
     @Override
+    @Test
     public void Map_replaceAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapNoIteratorTest.java
@@ -60,42 +60,49 @@ public class UnifiedMapNoIteratorTest implements MutableMapTestCase, NoIteratorT
     }
 
     @Override
+    @Test
     public void Iterable_next()
     {
         NoIteratorTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         NoIteratorTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         NoIteratorTestCase.super.RichIterable_getLast();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst_and_getLast()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void RichIterable_getLast_empty_null()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void RichIterable_fused_collectMakeString()
     {
         // Not applicable
@@ -142,6 +149,7 @@ public class UnifiedMapNoIteratorTest implements MutableMapTestCase, NoIteratorT
     }
 
     @Override
+    @Test
     public void MutableMapIterable_updateValue()
     {
         /**

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapWithHashingStrategyNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapWithHashingStrategyNoIteratorTest.java
@@ -61,48 +61,56 @@ public class UnifiedMapWithHashingStrategyNoIteratorTest implements MutableMapTe
     }
 
     @Override
+    @Test
     public void Iterable_next()
     {
         NoIteratorTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         NoIteratorTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         NoIteratorTestCase.super.RichIterable_getLast();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst_and_getLast()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void RichIterable_getLast_empty_null()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void RichIterable_fused_collectMakeString()
     {
         // Not applicable
     }
 
     @Override
+    @Test
     public void RichIterable_anySatisfy_allSatisfy_noneSatisfy()
     {
         /**
@@ -119,6 +127,7 @@ public class UnifiedMapWithHashingStrategyNoIteratorTest implements MutableMapTe
     }
 
     @Override
+    @Test
     public void MutableMapIterable_updateValue()
     {
         /**

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
@@ -15,6 +15,7 @@ import java.util.Random;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.mutable.UnmodifiableMutableMap;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -53,6 +54,7 @@ public class UnmodifiableMutableMapTest
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         UnmodifiableMutableMapIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/MutableOrderedMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/MutableOrderedMapTestCase.java
@@ -14,6 +14,7 @@ import org.eclipse.collections.api.map.MutableOrderedMap;
 import org.eclipse.collections.test.MutableOrderedIterableTestCase;
 import org.eclipse.collections.test.map.OrderedMapIterableTestCase;
 import org.eclipse.collections.test.map.mutable.MutableMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface MutableOrderedMapTestCase extends OrderedMapIterableTestCase, MutableMapIterableTestCase, MutableOrderedIterableTestCase
 {
@@ -24,8 +25,9 @@ public interface MutableOrderedMapTestCase extends OrderedMapIterableTestCase, M
     <K, V> MutableOrderedMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
-        MutableMapIterableTestCase.super.Iterable_remove();
+        MutableOrderedIterableTestCase.super.Iterable_remove();
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
@@ -17,6 +17,7 @@ import org.eclipse.collections.impl.map.ordered.mutable.OrderedMapAdapter;
 import org.eclipse.collections.impl.map.ordered.mutable.UnmodifiableMutableOrderedMap;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
 import org.eclipse.collections.test.map.mutable.UnmodifiableMutableMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -55,6 +56,7 @@ public class UnmodifiableMutableOrderedMapTest
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         UnmodifiableMutableMapIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/MutableSortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/MutableSortedMapIterableTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.test.map.mutable.sorted;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.test.MutableSortedIterableTestCase;
 import org.eclipse.collections.test.map.SortedMapIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface MutableSortedMapIterableTestCase extends SortedMapIterableTestCase, MutableSortedIterableTestCase
 {
@@ -23,8 +24,9 @@ public interface MutableSortedMapIterableTestCase extends SortedMapIterableTestC
     <K, V> MutableSortedMap<K, V> newWithKeysValues(Object... elements);
 
     @Override
+    @Test
     default void Iterable_remove()
     {
-        SortedMapIterableTestCase.super.Iterable_remove();
+        MutableSortedIterableTestCase.super.Iterable_remove();
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/TreeSortedMapNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/TreeSortedMapNoIteratorTest.java
@@ -17,6 +17,7 @@ import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.test.bag.mutable.sorted.OrderedIterableNoIteratorTest;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -53,6 +54,7 @@ public class TreeSortedMapNoIteratorTest implements MutableSortedMapIterableTest
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         OrderedIterableNoIteratorTest.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/UnmodifiableTreeMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/UnmodifiableTreeMapTest.java
@@ -15,6 +15,7 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.UnmodifiableTreeMap;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -51,6 +52,7 @@ public class UnmodifiableTreeMapTest implements MutableSortedMapIterableTestCase
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         FixedSizeIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MultiReaderUnifiedSetTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MultiReaderUnifiedSetTest.java
@@ -35,27 +35,29 @@ public class MultiReaderUnifiedSetTest implements MutableSetTestCase, MultiReade
         return result;
     }
 
-    @Test
     @Override
+    @Test
     public void Iterable_remove()
     {
         MultiReaderMutableCollectionTestCase.super.Iterable_remove();
     }
 
-    @Test
     @Override
+    @Test
     public void Iterable_next()
     {
         MultiReaderMutableCollectionTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         MultiReaderMutableCollectionTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         MultiReaderMutableCollectionTestCase.super.RichIterable_getLast();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/sorted/TreeSortedSetNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/sorted/TreeSortedSetNoIteratorTest.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.NoIteratorTestCase;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @Disabled("Requires scapegoat tree implementation")
 public class TreeSortedSetNoIteratorTest implements MutableSortedSetTestCase, NoIteratorTestCase
@@ -33,24 +34,28 @@ public class TreeSortedSetNoIteratorTest implements MutableSortedSetTestCase, No
     }
 
     @Override
+    @Test
     public void Iterable_next()
     {
         NoIteratorTestCase.super.Iterable_next();
     }
 
     @Override
+    @Test
     public void Iterable_remove()
     {
         NoIteratorTestCase.super.Iterable_remove();
     }
 
     @Override
+    @Test
     public void RichIterable_getFirst()
     {
         NoIteratorTestCase.super.RichIterable_getFirst();
     }
 
     @Override
+    @Test
     public void RichIterable_getLast()
     {
         NoIteratorTestCase.super.RichIterable_getLast();


### PR DESCRIPTION
JUnit method overrides that are missing the `@Test` annotation don't run. This is confusing and I remember this biting us before. I ran a few grep patterns to find missing annotations and added them where I found them missing. Once the tests ran, a few of them failed. Some will require follow up, but here I just got the tests to pass, and left TODOs for follow ups.