### PR TITLE
Add EnumUniverse: ClassValue-based cache for enum constants

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/EnumUniverse.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/EnumUniverse.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.utility.internal;
+
+import java.util.Objects;
+
+/**
+ * A cached, GC-aware accessor for the universe (array of all constants) of an enum type.
+ * <p>
+ * {@code Class.getEnumConstants()} allocates a defensive copy on every call. This class
+ * uses a {@link ClassValue}-based cache to eliminate that overhead for hot-path operations
+ * in enum-optimized collections ({@code MutableEnumSet}, {@code MutableEnumMap}, etc.).
+ * <p>
+ * The backing array is never exposed; all access goes through {@link #size()} and
+ * {@link #fromOrdinal(int)}.
+ *
+ * @since 14.0
+ */
+public final class EnumUniverse<E extends Enum<E>>
+{
+    @SuppressWarnings("rawtypes")
+    private static final ClassValue<EnumUniverse<?>> CACHE = new ClassValue<>()
+    {
+        @Override
+        protected EnumUniverse<?> computeValue(Class<?> type)
+        {
+            return new EnumUniverse<>(type.asSubclass(Enum.class).getEnumConstants());
+        }
+    };
+
+    private final E[] constants;
+
+    private EnumUniverse(E[] constants)
+    {
+        this.constants = Objects.requireNonNull(constants);
+    }
+
+    /**
+     * Returns the cached {@code EnumUniverse} for the given enum type.
+     *
+     * @param enumClass the enum class; must be a direct enum type, not an anonymous subclass
+     * @throws IllegalArgumentException if {@code enumClass} is not a direct enum type
+     */
+    @SuppressWarnings("unchecked")
+    public static <E extends Enum<E>> EnumUniverse<E> forClass(Class<E> enumClass)
+    {
+        if (!enumClass.isEnum())
+        {
+            throw new IllegalArgumentException(enumClass + " is not a direct enum type");
+        }
+        return (EnumUniverse<E>) CACHE.get(enumClass);
+    }
+
+    /**
+     * Returns the enum constant with the given ordinal.
+     */
+    public E fromOrdinal(int ordinal)
+    {
+        return this.constants[ordinal];
+    }
+
+    /**
+     * Returns the number of constants in the enum type.
+     */
+    public int size()
+    {
+        return this.constants.length;
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/package-info.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2026 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,10 +13,13 @@
  * <p>
  *     All the iteration patterns in this package are internal. It is used by iterators specialized for various collections.
  * <p>
- *     This package contains 10 Iteration implementations:
+ *     This package contains the following internal utilities:
  * <ul>
  *     <li>
  *          {@link org.eclipse.collections.impl.utility.internal.DefaultSpeciesNewStrategy} - creates a new instance of a collection based on the class type of collection.
+ *     </li>
+ *     <li>
+ *          {@link org.eclipse.collections.impl.utility.internal.EnumUniverse} - a cached, GC-aware accessor for the universe (array of all constants) of an enum type.
  *     </li>
  *     <li>
  *          {@link org.eclipse.collections.impl.utility.internal.InternalArrayIterate} -  a final class with static iterator methods.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/EnumUniverseTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/EnumUniverseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.utility.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EnumUniverseTest
+{
+    private enum Color
+    {
+        RED, GREEN, BLUE
+    }
+
+    private enum Singleton
+    {
+        INSTANCE
+    }
+
+    private enum WithBody
+    {
+        VALUE
+        {
+            @Override
+            public String toString()
+            {
+                return "custom";
+            }
+        }
+    }
+
+    @Test
+    public void size()
+    {
+        assertEquals(3, EnumUniverse.forClass(Color.class).size());
+        assertEquals(1, EnumUniverse.forClass(Singleton.class).size());
+        assertEquals(1, EnumUniverse.forClass(WithBody.class).size());
+    }
+
+    @Test
+    public void fromOrdinal()
+    {
+        EnumUniverse<Color> universe = EnumUniverse.forClass(Color.class);
+        assertEquals(Color.RED, universe.fromOrdinal(0));
+        assertEquals(Color.GREEN, universe.fromOrdinal(1));
+        assertEquals(Color.BLUE, universe.fromOrdinal(2));
+    }
+
+    @Test
+    public void fromOrdinalOutOfBounds()
+    {
+        EnumUniverse<Color> universe = EnumUniverse.forClass(Color.class);
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> universe.fromOrdinal(-1));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> universe.fromOrdinal(3));
+    }
+
+    @Test
+    public void caching()
+    {
+        assertSame(
+                EnumUniverse.forClass(Color.class),
+                EnumUniverse.forClass(Color.class));
+    }
+
+    @Test
+    public void rejectsAnonymousEnumSubclass()
+    {
+        @SuppressWarnings("unchecked")
+        Class<WithBody> anonymousClass = (Class<WithBody>) WithBody.VALUE.getClass();
+        assertThrows(IllegalArgumentException.class, () -> EnumUniverse.forClass(anonymousClass));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void rejectsNonEnumClass()
+    {
+        Class notAnEnum = Object.class;
+        assertThrows(IllegalArgumentException.class, () -> EnumUniverse.forClass(notAnEnum));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `EnumUniverse<E>`, a `ClassValue`-based cached accessor for the universe (array of all constants) of an enum type
- First building block for enum-optimized collections (`MutableEnumSet`, `MutableEnumMap`, etc.)
- `Class.getEnumConstants()` allocates a defensive copy on every call — `EnumUniverse` eliminates that overhead via a GC-aware, thread-safe `ClassValue` cache

## Changes

### `eclipse-collections/.../impl/utility/internal/EnumUniverse.java` (new)

- `forClass(Class<E>)` — factory method with `ClassValue` cache lookup; rejects non-enum types and anonymous enum subclasses via `isEnum()` guard
- `fromOrdinal(int)` — returns the enum constant at the given ordinal
- `size()` — returns the number of constants in the enum type
- Backing array never exposed (encapsulation by design)
- `Objects.requireNonNull` in constructor for defense-in-depth against null constants array

### `unit-tests/.../impl/utility/internal/EnumUniverseTest.java` (new)

6 tests covering:
- `size()` for multi-constant, singleton, and body-override enums
- `fromOrdinal()` for all constants of a 3-value enum
- Out-of-bounds ordinal (negative and beyond range)
- `ClassValue` caching identity (`assertSame`)
- Rejection of anonymous enum subclasses (`WithBody.VALUE.getClass()`)
- Rejection of non-enum classes via raw type (`Object.class`)

### `eclipse-collections/.../impl/utility/internal/package-info.java` (updated)

- Added `EnumUniverse` to the package documentation listing

## Design decisions

| Decision | Rationale |
|----------|-----------|
| `ClassValue` over `ConcurrentHashMap` | GC-aware — entries evicted on class unload, handles OSGi and dynamic classloaders correctly |
| `asSubclass(Enum.class)` in `computeValue` | Clearer failure mode than raw cast; runtime check at cache population |
| `isEnum()` guard in `forClass` | Anonymous enum subclasses (`Foo.VALUE.getClass()`) have `isEnum() == false`; rejects them early with a clear message |
| `Objects.requireNonNull` in constructor | Defense-in-depth — structurally prevents a null-constants `EnumUniverse` from entering the cache |
| Minimal API (`size` + `fromOrdinal`) | Only what `MutableEnumSet`/`MutableEnumMap` need; no array exposure, no mutable collection wrapper |
| `forClass` naming over `of` | `of` is idiomatic in Eclipse Collections for creating instances with values; `forClass` communicates cache lookup semantics |
| `fromOrdinal` naming over `get`/`valueOf` | Explicit about the ordinal→constant mapping; avoids collision with `Enum.valueOf(String)` |

## Test plan

- [x] `mvn test -Dtest=EnumUniverseTest` — 6/6 pass
- [x] `mvn checkstyle:check` — 0 violations

Ref: #1798

🤖 Generated with [Claude Code](https://claude.com/claude-code)