### PR TITLE
Change ConcurrentHashMap and ConcurrentHashMapUnsafe's Entry.setValue() to throw UnsupportedOperationException instead of RuntimeException("not implemented").

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -1835,7 +1835,7 @@ public final class ConcurrentHashMap<K, V>
         @Override
         public V setValue(V value)
         {
-            throw new RuntimeException("not implemented");
+            throw new UnsupportedOperationException("ConcurrentHashMap.Entry.setValue() not implemented. Use put() instead.");
         }
 
         public Entry<K, V> getNext()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -1948,7 +1948,7 @@ public class ConcurrentHashMapUnsafe<K, V>
         @Override
         public V setValue(V value)
         {
-            throw new RuntimeException("not implemented");
+            throw new UnsupportedOperationException("ConcurrentHashMapUnsafe.Entry.setValue() not implemented. Use put() instead.");
         }
 
         public Entry<K, V> getNext()

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
@@ -61,16 +61,12 @@ public class ConcurrentHashMapTest implements MutableMapTestCase
         return false;
     }
 
-    /**
-     * TODO: ConcurrentHashMap's Entry.setValue() throws RuntimeException("not implemented")
-     * instead of UnsupportedOperationException.
-     */
     @Override
     @Test
     public void Map_entrySet_setValue()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        map.entrySet().forEach(each -> assertThrows(RuntimeException.class, () -> each.setValue(each.getValue() + 1)));
+        map.entrySet().forEach(each -> assertThrows(UnsupportedOperationException.class, () -> each.setValue(each.getValue() + 1)));
         assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
     }
 
@@ -82,17 +78,16 @@ public class ConcurrentHashMapTest implements MutableMapTestCase
     }
 
     /**
-     * TODO: Implement {@link java.util.Map.Entry#setValue(Object)} in {@link ConcurrentHashMap}
-     * or provide a custom {@link Map#replaceAll(java.util.function.BiFunction)} implementation.
-     * Currently, {@link ConcurrentHashMap}'s Entry.setValue() throws {@link RuntimeException} "not implemented",
-     * so replaceAll (which uses setValue internally) cannot work.
+     * TODO: Implement a custom replaceAll() using the JDK's retry-loop approach with replace().
+     * ConcurrentHashMap's Entry.setValue() throws UnsupportedOperationException,
+     * so the default replaceAll (which uses setValue internally) cannot work.
      */
     @Override
     @Test
     public void Map_replaceAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
-        assertThrows(RuntimeException.class, () -> map.replaceAll((k, v) -> v + k));
+        assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((k, v) -> v + k));
         assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
@@ -66,7 +66,7 @@ public class ConcurrentHashMapUnsafeTest implements MutableMapTestCase
     public void Map_entrySet_setValue()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        map.entrySet().forEach(each -> assertThrows(RuntimeException.class, () -> each.setValue(each.getValue() + 1)));
+        map.entrySet().forEach(each -> assertThrows(UnsupportedOperationException.class, () -> each.setValue(each.getValue() + 1)));
         assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
     }
 
@@ -75,22 +75,21 @@ public class ConcurrentHashMapUnsafeTest implements MutableMapTestCase
     public void MutableMapIterable_entrySet_setValue()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        map.entrySet().forEach(each -> assertThrows(RuntimeException.class, () -> each.setValue(each.getValue() + 1)));
+        map.entrySet().forEach(each -> assertThrows(UnsupportedOperationException.class, () -> each.setValue(each.getValue() + 1)));
         assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
     }
 
     /**
-     * TODO: Implement {@link java.util.Map.Entry#setValue(Object)} in {@link ConcurrentHashMapUnsafe}
-     * or provide a custom {@link Map#replaceAll(java.util.function.BiFunction)} implementation.
-     * Currently, {@link ConcurrentHashMapUnsafe}'s Entry.setValue() throws {@link RuntimeException} "not implemented",
-     * so replaceAll (which uses setValue internally) cannot work.
+     * TODO: Implement a custom replaceAll() using the JDK's retry-loop approach with replace().
+     * ConcurrentHashMapUnsafe's Entry.setValue() throws UnsupportedOperationException,
+     * so the default replaceAll (which uses setValue internally) cannot work.
      */
     @Override
     @Test
     public void Map_replaceAll()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
-        assertThrows(RuntimeException.class, () -> map.replaceAll((k, v) -> v + k));
+        assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((k, v) -> v + k));
         assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 }


### PR DESCRIPTION
This is consistent with the JDK's implementation of ConcurrentHashMap.