### PR TITLE
Provide efficient removeIf implementation for FastList (#147)

### DIFF
--- a/.idea/eclipse-collections.iml
+++ b/.idea/eclipse-collections.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -116,6 +116,25 @@ public class FastList<T>
         implements Externalizable, RandomAccess, BatchIterable<T>
 {
     private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean removeIf(java.util.function.Predicate<? super T> filter)
+    {
+        int currentIndex = 0;
+        for(int i = 0 ; i < this.size ; i++)
+        {
+            T val = this.items[i];
+            if(!filter.test(val))
+            {
+                this.items[currentIndex] = val;
+                currentIndex++;
+            }
+        }
+        boolean changed = currentIndex != this.size;
+        this.wipeAndResetTheEnd(currentIndex);
+        return changed;
+    }
+
     private static final Object[] DEFAULT_SIZED_EMPTY_ARRAY = {};
     private static final Object[] ZERO_SIZED_ARRAY = {};
     private static final int MAXIMUM_ARRAY_SIZE = Integer.MAX_VALUE - 8;

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -52,6 +52,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
@@ -1239,5 +1240,13 @@ public class FastListTest extends AbstractListTestCase
     public void testNegativeInitialCapacity()
     {
         assertThrows(IllegalArgumentException.class, () -> new FastList<>(-1));
+    }
+    @Test
+    public void removeIf_java8()
+    {
+        FastList<Integer> list = FastList.newListWith(1, 2, 3, 4, 5);
+        boolean changed = list.removeIf(i -> i % 2 == 0);
+        Assert.assertTrue(changed);
+        Assert.assertEquals(FastList.newListWith(1, 3, 5), list);
     }
 }


### PR DESCRIPTION
## Summary
Provides an efficient override of `removeIf(Predicate)` in `FastList` 
instead of falling back to the JDK default which uses an Iterator.

## Changes
- Overridden `removeIf` in `FastList` using direct array traversal
- Added tests in `FastListTest`

Closes #147