### PR TITLE
Override merge() to throw UnsupportedOperationException immediately.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/immutable/ImmutableOrderedMapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/immutable/ImmutableOrderedMapAdapter.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
@@ -294,6 +295,12 @@ public class ImmutableOrderedMapAdapter<K, V>
     public V remove(Object key)
     {
         throw new UnsupportedOperationException("Cannot call remove() on " + this.getClass().getSimpleName());
+    }
+
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction)
+    {
+        throw new UnsupportedOperationException("Cannot call merge() on " + this.getClass().getSimpleName());
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
@@ -149,19 +149,19 @@ public class ImmutableOrderedMapTest
         assertThrows(UnsupportedOperationException.class, () -> map.putAll(Map.of()));
     }
 
-    /**
-     * ImmutableOrderedMapAdapter uses default Map.merge which calls the lambda before put.
-     * The lambda is called, then put throws UnsupportedOperationException.
-     */
     @Override
     @Test
     public void Map_merge()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
-        // TODO: For existing key, lambda is called before put throws. Ideally should throw immediately.
-        assertThrows(UnsupportedOperationException.class, () -> map.merge(3, "4", (v1, v2) -> v1 + v2));
-        // TODO: For new key, put throws but only after checking the value. Ideally should throw immediately.
-        assertThrows(UnsupportedOperationException.class, () -> map.merge(4, "4", (v1, v2) -> v1 + v2));
+        assertThrows(UnsupportedOperationException.class, () -> map.merge(3, "4", (v1, v2) -> {
+            fail("Expected lambda not to be called on unmodifiable map");
+            return null;
+        }));
+        assertThrows(UnsupportedOperationException.class, () -> map.merge(4, "4", (v1, v2) -> {
+            fail("Expected lambda not to be called on unmodifiable map");
+            return null;
+        }));
         assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 


### PR DESCRIPTION
instead of relying on the default Map.merge() which calls the lambda before failing on put(). This ensures consistent behavior with other mutating operations on immutable maps.