### PR TITLE
Fix UnifiedMapWithHashingStrategy.entrySet().batchForEach() to expose Entries that use the HashingStrategy.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -54,7 +54,6 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.AbstractMutableMap;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -2753,7 +2752,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             {
                 if (UnifiedMapWithHashingStrategy.nullSafeEquals(value, curValue))
                 {
-                    return ImmutableEntry.of(UnifiedMapWithHashingStrategy.this.nonSentinel(cur), (V) curValue);
+                    return new WeakBoundEntry<>(UnifiedMapWithHashingStrategy.this.nonSentinel(cur), (V) curValue, this.holder, UnifiedMapWithHashingStrategy.this.hashingStrategy);
                 }
             }
             return null;
@@ -2773,7 +2772,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
                     Object curValue = chain[i + 1];
                     if (UnifiedMapWithHashingStrategy.nullSafeEquals(value, curValue))
                     {
-                        return ImmutableEntry.of(UnifiedMapWithHashingStrategy.this.nonSentinel(cur), (V) curValue);
+                        return new WeakBoundEntry<>(UnifiedMapWithHashingStrategy.this.nonSentinel(cur), (V) curValue, this.holder, UnifiedMapWithHashingStrategy.this.hashingStrategy);
                     }
                 }
             }
@@ -2969,7 +2968,11 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
                 }
                 else if (cur != null)
                 {
-                    procedure.value(ImmutableEntry.of(UnifiedMapWithHashingStrategy.this.nonSentinel(cur), (V) map[i + 1]));
+                    procedure.value(new WeakBoundEntry<>(
+                            UnifiedMapWithHashingStrategy.this.nonSentinel(cur),
+                            (V) map[i + 1],
+                            this.holder,
+                            UnifiedMapWithHashingStrategy.this.hashingStrategy));
                 }
             }
         }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/strategy/HashingStrategyMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/strategy/HashingStrategyMapTestCase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2024 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.test.map.mutable.strategy;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.collections.api.block.HashingStrategy;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.parallel.BatchIterable;
+import org.eclipse.collections.impl.tuple.ImmutableEntry;
+import org.eclipse.collections.test.map.mutable.MutableMapTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public interface HashingStrategyMapTestCase extends MutableMapTestCase
+{
+    MutableMap<Integer, Integer> newMapWithConstantStrategy();
+
+    /**
+     * Override to add hashing strategy-specific hashCode tests.
+     * Tests that Entry.hashCode() and Map.hashCode() use strategy.computeHashCode().
+     */
+    @Override
+    @Test
+    default void Object_equalsAndHashCode()
+    {
+        MutableMapTestCase.super.Object_equalsAndHashCode();
+
+        MutableMap<Integer, Integer> map = this.newMapWithConstantStrategy();
+        map.put(3, 2);
+        Set<Map.Entry<Integer, Integer>> entries = map.entrySet();
+
+        // strategy.computeHashCode(key) ^ value.hashCode()
+        int expectedCombinedHashCode = 1 ^ 2;
+
+        assertEquals(expectedCombinedHashCode, entries.hashCode());
+        assertEquals(expectedCombinedHashCode, map.hashCode());
+
+        entries.forEach(entry -> assertEquals(expectedCombinedHashCode, entry.hashCode()));
+        for (Map.Entry<Integer, Integer> entry : entries)
+        {
+            assertEquals(expectedCombinedHashCode, entry.hashCode());
+        }
+
+        for (Object entry : entries.toArray())
+        {
+            assertEquals(expectedCombinedHashCode, entry.hashCode());
+        }
+
+        for (Object entry : entries.toArray(new Object[]{}))
+        {
+            assertEquals(expectedCombinedHashCode, entry.hashCode());
+        }
+
+        for (Object entry : entries.toArray(new Object[]{2}))
+        {
+            assertEquals(expectedCombinedHashCode, entry.hashCode());
+        }
+
+        if (entries instanceof BatchIterable<?> batchIterable)
+        {
+            batchIterable.batchForEach(entry -> assertEquals(expectedCombinedHashCode, entry.hashCode()), 0, 1);
+        }
+
+        assertTrue(entries.contains(new ImmutableEntry<>(3, 2)));
+        assertTrue(entries.contains(new ImmutableEntry<>(4, 2)));
+        assertFalse(entries.contains(new ImmutableEntry<>(3, 3)));
+        assertFalse(entries.contains(new ImmutableEntry<>(4, 3)));
+
+        Set<Integer> keys = map.keySet();
+
+        // strategy.computeHashCode(key) for single key
+        int expectedKeyHashCode = 1;
+
+        assertEquals(expectedKeyHashCode, keys.hashCode());
+
+        assertTrue(keys.contains(3));
+        assertTrue(keys.contains(4));
+    }
+
+    class ConstantHashingStrategy implements HashingStrategy<Object>
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int computeHashCode(Object object)
+        {
+            return 1;
+        }
+
+        @Override
+        public boolean equals(Object object1, Object object2)
+        {
+            return true;
+        }
+    }
+
+    class DefaultHashingStrategy<T> implements HashingStrategy<T>
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int computeHashCode(T object)
+        {
+            return Objects.hashCode(object);
+        }
+
+        @Override
+        public boolean equals(T object1, T object2)
+        {
+            return Objects.equals(object1, object2);
+        }
+    }
+}

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/strategy/UnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/strategy/UnifiedMapWithHashingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2026 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,14 +13,12 @@ package org.eclipse.collections.test.map.mutable.strategy;
 import java.util.Random;
 
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy;
-import org.eclipse.collections.test.map.mutable.MutableMapTestCase;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnifiedMapWithHashingStrategyTest implements MutableMapTestCase
+public class UnifiedMapWithHashingStrategyTest implements HashingStrategyMapTestCase
 {
     private static final long CURRENT_TIME_MILLIS = System.currentTimeMillis();
 
@@ -28,7 +26,7 @@ public class UnifiedMapWithHashingStrategyTest implements MutableMapTestCase
     public <T> MutableMap<Object, T> newWith(T... elements)
     {
         Random random = new Random(CURRENT_TIME_MILLIS);
-        MutableMap<Object, T> result = new UnifiedMapWithHashingStrategy<>(HashingStrategies.defaultStrategy());
+        MutableMap<Object, T> result = new UnifiedMapWithHashingStrategy<>(new DefaultHashingStrategy<>());
         for (T each : elements)
         {
             assertNull(result.put(random.nextDouble(), each));
@@ -44,7 +42,7 @@ public class UnifiedMapWithHashingStrategyTest implements MutableMapTestCase
             fail(String.valueOf(elements.length));
         }
 
-        MutableMap<K, V> result = new UnifiedMapWithHashingStrategy<>(HashingStrategies.defaultStrategy());
+        MutableMap<K, V> result = new UnifiedMapWithHashingStrategy<>(new DefaultHashingStrategy<>());
         for (int i = 0; i < elements.length; i += 2)
         {
             assertNull(result.put((K) elements[i], (V) elements[i + 1]));
@@ -53,9 +51,8 @@ public class UnifiedMapWithHashingStrategyTest implements MutableMapTestCase
     }
 
     @Override
-    public boolean supportsNullKeys()
+    public MutableMap<Integer, Integer> newMapWithConstantStrategy()
     {
-        // TODO: UnifiedMapWithHashingStrategy does support null, but we're using a hashing strategy in this test which does not.
-        return false;
+        return new UnifiedMapWithHashingStrategy<>(new ConstantHashingStrategy());
     }
 }


### PR DESCRIPTION
Discovered while code reviewing #1839