### PR TITLE
Docs: Add examples of iteration patterns for primitive Bag

### DIFF
--- a/docs/2-Collection_Containers.adoc
+++ b/docs/2-Collection_Containers.adoc
@@ -1109,6 +1109,66 @@ Primitive stack implementations are similar to JCF *ArrayStack* but optimized fo
 === Primitive bags
 
 Primitive bag implementations are similar to JCF *HashBag*, but both _item_ and _count_ are primitives.
+They allow duplicate elements and provide efficient querying of the number of occurrences of each element.
+
+.Creating primitive bags
+====
+[source,java]
+----
+MutableBooleanBag booleanBag = BooleanHashBag.newBagWith(true, false, true, true, false);
+
+// or
+
+MutableBooleanBag booleanBag2 = new BooleanHashBag();
+booleanBag2.add(true);
+booleanBag2.add(false);
+booleanBag2.addOccurrences(true, 3);
+----
+
+.Iteration patterns on primitive bags
+====
+[source,java]
+----
+MutableBooleanBag bag = BooleanHashBag.newBagWith(true, false, true, true, false);
+
+// Iterate with occurrence counts
+bag.forEachWithOccurrences((item, count) ->
+    System.out.println("Item: " + item + ", Occurrences: " + count));
+
+// Lazy iteration for deferred evaluation
+LazyBooleanIterable lazy = bag.asLazy();
+MutableBooleanBag filtered = lazy.select(x -> x).toBag();
+
+// Select elements by occurrence count
+MutableIntBag intBag = IntBags.mutable.with(1, 1, 1, 2, 2, 3);
+MutableIntBag frequent = intBag.selectByOccurrences(count -> count >= 2);
+
+// Check conditions with occurrence counts
+boolean anyMatch = intBag.anySatisfyWithOccurrences((each, count) -> each == 1 && count == 3);
+
+// Statistical operations
+int sum = intBag.sum();
+int min = intBag.min();
+int max = intBag.max();
+IntSummaryStatistics stats = intBag.summaryStatistics();
+
+// Collect with occurrences
+MutableBag<IntIntPair> pairs = intBag.collectWithOccurrences((each, count) ->
+    PrimitiveTuples.pair(each, count));
+
+// Chunking for batch processing
+RichIterable<IntIterable> chunks = intBag.chunk(2);
+----
+
+.Other primitive bag types
+====
+[source,java]
+----
+MutableIntBag intBag = IntBags.mutable.with(1, 2, 3, 1, 2, 3);
+MutableLongBag longBag = LongBags.mutable.with(100L, 200L, 100L);
+MutableDoubleBag doubleBag = DoubleBags.mutable.with(1.5, 2.5, 1.5);
+MutableCharBag charBag = CharBags.mutable.with('a', 'b', 'a', 'c');
+----
 
 === Primitive Maps
 


### PR DESCRIPTION

## Summary
Add examples of iteration patterns for primitive Bag to the reference guide as requested in #1387.

## What was added
Added comprehensive iteration pattern examples for primitive bags in `docs/2-Collection_Containers.adoc`:

### Creation patterns
- `BooleanHashBag.newBagWith()`
- Constructor with `addOccurrences()`

### Iteration patterns
- `forEachWithOccurrences()` - Iterate with occurrence counts
- `asLazy()` - Lazy iteration for deferred evaluation
- `selectByOccurrences()` - Filter by occurrence count
- `anySatisfyWithOccurrences()` - Check conditions with occurrence counts
- `sum()`, `min()`, `max()`, `summaryStatistics()` - Statistical operations
- `collectWithOccurrences()` - Collect element-count pairs
- `chunk()` - Batch processing

### Support for multiple primitive types
Examples for IntBag, LongBag, DoubleBag, CharBag using the same patterns.

## Notes
- Examples based on Lost and Found Kata patterns
- Documentation follows the same compact style as the Primitive sets section
- All examples are concise and practical

Resolves #1387