### PR TITLE
Replace deprecated boxed-type constructors with valueOf() in tests.

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
@@ -619,15 +619,15 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<Integer> numbers = this.newWith(1, 1, 1, 2, 2, 3, 3);
         MutableList<ObjectIntPair<Integer>> pairs = numbers.bottomOccurrences(1);
         Verify.assertSize(2, pairs);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(2)));
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(3)));
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(2));
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(3));
         numbers.withReadLockAndDelegate(bag ->
         {
             Verify.assertSize(2, bag.bottomOccurrences(1));
             Verify.assertAnySatisfy(
-                    bag.bottomOccurrences(1), pair -> pair.getOne().equals(new Integer(2)));
+                    bag.bottomOccurrences(1), pair -> pair.getOne().equals(2));
             Verify.assertAnySatisfy(
-                    bag.bottomOccurrences(1), pair -> pair.getOne().equals(new Integer(3)));
+                    bag.bottomOccurrences(1), pair -> pair.getOne().equals(3));
         });
     }
 
@@ -637,21 +637,21 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<Integer> numbers = this.newWith(1, 1, 1, 2, 2, 3, 3);
         MutableBag<ObjectIntPair<Integer>> pairs =
                 numbers.collectWithOccurrences(PrimitiveTuples::pair);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(1))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(1)
                 && pair.getTwo() == 3);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(2))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(2)
                 && pair.getTwo() == 2);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(3))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(3)
                 && pair.getTwo() == 2);
         numbers.withReadLockAndDelegate(bag ->
         {
             MutableBag<ObjectIntPair<Integer>> pairs2 =
                     bag.collectWithOccurrences(PrimitiveTuples::pair);
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(1))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(1)
                     && pair.getTwo() == 3);
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(2))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(2)
                     && pair.getTwo() == 2);
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(3))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(3)
                     && pair.getTwo() == 2);
         });
     }
@@ -662,21 +662,21 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<Integer> numbers = this.newWith(1, 1, 1, 2, 2, 3, 3);
         MutableBag<ObjectIntPair<Integer>> pairs =
                 numbers.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(1))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(1)
                 && pair.getTwo() == 3);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(2))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(2)
                 && pair.getTwo() == 2);
-        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(new Integer(3))
+        Verify.assertAnySatisfy(pairs, pair -> pair.getOne().equals(3)
                 && pair.getTwo() == 2);
         numbers.withReadLockAndDelegate(bag ->
         {
             MutableBag<ObjectIntPair<Integer>> pairs2 =
                     bag.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(1))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(1)
                     && pair.getTwo() == 3);
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(2))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(2)
                     && pair.getTwo() == 2);
-            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(new Integer(3))
+            Verify.assertAnySatisfy(pairs2, pair -> pair.getOne().equals(3)
                     && pair.getTwo() == 2);
         });
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
@@ -24,9 +24,9 @@ public class MinAndMaxBlocksTest
     @Test
     public void minBlocks()
     {
-        assertEquals(new Double(1.0), MinFunction.DOUBLE.value(1.0, 2.0));
-        assertEquals(new Double(0.0), MinFunction.DOUBLE.value(0.0, 1.0));
-        assertEquals(new Double(-1.0), MinFunction.DOUBLE.value(1.0, -1.0));
+        assertEquals(Double.valueOf(1.0), MinFunction.DOUBLE.value(1.0, 2.0));
+        assertEquals(Double.valueOf(0.0), MinFunction.DOUBLE.value(0.0, 1.0));
+        assertEquals(Double.valueOf(-1.0), MinFunction.DOUBLE.value(1.0, -1.0));
 
         assertEquals(Integer.valueOf(1), MinFunction.INTEGER.value(1, 2));
         assertEquals(Integer.valueOf(0), MinFunction.INTEGER.value(0, 1));
@@ -56,9 +56,9 @@ public class MinAndMaxBlocksTest
     @Test
     public void maxBlocks()
     {
-        assertEquals(new Double(2.0), MaxFunction.DOUBLE.value(1.0, 2.0));
-        assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(0.0, 1.0));
-        assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(1.0, -1.0));
+        assertEquals(Double.valueOf(2.0), MaxFunction.DOUBLE.value(1.0, 2.0));
+        assertEquals(Double.valueOf(1.0), MaxFunction.DOUBLE.value(0.0, 1.0));
+        assertEquals(Double.valueOf(1.0), MaxFunction.DOUBLE.value(1.0, -1.0));
 
         assertEquals(Integer.valueOf(2), MaxFunction.INTEGER.value(1, 2));
         assertEquals(Integer.valueOf(1), MaxFunction.INTEGER.value(0, 1));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
