### PR TITLE
remove some build warnings

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/CollectionsThreadFactory.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/CollectionsThreadFactory.java
@@ -24,10 +24,7 @@ public final class CollectionsThreadFactory
     CollectionsThreadFactory(String poolPrefix, boolean useDaemonThreads)
     {
         this.isDaemon = useDaemonThreads;
-        SecurityManager securityManager = System.getSecurityManager();
-        this.group = securityManager == null
-                ? Thread.currentThread().getThreadGroup()
-                : securityManager.getThreadGroup();
+        this.group = Thread.currentThread().getThreadGroup();
         this.namePrefix = poolPrefix + " pool- thread-";
     }
 

--- a/jcstress-tests/pom.xml
+++ b/jcstress-tests/pom.xml
@@ -84,6 +84,7 @@
 
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
         <junit.version>4.13.2</junit.version>
         <jmh.version>1.37</jmh.version>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.fork>true</maven.compiler.fork>
         <maven.compiler.meminitial>2048m</maven.compiler.meminitial>
         <maven.compiler.maxmem>2048m</maven.compiler.maxmem>

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -98,6 +98,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
+
         </plugins>
     </build>
 


### PR DESCRIPTION
# Remove Maven Build WARNINGs

## Context
The build shows 7 distinct warning categories. Removing them improves build hygiene, eliminates deprecated API usage before Java removes them, and reduces noise that hides real issues.

---

## Warning Categories & Fixes

### 1. `maven-enforcer-plugin` version missing — **jcstress-tests/pom.xml:85**

**Warning:**
```
'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing
```

**Fix:** Add explicit version in `jcstress-tests/pom.xml`:
```xml
<plugin>
    <artifactId>maven-enforcer-plugin</artifactId>
    <version>3.5.0</version>  <!-- add this -->
</plugin>
```
Version `3.5.0` is already used in the parent `pom.xml` profile.

**File:** `jcstress-tests/pom.xml` line ~85

---

### 2. `system modules path not set in conjunction with -source 17` — **all modules**

**Warning:** Appears in every compiled module.

**Root cause:** `pom.xml` uses deprecated `maven.compiler.source`/`maven.compiler.target` properties instead of `--release`.

**Fix:** In root `pom.xml`, replace:
```xml
<maven.compiler.source>17</maven.compiler.source>
<maven.compiler.target>17</maven.compiler.target>
```
with:
```xml
<maven.compiler.release>17</maven.compiler.release>
```
`--release` sets source, target, and the system API all at once, eliminating the warning.

**File:** `pom.xml` lines ~133-137

---

### 3. `SecurityManager` deprecated for removal — **CollectionsThreadFactory.java:27**

**Warning:**
```
[removal] SecurityManager in java.lang has been deprecated and marked for removal
[removal] getSecurityManager() in System has been deprecated and marked for removal
```

**Fix:** Remove the `SecurityManager` conditional; always use the fallback:
```java
// Before:
SecurityManager securityManager = System.getSecurityManager();
this.group = securityManager == null
        ? Thread.currentThread().getThreadGroup()
        : securityManager.getThreadGroup();

// After:
this.group = Thread.currentThread().getThreadGroup();
```

**File:** `eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/CollectionsThreadFactory.java` lines ~27-30

---

### 4. Maven shade plugin overlapping resources — **jcstress-tests shading**

**Warnings:**
```
jna-5.8.0.jar, jna-platform-5.8.0.jar define 3 overlapping resources: META-INF/AL2.0, META-INF/LGPL2.1, META-INF/LICENSE
eclipse-collections JARs define 3 overlapping: LICENSE-EDL-1.0.txt, LICENSE-EPL-1.0.txt, about.html
All JARs define overlapping: META-INF/MANIFEST.MF
```

**Fix:** Add exclusion/transformer rules to the shade plugin in `jcstress-tests/pom.xml`. The `ManifestResourceTransformer` already handles `MANIFEST.MF`. For LICENSE files, add an `ApacheLicenseResourceTransformer` or simply exclude the duplicates:
```xml
<filters>
    <filter>
        <artifact>net.java.dev.jna:*</artifact>
        <excludes>
            <exclude>META-INF/AL2.0</exclude>
            <exclude>META-INF/LGPL2.1</exclude>
        </excludes>
    </filter>
    <filter>
        <artifact>org.eclipse.collections:eclipse-collections-api</artifact>
        <excludes>
            <exclude>LICENSE-EDL-1.0.txt</exclude>
            <exclude>LICENSE-EPL-1.0.txt</exclude>
            <exclude>about.html</exclude>
        </excludes>
    </filter>
</filters>
```

**File:** `jcstress-tests/pom.xml`

---
[build-before.txt](https://github.com/user-attachments/files/25884249/build-before.txt)
[build-after.txt](https://github.com/user-attachments/files/25884825/build-after.txt)

