### PR TITLE
Fix ErrorProne rules ClassCanBeStatic, StringCaseLocaleUsage, and MissingOverride in tests.

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/impl/WordleTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/WordleTest.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl;
 
+import java.util.Locale;
+
 import org.eclipse.collections.api.bag.primitive.MutableCharBag;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.primitive.CharLists;
@@ -66,18 +68,18 @@ public class WordleTest
                 triple -> triple.getOne().equals(new Wordle(triple.getTwo()).guessZipCharReject(triple.getThree())));
     }
 
-    class Wordle
+    static class Wordle
     {
         private final String string;
 
         Wordle(String string)
         {
-            this.string = string.toLowerCase();
+            this.string = string.toLowerCase(Locale.ROOT);
         }
 
         public String guessForEachInBoth(String guess)
         {
-            CharAdapter guessChars = Strings.asChars(guess.toLowerCase());
+            CharAdapter guessChars = Strings.asChars(guess.toLowerCase(Locale.ROOT));
             CharAdapter hiddenChars = Strings.asChars(this.string);
             MutableCharBag remaining = CharBags.mutable.empty();
             hiddenChars.forEachInBoth(guessChars, (h, g) -> remaining.add(h == g ? '.' : h));
@@ -98,7 +100,7 @@ public class WordleTest
 
         public String guessInjectIntoIndex(String guess)
         {
-            CharAdapter guessChars = Strings.asChars(guess.toLowerCase());
+            CharAdapter guessChars = Strings.asChars(guess.toLowerCase(Locale.ROOT));
             CharAdapter hiddenChars = Strings.asChars(this.string);
             MutableCharBag remaining =
                     hiddenChars.injectIntoWithIndex(
@@ -109,7 +111,7 @@ public class WordleTest
 
         public String guessRejectWithIndex(String guess)
         {
-            CharAdapter guessChars = Strings.asChars(guess.toLowerCase());
+            CharAdapter guessChars = Strings.asChars(guess.toLowerCase(Locale.ROOT));
             CharAdapter hiddenChars = Strings.asChars(this.string);
             MutableCharBag remaining =
                     hiddenChars.rejectWithIndex((each, i) -> guessChars.get(i) == each, CharBags.mutable.empty());
@@ -118,7 +120,7 @@ public class WordleTest
 
         public String guessSelectWithIndex(String guess)
         {
-            CharAdapter guessChars = Strings.asChars(guess.toLowerCase());
+            CharAdapter guessChars = Strings.asChars(guess.toLowerCase(Locale.ROOT));
             CharAdapter hiddenChars = Strings.asChars(this.string);
             MutableCharBag remaining =
                     hiddenChars.selectWithIndex((each, i) -> guessChars.get(i) != each, CharBags.mutable.empty());
@@ -128,7 +130,7 @@ public class WordleTest
         public String guessZipCharReject(String guess)
         {
             ImmutableList<CharCharPair> charPairs =
-                    Strings.asChars(this.string).zipChar(Strings.asChars(guess.toLowerCase()));
+                    Strings.asChars(this.string).zipChar(Strings.asChars(guess.toLowerCase(Locale.ROOT)));
             MutableCharBag remaining =
                     charPairs.asLazy()
                             .reject(pair -> pair.getOne() == pair.getTwo())

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
@@ -66,6 +66,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
 
     public static final Predicates2<String, Class<Integer>> ERROR_THROWING_PREDICATE_2 = new Predicates2<String, Class<Integer>>()
     {
+        @Override
         public boolean accept(String argument1, Class<Integer> argument2)
         {
             throw new AssertionError();
@@ -591,6 +592,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         assertEquals(UnifiedMap.newMap(), this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
     }
 
+    @Override
     @Test
     public void countByEach()
     {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
@@ -36,6 +36,7 @@ public class MultiReaderHashBagAsUnmodifiableTest extends UnmodifiableMutableCol
         assertEquals(expected, actual);
     }
 
+    @Override
     @Test
     public void iteratorRemove()
     {


### PR DESCRIPTION
I've been experimenting with turning on ErrorProne, mostly because I needed the MissingOverride rule in tests to find the problems I've been fixing in my recent PRs. It caught a few more very minor problems and I figured I'd socialize the fixes and start to see if it's realistic and helpful to turn on this additional linter.