### PR TITLE
Fix #1790: make sumOfDoubleConsistentRounding deterministic and ULP-tolerant

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -21,8 +21,7 @@ The Eclipse Collections team gives a huge thank you to everyone who participated
 
 # Bug Fixes
 -----------------
-* Fixed flaky parallel sumOfDoubleConsistentRounding() test by using deterministic shuffle seed and ULP-based tolerance. Fixes #1790.
-
+* Fixed flaky sumOfDoubleConsistentRounding() test by using deterministic input ordering and validating the sum stays within the mathematically expected range for rounding-sensitive values across batch sizes. Fixes #1790.
 
 
 # Note


### PR DESCRIPTION
### Description

This change fixes a flaky `sumOfDoubleConsistentRounding()` test caused by non-associative floating-point summation in parallel reductions.

The test now:
- Uses a deterministic shuffle with a fixed random seed for reproducibility.
- Replaces the fixed delta assertion with an ULP-based tolerance to account for rounding differences due to varying summation order across batch sizes.

Fixes #1790.