@@ -26,7 +26,7 @@ public class MultiplyFunctionTest
     @Test
     public void doubleBlock()
     {
-        assertEquals(new Double(20), MultiplyFunction.DOUBLE.value(2.0, 10.0));
+        assertEquals(Double.valueOf(20.0), MultiplyFunction.DOUBLE.value(2.0, 10.0));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
@@ -373,11 +373,11 @@ public class ListsTest
     public void withNValues()
     {
         ImmutableList<Integer> expected =
-                IntInterval.oneTo(10).collect(each -> new Integer(1));
+                IntInterval.oneTo(10).collect(each -> 1);
         MutableList<Integer> mutable =
-                Lists.mutable.withNValues(10, () -> new Integer(1));
+                Lists.mutable.withNValues(10, () -> 1);
         MutableList<Integer> multiReader =
-                Lists.multiReader.withNValues(10, () -> new Integer(1));
+                Lists.multiReader.withNValues(10, () -> 1);
         assertEquals(expected, mutable);
         assertEquals(expected, multiReader);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -187,14 +187,14 @@ public class FastListTest extends AbstractListTestCase
     public void testInjectIntoDouble()
     {
         FastList<Double> list = this.newWith(1.0, 2.0, 3.0);
-        assertEquals(new Double(1.0 + 1.0 + 2.0 + 3.0), list.injectInto(new Double(1.0d), AddFunction.DOUBLE));
+        assertEquals(Double.valueOf(1.0 + 1.0 + 2.0 + 3.0), list.injectInto(Double.valueOf(1.0), AddFunction.DOUBLE));
     }
 
     @Test
     public void testInjectIntoFloat()
     {
         FastList<Float> list = this.newWith(1.0f, 2.0f, 3.0f);
-        assertEquals(new Float(7.0f), list.injectInto(new Float(1.0f), AddFunction.FLOAT));
+        assertEquals(Float.valueOf(7.0f), list.injectInto(Float.valueOf(1.0f), AddFunction.FLOAT));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
@@ -97,7 +97,7 @@ public class ArrayIterateTest
     {
         Double[] objectArray = {(double) 1, (double) 2, (double) 3};
         assertEquals(
-                new Double(1 + 1 + 2 + 3),
+                Double.valueOf(1 + 1 + 2 + 3),
                 ArrayIterate.injectInto((double) 1, objectArray, AddFunction.DOUBLE));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
@@ -296,7 +296,7 @@ public class ArrayListIterateTest
         list.add(2.0);
         list.add(3.0);
         assertEquals(
-                new Double(7.0),
+                Double.valueOf(7.0),
                 ArrayListIterate.injectInto(1.0, list, AddFunction.DOUBLE));
     }
 
@@ -308,7 +308,7 @@ public class ArrayListIterateTest
         list.add(2.0f);
         list.add(3.0f);
         assertEquals(
-                new Float(7.0f),
+                Float.valueOf(7.0f),
                 ArrayListIterate.injectInto(1.0f, list, AddFunction.FLOAT));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -351,7 +351,7 @@ public class IterateTest
     @Test
     public void injectInto2()
     {
-        assertEquals(new Double(7), Iterate.injectInto(1.0, iList(1.0, 2.0, 3.0), AddFunction.DOUBLE));
+        assertEquals(Double.valueOf(7.0), Iterate.injectInto(1.0, iList(1.0, 2.0, 3.0), AddFunction.DOUBLE));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
@@ -732,7 +732,7 @@ public class ListIterateTest
     {
         String abc = "abc";
         String def = "def";
-        MutableList<? extends Serializable> list = Lists.mutable.of(new Integer(1), abc, new Long(2), def);
+        MutableList<? extends Serializable> list = Lists.mutable.of(1, abc, 2L, def);
         MutableList<String> expected = Lists.mutable.of(abc, def);
         assertEquals(expected, ListIterate.selectInstancesOf(list, String.class));
         assertEquals(expected, ListIterate.selectInstancesOf(new LinkedList<>(list), String.class));


### PR DESCRIPTION
The boxed constructors like new Integer(1) are marked deprecated for removal, and emit warnings during the build. Some are used for tests that care about reference equality but many aren't, and the ones that aren't are removed in this PR.