### PR TITLE
Docs: remove outdated version information from about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,12 +3,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
-<title>About Eclipse Collections 7.0</title>
+<title>About Eclipse Collections</title>
 </head>
 <body lang="EN-US">
-<h1>Eclipse Collections 7.0</h1>
+<h1>Eclipse Collections</h1>
 <h2>Eclipse Collections initial release</h2>
-<p>Dec 24 2015<p>
+<p>See project documentation for current release information.</p>
 <h2>About</h2>
 <p><a href="http://www.eclipse.org/collections/">Eclipse Collections</a> 
   is a collections framework for Java. It has JDK-compatible 


### PR DESCRIPTION
This PR removes hardcoded version and date information from about.html, which referenced Eclipse Collections 7.0 from 2015. This change helps avoid confusion for users. 
The current release and Java compatibility details are now kept in the main documentation.