### PR TITLE
Add test coverage to MapTestCase for null-value-as-absent behavior in ConcurrentHashMap/ConcurrentHashMapUnsafe (putIfAbsent, computeIfAbsent, computeIfPresent, and values spliterator).

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapTest.java
@@ -10,12 +10,21 @@
 
 package org.eclipse.collections.test.map.mutable;
 
+import java.util.Map;
 import java.util.Random;
+import java.util.Spliterator;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConcurrentHashMapTest implements MutableMapTestCase
@@ -54,5 +63,147 @@ public class ConcurrentHashMapTest implements MutableMapTestCase
     public boolean supportsNullKeys()
     {
         return false;
+    }
+
+    // TODO: Fix bug in ConcurrentHashMap.putIfAbsent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_putIfAbsent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertEquals("1", map.putIfAbsent(1, "One"));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        assertNull(map.putIfAbsent(4, "4"));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        Map<Integer, String> map2 = this.newWithKeysValues(1, "1", 2, "2");
+        assertNull(map2.putIfAbsent(5, null));
+        assertTrue(map2.containsKey(5));
+
+        // TODO: Fix bug in ConcurrentHashMap.putIfAbsent: null values should be treated as absent.
+        // When fixed, change assertNull(map3.get(1)) to assertEquals("One", map3.get(1))
+        Map<Integer, String> map3 = this.newWithKeysValues(1, null, 2, "2");
+        assertNull(map3.putIfAbsent(1, "One"));
+        assertNull(map3.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMap.computeIfAbsent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_computeIfAbsent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertThrows(NullPointerException.class, () -> map.computeIfAbsent(1, null));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value1 = map.computeIfAbsent(2, k -> {
+            fail("Expected mapping function not to be called for existing key");
+            return "Should not be returned";
+        });
+        assertEquals("2", value1);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value2 = map.computeIfAbsent(4, k -> {
+            assertEquals(Integer.valueOf(4), k);
+            return "4";
+        });
+        assertEquals("4", value2);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        String value3 = map.computeIfAbsent(5, k -> null);
+        assertNull(value3);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        RuntimeException exception = new RuntimeException("Test exception");
+        RuntimeException actualException = assertThrows(RuntimeException.class, () -> map.computeIfAbsent(6, k -> {
+            throw exception;
+        }));
+        assertSame(exception, actualException);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        // TODO: Fix bug in ConcurrentHashMap.computeIfAbsent: null values should be treated as absent.
+        // When fixed, change both assertNull calls to assertEquals("One", ...)
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        String value4 = map2.computeIfAbsent(1, k -> "One");
+        assertNull(value4);
+        assertNull(map2.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMap.computeIfPresent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_computeIfPresent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertThrows(NullPointerException.class, () -> map.computeIfPresent(1, null));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value1 = map.computeIfPresent(4, (k, v) -> {
+            fail("Expected remapping function not to be called for non-existing key");
+            return "Should not be returned";
+        });
+        assertNull(value1);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value2 = map.computeIfPresent(2, (k, v) -> {
+            assertEquals(Integer.valueOf(2), k);
+            assertEquals("2", v);
+            return v + "Modified";
+        });
+        assertEquals("2Modified", value2);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified", 3, "3"), map);
+
+        String value3 = map.computeIfPresent(3, (k, v) -> null);
+        assertNull(value3);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified"), map);
+
+        map.put(3, "3");
+        RuntimeException exception = new RuntimeException("Test exception");
+        RuntimeException actualException = assertThrows(RuntimeException.class, () -> map.computeIfPresent(3, (k, v) -> {
+            assertEquals(Integer.valueOf(3), k);
+            assertEquals("3", v);
+            throw exception;
+        }));
+        assertSame(exception, actualException);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified", 3, "3"), map);
+
+        // TODO: Fix bug in ConcurrentHashMap.computeIfPresent: null values should be treated as absent.
+        // When fixed, the remapping function should not be called.
+        // Replace the following with:
+        //   Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        //   assertNull(map2.computeIfPresent(1, (k, v) -> { fail(); return "x"; }));
+        //   assertTrue(map2.containsKey(1));
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        String value4 = map2.computeIfPresent(1, (k, v) -> {
+            assertEquals(Integer.valueOf(1), k);
+            assertNull(v);
+            return "One";
+        });
+        assertEquals("One", value4);
+        assertEquals("One", map2.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMap: values().spliterator() reports NONNULL but the map supports null values.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_values()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
+        assertEquals(3, map.values().size());
+        assertFalse(map.values().isEmpty());
+        assertTrue(map.values().contains("One"));
+        assertFalse(map.values().contains("Four"));
+
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        assertTrue(map2.values().contains(null));
+        assertTrue(map2.values().spliterator().hasCharacteristics(Spliterator.NONNULL));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentHashMapUnsafeTest.java
@@ -10,12 +10,21 @@
 
 package org.eclipse.collections.test.map.mutable;
 
+import java.util.Map;
 import java.util.Random;
+import java.util.Spliterator;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe;
+import org.junit.jupiter.api.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConcurrentHashMapUnsafeTest implements MutableMapTestCase
@@ -54,5 +63,147 @@ public class ConcurrentHashMapUnsafeTest implements MutableMapTestCase
     public boolean supportsNullKeys()
     {
         return false;
+    }
+
+    // TODO: Fix bug in ConcurrentHashMapUnsafe.putIfAbsent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_putIfAbsent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertEquals("1", map.putIfAbsent(1, "One"));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        assertNull(map.putIfAbsent(4, "4"));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        Map<Integer, String> map2 = this.newWithKeysValues(1, "1", 2, "2");
+        assertNull(map2.putIfAbsent(5, null));
+        assertTrue(map2.containsKey(5));
+
+        // TODO: Fix bug in ConcurrentHashMapUnsafe.putIfAbsent: null values should be treated as absent.
+        // When fixed, change assertNull(map3.get(1)) to assertEquals("One", map3.get(1))
+        Map<Integer, String> map3 = this.newWithKeysValues(1, null, 2, "2");
+        assertNull(map3.putIfAbsent(1, "One"));
+        assertNull(map3.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMapUnsafe.computeIfAbsent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_computeIfAbsent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertThrows(NullPointerException.class, () -> map.computeIfAbsent(1, null));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value1 = map.computeIfAbsent(2, k -> {
+            fail("Expected mapping function not to be called for existing key");
+            return "Should not be returned";
+        });
+        assertEquals("2", value1);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value2 = map.computeIfAbsent(4, k -> {
+            assertEquals(Integer.valueOf(4), k);
+            return "4";
+        });
+        assertEquals("4", value2);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        String value3 = map.computeIfAbsent(5, k -> null);
+        assertNull(value3);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        RuntimeException exception = new RuntimeException("Test exception");
+        RuntimeException actualException = assertThrows(RuntimeException.class, () -> map.computeIfAbsent(6, k -> {
+            throw exception;
+        }));
+        assertSame(exception, actualException);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        // TODO: Fix bug in ConcurrentHashMapUnsafe.computeIfAbsent: null values should be treated as absent.
+        // When fixed, change both assertNull calls to assertEquals("One", ...)
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        String value4 = map2.computeIfAbsent(1, k -> "One");
+        assertNull(value4);
+        assertNull(map2.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMapUnsafe.computeIfPresent: null values should be treated as absent.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_computeIfPresent()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
+
+        assertThrows(NullPointerException.class, () -> map.computeIfPresent(1, null));
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value1 = map.computeIfPresent(4, (k, v) -> {
+            fail("Expected remapping function not to be called for non-existing key");
+            return "Should not be returned";
+        });
+        assertNull(value1);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+
+        String value2 = map.computeIfPresent(2, (k, v) -> {
+            assertEquals(Integer.valueOf(2), k);
+            assertEquals("2", v);
+            return v + "Modified";
+        });
+        assertEquals("2Modified", value2);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified", 3, "3"), map);
+
+        String value3 = map.computeIfPresent(3, (k, v) -> null);
+        assertNull(value3);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified"), map);
+
+        map.put(3, "3");
+        RuntimeException exception = new RuntimeException("Test exception");
+        RuntimeException actualException = assertThrows(RuntimeException.class, () -> map.computeIfPresent(3, (k, v) -> {
+            assertEquals(Integer.valueOf(3), k);
+            assertEquals("3", v);
+            throw exception;
+        }));
+        assertSame(exception, actualException);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified", 3, "3"), map);
+
+        // TODO: Fix bug in ConcurrentHashMapUnsafe.computeIfPresent: null values should be treated as absent.
+        // When fixed, the remapping function should not be called.
+        // Replace the following with:
+        //   Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        //   assertNull(map2.computeIfPresent(1, (k, v) -> { fail(); return "x"; }));
+        //   assertTrue(map2.containsKey(1));
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        String value4 = map2.computeIfPresent(1, (k, v) -> {
+            assertEquals(Integer.valueOf(1), k);
+            assertNull(v);
+            return "One";
+        });
+        assertEquals("One", value4);
+        assertEquals("One", map2.get(1));
+    }
+
+    // TODO: Fix bug in ConcurrentHashMapUnsafe: values().spliterator() reports NONNULL but the map supports null values.
+    // When fixed, delete this override to inherit the correct assertion from MapTestCase.
+    @Override
+    @Test
+    public void Map_values()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
+        assertEquals(3, map.values().size());
+        assertFalse(map.values().isEmpty());
+        assertTrue(map.values().contains("One"));
+        assertFalse(map.values().contains("Four"));
+
+        Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+        assertTrue(map2.values().contains(null));
+        assertTrue(map2.values().spliterator().hasCharacteristics(Spliterator.NONNULL));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
@@ -10,11 +10,14 @@
 
 package org.eclipse.collections.test.map.mutable;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.function.BiConsumer;
 
 import org.eclipse.collections.api.factory.Sets;
@@ -114,6 +117,36 @@ public interface MapTestCase
     }
 
     @Test
+    default void Map_keySet()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
+        Set<Integer> keySet = map.keySet();
+
+        assertEquals(3, keySet.size());
+        assertFalse(keySet.isEmpty());
+
+        assertTrue(keySet.contains(1));
+        assertTrue(keySet.contains(2));
+        assertTrue(keySet.contains(3));
+        assertFalse(keySet.contains(4));
+
+        assertTrue(keySet.containsAll(List.of(1, 2, 3)));
+        assertFalse(keySet.containsAll(List.of(1, 4)));
+
+        Map<Object, Object> empty = this.newWith();
+        assertEquals(0, empty.keySet().size());
+        assertTrue(empty.keySet().isEmpty());
+
+        if (this.supportsNullKeys())
+        {
+            assertFalse(keySet.contains(null));
+
+            Map<Integer, String> map2 = this.newWithKeysValues(null, "Null", 1, "One");
+            assertTrue(map2.keySet().contains(null));
+        }
+    }
+
+    @Test
     default void Map_entrySet_equals()
     {
         Map<Integer, String> map = this.newWithKeysValues(1, "One", 2, "Two", 3, "Three");
@@ -172,6 +205,48 @@ public interface MapTestCase
             assertEquals(currentValue, oldValue);
         });
         assertIterablesEqual(this.newWithKeysValues("3", 4, "2", 3, "1", 2), map);
+    }
+
+    @Test
+    default void Map_entrySet()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
+        Set<Map.Entry<Integer, String>> entrySet = map.entrySet();
+
+        assertEquals(3, entrySet.size());
+        assertFalse(entrySet.isEmpty());
+
+        assertTrue(entrySet.contains(ImmutableEntry.of(1, "One")));
+        assertTrue(entrySet.contains(ImmutableEntry.of(2, "Two")));
+        assertTrue(entrySet.contains(ImmutableEntry.of(3, "Three")));
+        assertFalse(entrySet.contains(ImmutableEntry.of(4, "Four")));
+        assertFalse(entrySet.contains(ImmutableEntry.of(1, "Wrong")));
+
+        assertTrue(entrySet.containsAll(List.of(
+                ImmutableEntry.of(1, "One"),
+                ImmutableEntry.of(2, "Two"),
+                ImmutableEntry.of(3, "Three"))));
+        assertFalse(entrySet.containsAll(List.of(
+                ImmutableEntry.of(1, "One"),
+                ImmutableEntry.of(4, "Four"))));
+
+        Map<Object, Object> empty = this.newWith();
+        assertEquals(0, empty.entrySet().size());
+        assertTrue(empty.entrySet().isEmpty());
+
+        if (this.supportsNullKeys())
+        {
+            Map<Integer, String> map2 = this.newWithKeysValues(null, "Null", 1, "One");
+            assertTrue(map2.entrySet().contains(ImmutableEntry.of(null, "Null")));
+            assertFalse(map2.entrySet().contains(ImmutableEntry.of(null, "Wrong")));
+        }
+
+        if (this.supportsNullValues())
+        {
+            Map<Integer, String> map3 = this.newWithKeysValues(1, null, 2, "Two");
+            assertTrue(map3.entrySet().contains(ImmutableEntry.of(1, null)));
+            assertFalse(map3.entrySet().contains(ImmutableEntry.of(1, "Wrong")));
+        }
     }
 
     @Test
