### PR TITLE
Fix #1801: ConcurrentHashMap view spliterators should be CONCURRENT and not SIZED

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -18,6 +18,14 @@ The Eclipse Collections team gives a huge thank you to everyone who participated
 * Upgrade bnd plugin to 7.1.0.
 * Publish p2 artifacts to maven central. Fixes #294 . Example [here](https://central.sonatype.com/artifact/org.eclipse.collections/p2-site)
 
+
+# Bug Fixes
+-----------------
+* Fixed ConcurrentHashMap keySet(), values(), and entrySet() spliterators to ensure they are CONCURRENT and not SIZED. Fixes #1801.
+* Fixed ConcurrentHashMapUnsafe keySet(), values(), and entrySet() spliterators to ensure they are CONCURRENT and not SIZED.
+
+
+
 # Note
 -------
 _We have taken all the measures to ensure all features are captured in the release notes. 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1631,6 +1633,12 @@ public final class ConcurrentHashMap<K, V>
         }
 
         @Override
+        public Spliterator<K> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
+        }
+
+        @Override
         public int size()
         {
             return ConcurrentHashMap.this.size();
@@ -1661,6 +1669,12 @@ public final class ConcurrentHashMap<K, V>
         public Iterator<V> iterator()
         {
             return new ValueIterator();
+        }
+
+        @Override
+        public Spliterator<V> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.CONCURRENT | Spliterator.NONNULL);
         }
 
         @Override
@@ -1720,6 +1734,12 @@ public final class ConcurrentHashMap<K, V>
         public Iterator<Map.Entry<K, V>> iterator()
         {
             return new EntryIterator();
+        }
+
+        @Override
+        public Spliterator<Map.Entry<K, V>> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
         }
 
         @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1744,6 +1746,13 @@ public class ConcurrentHashMapUnsafe<K, V>
         }
 
         @Override
+        public Spliterator<K> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(),
+                    Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
+        }
+
+        @Override
         public int size()
         {
             return ConcurrentHashMapUnsafe.this.size();
@@ -1774,6 +1783,13 @@ public class ConcurrentHashMapUnsafe<K, V>
         public Iterator<V> iterator()
         {
             return new ValueIterator();
+        }
+
+        @Override
+        public Spliterator<V> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(),
+                    Spliterator.CONCURRENT | Spliterator.NONNULL);
         }
 
         @Override
@@ -1833,6 +1849,13 @@ public class ConcurrentHashMapUnsafe<K, V>
         public Iterator<Map.Entry<K, V>> iterator()
         {
             return new EntryIterator();
+        }
+
+        @Override
+        public Spliterator<Map.Entry<K, V>> spliterator()
+        {
+            return Spliterators.spliteratorUnknownSize(this.iterator(),
+                    Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
         }
 
         @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
@@ -11,8 +11,14 @@
 package org.eclipse.collections.impl.map.mutable;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ConcurrentMutableMap;
@@ -25,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
 {
@@ -105,5 +113,78 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
                 FastList.newList(Collections.nCopies(100, 2)),
                 FastList.newList(map.values()),
                 HashBag.newBag(map.values()).toStringOfItemToCount());
+    }
+
+    @Test
+    public void keySetValuesEntrySetSpliteratorsAreConcurrentAndNotSized()
+    {
+        ConcurrentMap<Integer, String> map = this.newMap();
+        map.put(1, "1");
+
+        Spliterator<Integer> ks = map.keySet().spliterator();
+        assertFalse(ks.hasCharacteristics(Spliterator.ORDERED));
+        assertTrue(ks.hasCharacteristics(Spliterator.DISTINCT));
+        assertFalse(ks.hasCharacteristics(Spliterator.SORTED));
+        assertFalse(ks.hasCharacteristics(Spliterator.SIZED));
+        assertTrue(ks.hasCharacteristics(Spliterator.NONNULL));
+        assertFalse(ks.hasCharacteristics(Spliterator.IMMUTABLE));
+        assertTrue(ks.hasCharacteristics(Spliterator.CONCURRENT));
+        assertFalse(ks.hasCharacteristics(Spliterator.SUBSIZED));
+
+        Spliterator<String> vs = map.values().spliterator();
+        assertFalse(vs.hasCharacteristics(Spliterator.ORDERED));
+        assertFalse(vs.hasCharacteristics(Spliterator.DISTINCT));
+        assertFalse(vs.hasCharacteristics(Spliterator.SORTED));
+        assertFalse(vs.hasCharacteristics(Spliterator.SIZED));
+        assertTrue(vs.hasCharacteristics(Spliterator.NONNULL));
+        assertFalse(vs.hasCharacteristics(Spliterator.IMMUTABLE));
+        assertTrue(vs.hasCharacteristics(Spliterator.CONCURRENT));
+        assertFalse(vs.hasCharacteristics(Spliterator.SUBSIZED));
+
+        Spliterator<Map.Entry<Integer, String>> es = map.entrySet().spliterator();
+        assertFalse(es.hasCharacteristics(Spliterator.ORDERED));
+        assertTrue(es.hasCharacteristics(Spliterator.DISTINCT));
+        assertFalse(es.hasCharacteristics(Spliterator.SORTED));
+        assertFalse(es.hasCharacteristics(Spliterator.SIZED));
+        assertTrue(es.hasCharacteristics(Spliterator.NONNULL));
+        assertFalse(es.hasCharacteristics(Spliterator.IMMUTABLE));
+        assertTrue(es.hasCharacteristics(Spliterator.CONCURRENT));
+        assertFalse(es.hasCharacteristics(Spliterator.SUBSIZED));
+    }
+
+    @Test
+    public void raceConditionReproductionTest()
+    {
+        ConcurrentMap<Integer, String> eclipseMap = this.newMap();
+        IntStream.range(0, 200000)
+                .boxed()
+                .forEach(i -> eclipseMap.put(i, String.valueOf(i)));
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(
+                        () -> eclipseMap.values()
+                                .stream()
+                                .peek(s -> randomWait())
+                                .toArray(String[]::new)),
+                CompletableFuture.runAsync(
+                        () -> IntStream.range(200000, 400000)
+                                .boxed()
+                                .peek(i -> randomWait())
+                                .forEach(i -> eclipseMap.put(i, String.valueOf(i))))).join();
+    }
+
+    private static void randomWait()
+    {
+        try
+        {
+            if (ThreadLocalRandom.current().nextInt(1000) == 0)
+            {
+                Thread.sleep(1);
+            }
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
### What was changed
Updated the `spliterator()` implementations for `keySet()`, `values()`, and `entrySet()` views of
`ConcurrentHashMap` to ensure they correctly report `Spliterator.CONCURRENT` and do **not**
report `SIZED` or `SUBSIZED`.

This aligns the behavior with the concurrent nature of the map and prevents incorrect
assumptions when these views are used with streams.

### Why this change
The previous behavior could expose spliterators that appeared sized, even though the
underlying collection can change concurrently. This could lead to race conditions or
incorrect stream behavior, as reported in #1801.

### Tests
- Added unit test verifying that `keySet`, `values`, and `entrySet` spliterators:
  - have `Spliterator.CONCURRENT`
  - do not have `Spliterator.SIZED` or `Spliterator.SUBSIZED`
- Ran the full Maven test suite successfully.
