### PR TITLE
Fix ImmutableOrderedMapAdapter.entrySet() to throw UnsupportedOperationException on Entry.setValue().

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/immutable/ImmutableOrderedMapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/immutable/ImmutableOrderedMapAdapter.java
@@ -69,7 +69,7 @@ public class ImmutableOrderedMapAdapter<K, V>
 
     public ImmutableOrderedMapAdapter(Map<K, V> delegate)
     {
-        this.delegate = OrderedMapAdapter.adapt(new LinkedHashMap<>(delegate));
+        this.delegate = OrderedMapAdapter.adapt(Collections.unmodifiableMap(new LinkedHashMap<>(delegate)));
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
@@ -110,6 +110,15 @@ public class ImmutableOrderedMapTest
 
     @Override
     @Test
+    public void Map_entrySet_setValue()
+    {
+        Map<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
+        map.entrySet().forEach(each -> assertThrows(UnsupportedOperationException.class, () -> each.setValue(each.getValue() + 1)));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+    }
+
+    @Override
+    @Test
     public void Map_put()
     {
         Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");


### PR DESCRIPTION
This fixes the most important bug uncovered in https://github.com/eclipse-collections/eclipse-collections/pull/1821