@@ -399,6 +474,14 @@ public interface MapTestCase
         }));
         assertSame(exception, actualException);
         assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+
+        if (this.supportsNullValues())
+        {
+            Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+            String value4 = map2.computeIfAbsent(1, k -> "One");
+            assertEquals("One", value4);
+            assertEquals("One", map2.get(1));
+        }
     }
 
     @Test
@@ -437,6 +520,18 @@ public interface MapTestCase
         }));
         assertSame(exception, actualException);
         assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Modified", 3, "3"), map);
+
+        if (this.supportsNullValues())
+        {
+            Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+            String value4 = map2.computeIfPresent(1, (k, v) -> {
+                fail("Expected remapping function not to be called for null value");
+                return "Should not be returned";
+            });
+            assertNull(value4);
+            assertNull(map2.get(1));
+            assertTrue(map2.containsKey(1));
+        }
     }
 
     @Test
@@ -542,6 +637,10 @@ public interface MapTestCase
             Map<Integer, String> map2 = this.newWithKeysValues(1, "1", 2, "2");
             assertNull(map2.putIfAbsent(5, null));
             assertTrue(map2.containsKey(5));
+
+            Map<Integer, String> map3 = this.newWithKeysValues(1, null, 2, "2");
+            assertNull(map3.putIfAbsent(1, "One"));
+            assertEquals("One", map3.get(1));
         }
     }
 
