### PR TITLE
Fix SubList.add(int, T) bounds check rejecting index 0 on empty SubList.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
@@ -708,7 +708,10 @@ public abstract class AbstractMutableList<T>
         @Override
         public void add(int index, T element)
         {
-            this.checkIfOutOfBounds(index);
+            if (index > this.size || index < 0)
+            {
+                throw new IndexOutOfBoundsException("Index: " + index + " Size: " + this.size);
+            }
             this.original.add(index + this.offset, element);
             this.size++;
             this.updateSize(1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
@@ -169,7 +169,7 @@ public interface ListTestCase extends CollectionTestCase
         assertIterablesEqual(Lists.immutable.with("F"), sublist);
         assertIterablesEqual(Lists.immutable.with(), sublist2);
 
-        sublist2.add("J");
+        sublist2.add(0, "J");
         assertIterablesEqual(Lists.immutable.with("A", "B", "C", "J", "F"), list);
         assertIterablesEqual(Lists.immutable.with("J", "F"), sublist);
         assertIterablesEqual(Lists.immutable.with("J"), sublist2);


### PR DESCRIPTION
`AbstractMutableList.SubList.add(int index, T element)` throws `IndexOutOfBoundsException` when adding at index 0 to an empty SubList. This violates the `java.util.List` contract, which specifies that `add(index, element)` accepts indices in the range `[0, size]`.

The bug is in `SubList.checkIfOutOfBounds`, which uses `>=`:

```java
private void checkIfOutOfBounds(int index)
{
    if (index >= this.size || index < 0)
    {
        throw new IndexOutOfBoundsException("Index: " + index + " Size: " + this.size);
    }
}
```

This check is shared by `get`, `set`, `remove`, and `add`. It is correct for `get`, `set`, and `remove` (valid range `[0, size)`), but wrong for `add` (valid range `[0, size]`).

By comparison, `java.util.ArrayList.SubList` uses two separate checks:

- `Objects.checkIndex(index, size)` for `get`, `set`, `remove` — rejects `index >= size`
- `rangeCheckForAdd(index)` for `add`, `addAll` — uses `index > size`, allowing `index == size`

### Reproducer

```java
List<Integer> list = Lists.mutable.with(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
List<Integer> sublist  = list.subList(3, 6);
List<Integer> sublist2 = sublist.subList(0, 2);
sublist2.clear();
sublist2.add(0, 99);  // IndexOutOfBoundsException: Index: 0 Size: 0
```

The same sequence works correctly with `java.util.ArrayList`.

### Test output

`ArrayListTest.List_subList` passes:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`FastListTest.List_subList` fails:

```
java.lang.IndexOutOfBoundsException: Index: 0 Size: 0
	at o.e.c.impl.list.mutable.AbstractMutableList$SubList.checkIfOutOfBounds(AbstractMutableList.java:859)
	at o.e.c.impl.list.mutable.AbstractMutableList$SubList.add(AbstractMutableList.java:711)
	at o.e.c.test.list.ListTestCase.List_subList(ListTestCase.java:222)
```

### Fix

Inline the bounds check in `SubList.add(int, T)` with `>` instead of `>=`, consistent with `ArrayList.SubList.rangeCheckForAdd`:

```java
@Override
public void add(int index, T element)
{
    if (index > this.size || index < 0)
    {
        throw new IndexOutOfBoundsException("Index: " + index + " Size: " + this.size);
    }
    this.original.add(index + this.offset, element);
    this.size++;
    this.updateSize(1);
}
```

### Note

The single-arg `SubList.add(T)` was unaffected because it bypasses `checkIfOutOfBounds` entirely, inserting directly at `this.offset + this.size`. This masked the bug in most test scenarios.