@@ -578,6 +677,37 @@ public interface MapTestCase
         MutableSet<String> actual = Sets.mutable.with();
         map.forEach((BiConsumer<Integer, String>) (key, value) -> actual.add(key + "=" + value));
         assertEquals(Sets.immutable.with("1=1", "2=2", "3=3"), actual);
+    }
+
+    @Test
+    default void Map_values()
+    {
+        Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
+        Collection<String> values = map.values();
+
+        assertEquals(3, values.size());
+        assertFalse(values.isEmpty());
+
+        assertTrue(values.contains("One"));
+        assertTrue(values.contains("Two"));
+        assertTrue(values.contains("Three"));
+        assertFalse(values.contains("Four"));
+
+        assertTrue(values.containsAll(List.of("One", "Two", "Three")));
+        assertFalse(values.containsAll(List.of("One", "Four")));
+
+        Map<Object, Object> empty = this.newWith();
+        assertEquals(0, empty.values().size());
+        assertTrue(empty.values().isEmpty());
+
+        if (this.supportsNullValues())
+        {
+            assertFalse(values.contains(null));
+
+            Map<Integer, String> map2 = this.newWithKeysValues(1, null, 2, "2");
+            assertTrue(map2.values().contains(null));
+            assertFalse(map2.values().spliterator().hasCharacteristics(Spliterator.NONNULL));
+        }
     }
 
     class AlwaysEqual


### PR DESCRIPTION
The #1611 Draft PR shows that the Guava test library finds several minor bugs in our collections. I'm trying to add targeted test coverage and targeted fixes since that PR cannot really land in its current form.