### PR TITLE
Update : JMH Scala tests compilation errors with scala 2.13

### DIFF
--- a/jmh-scala-tests/pom.xml
+++ b/jmh-scala-tests/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parallel-collections_2.13</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang.version}</version>

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/AnagramSetScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/AnagramSetScalaTest.scala
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.junit.Assert
 
 import scala.collection.mutable
+import scala.collection.parallel.CollectionConverters._
 import scala.collection.parallel.immutable.ParSet
 
 object AnagramSetScalaTest
@@ -42,7 +43,7 @@ object AnagramSetScalaTest
     def serial_eager_scala(): Unit =
     {
         WORDS
-                .groupBy(Alphagram.apply)
+                .groupBy(Alphagram.apply(_))
                 .values
                 .filter(_.size >= SIZE_THRESHOLD)
                 .toSeq.sortBy(_.size)
@@ -54,7 +55,7 @@ object AnagramSetScalaTest
     def serial_lazy_scala(): Unit =
     {
         WORDS.view
-                .groupBy(Alphagram.apply)
+                .groupBy(Alphagram.apply(_))
                 .values
                 .filter(_.size >= SIZE_THRESHOLD)
                 .toSeq.sortBy(_.size)
@@ -66,7 +67,7 @@ object AnagramSetScalaTest
     def parallel_lazy_scala(): Unit =
     {
         val toBuffer: mutable.Buffer[ParSet[String]] = WORDS.par
-                .groupBy(Alphagram.apply)
+                .groupBy(Alphagram.apply(_))
                 .values
                 .filter(_.size >= SIZE_THRESHOLD)
                 .toBuffer

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/AnySatisfyScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/AnySatisfyScalaTest.scala
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.jmh
 import org.junit.Assert
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 
 object AnySatisfyScalaTest
 {

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CollectScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CollectScalaTest.scala
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.jmh
 import org.junit.Assert
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 
 object CollectScalaTest
 {

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CountScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CountScalaTest.scala
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.jmh
 import org.junit.Assert
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 
 object CountScalaTest
 {
@@ -58,10 +59,10 @@ object CountScalaTest
         // deoptimize scala.collection.IndexedSeqOptimized.foreach()
         if (megamorphicWarmupLevel > 1)
         {
-            this.integers.view.foreach(Assert.assertNotNull)
+            this.integers.view.foreach(Assert.assertNotNull(_))
             this.integers.view.foreach(each => Assert.assertEquals(each, each))
             this.integers.view.foreach(each => Assert.assertNotEquals(null, each))
-            this.integers.par.foreach(Assert.assertNotNull)
+            this.integers.par.foreach(Assert.assertNotNull(_))
             this.integers.par.foreach(each => Assert.assertEquals(each, each))
             this.integers.par.foreach(each => Assert.assertNotEquals(null, each))
         }
@@ -70,7 +71,7 @@ object CountScalaTest
         // deoptimize scala.collection.IndexedSeqOptimized.foreach()
         if (megamorphicWarmupLevel > 2)
         {
-            this.integers.foreach(Assert.assertNotNull)
+            this.integers.foreach(Assert.assertNotNull(_))
             this.integers.foreach(each => Assert.assertEquals(each, each))
             this.integers.foreach(each => Assert.assertNotEquals(null, each))
         }

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CountSetScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/CountSetScalaTest.scala
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.jmh
 import org.junit.Assert
 
 import scala.collection.mutable
+import scala.collection.parallel.CollectionConverters._
 
 object CountSetScalaTest
 {
@@ -58,10 +59,10 @@ object CountSetScalaTest
         // deoptimize scala.collection.IndexedSeqOptimized.foreach()
         if (megamorphicWarmupLevel > 1)
         {
-            this.integers.view.foreach(Assert.assertNotNull)
+            this.integers.view.foreach(Assert.assertNotNull(_))
             this.integers.view.foreach(each => Assert.assertEquals(each, each))
             this.integers.view.foreach(each => Assert.assertNotEquals(null, each))
-            this.integers.par.foreach(Assert.assertNotNull)
+            this.integers.par.foreach(Assert.assertNotNull(_))
             this.integers.par.foreach(each => Assert.assertEquals(each, each))
             this.integers.par.foreach(each => Assert.assertNotEquals(null, each))
         }
@@ -70,7 +71,7 @@ object CountSetScalaTest
         // deoptimize scala.collection.IndexedSeqOptimized.foreach()
         if (megamorphicWarmupLevel > 2)
         {
-            this.integers.foreach(Assert.assertNotNull)
+            this.integers.foreach(Assert.assertNotNull(_))
             this.integers.foreach(each => Assert.assertEquals(each, each))
             this.integers.foreach(each => Assert.assertNotEquals(null, each))
         }

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/FunctionalInterfaceScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/FunctionalInterfaceScalaTest.scala
@@ -14,6 +14,7 @@ import org.junit.Assert
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 
 object FunctionalInterfaceScalaTest
 {

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/GroupBySetScalaTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/GroupBySetScalaTest.scala
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.jmh
 
 import org.junit.Assert
 
-import scala.collection.IterableView
+import scala.collection.View
 import scala.collection.mutable.HashSet
+import scala.collection.parallel.CollectionConverters._
 import scala.collection.parallel.immutable.ParMap
 import scala.collection.parallel.mutable.ParHashSet
 
@@ -72,52 +73,52 @@ object GroupBySetScalaTest
         }
     }
 
-    def groupBy_unordered_lists_2_keys_serial_lazy_scala(): Map[Boolean, IterableView[Int, HashSet[Int]]] =
+    def groupBy_unordered_lists_2_keys_serial_lazy_scala(): Map[Boolean, View[Int]] =
     {
-        val multimap: Map[Boolean, IterableView[Int, HashSet[Int]]] = this.integers.view.groupBy((each: Int) => each % 2 == 0)
+        val multimap: Map[Boolean, View[Int]] = this.integers.view.groupBy((each: Int) => each % 2 == 0)
         Assert.assertEquals(2, multimap.size)
         multimap
     }
 
     def test_groupBy_unordered_lists_2_keys_serial_lazy_scala(): Unit =
     {
-        val multimap: Map[Boolean, IterableView[Int, HashSet[Int]]] = groupBy_unordered_lists_2_keys_serial_lazy_scala()
-        val evens: IterableView[Int, HashSet[Int]] = multimap(true)
-        val odds: IterableView[Int, HashSet[Int]] = multimap(false)
+        val multimap: Map[Boolean, View[Int]] = groupBy_unordered_lists_2_keys_serial_lazy_scala()
+        val evens: View[Int] = multimap(true)
+        val odds: View[Int] = multimap(false)
         Assert.assertEquals(0.to(999999, 2).toSet, evens.toSet)
         Assert.assertEquals(1.to(999999, 2).toSet, odds.toSet)
     }
 
-    def groupBy_unordered_lists_100_keys_serial_lazy_scala(): Map[Int, IterableView[Int, HashSet[Int]]] =
+    def groupBy_unordered_lists_100_keys_serial_lazy_scala(): Map[Int, View[Int]] =
     {
-        val multimap: Map[Int, IterableView[Int, HashSet[Int]]] = this.integers.view.groupBy((each: Int) => each % 100)
+        val multimap: Map[Int, View[Int]] = this.integers.view.groupBy((each: Int) => each % 100)
         Assert.assertEquals(100, multimap.size)
         multimap
     }
 
     def test_groupBy_unordered_lists_100_keys_serial_lazy_scala(): Unit =
     {
-        val multimap: Map[Int, IterableView[Int, HashSet[Int]]] = groupBy_unordered_lists_100_keys_serial_lazy_scala()
+        val multimap: Map[Int, View[Int]] = groupBy_unordered_lists_100_keys_serial_lazy_scala()
         for (i <- 0 to 99)
         {
-            val integers: IterableView[Int, HashSet[Int]] = multimap(i)
+            val integers: View[Int] = multimap(i)
             Assert.assertEquals(i.to(999999, 100).toSet, integers.toSet)
         }
     }
 
-    def groupBy_unordered_lists_10000_keys_serial_lazy_scala(): Map[Int, IterableView[Int, HashSet[Int]]] =
+    def groupBy_unordered_lists_10000_keys_serial_lazy_scala(): Map[Int, View[Int]] =
     {
-        val multimap: Map[Int, IterableView[Int, HashSet[Int]]] = this.integers.view.groupBy((each: Int) => each % 10000)
+        val multimap: Map[Int, View[Int]] = this.integers.view.groupBy((each: Int) => each % 10000)
         Assert.assertEquals(10000, multimap.size)
         multimap
     }
 
     def test_groupBy_unordered_lists_10000_keys_serial_lazy_scala(): Unit =
     {
-        val multimap: Map[Int, IterableView[Int, HashSet[Int]]] = groupBy_unordered_lists_10000_keys_serial_lazy_scala()
+        val multimap: Map[Int, View[Int]] = groupBy_unordered_lists_10000_keys_serial_lazy_scala()
         for (i <- 0 to 9999)
         {
-            val integers: IterableView[Int, HashSet[Int]] = multimap(i)
+            val integers: View[Int] = multimap(i)
             Assert.assertEquals(i.to(999999, 10000).toSet, integers.toSet)
         }
     }

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/list/ScalaListIterationTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/list/ScalaListIterationTest.scala
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.jmh.list
 
 import scala.collection.mutable
+import scala.collection.parallel.CollectionConverters._
 
 object ScalaListIterationTest
 {

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/map/PresizableHashMap.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/map/PresizableHashMap.scala
@@ -12,13 +12,8 @@ package org.eclipse.collections.impl.jmh.map
 
 class PresizableHashMap[K, V](val _initialSize: Int) extends scala.collection.mutable.HashMap[K, V]
 {
-    private def initialCapacity =
-        if (_initialSize == 0) 1
-        else smallestPowerOfTwoGreaterThan((_initialSize.toLong * 1000 / _loadFactor).asInstanceOf[Int])
-
-    private def smallestPowerOfTwoGreaterThan(n: Int): Int =
-        if (n > 1) Integer.highestOneBit(n - 1) << 1 else 1
-
-    table = new Array(initialCapacity)
-    threshold = ((initialCapacity.toLong * _loadFactor) / 1000).toInt
+    if (_initialSize > 0)
+    {
+        this.sizeHint(_initialSize)
+    }
 }

--- a/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/set/sorted/ScalaSortedSetIterationTest.scala
+++ b/jmh-scala-tests/src/main/scala/org/eclipse/collections/impl/jmh/set/sorted/ScalaSortedSetIterationTest.scala
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.jmh.set.sorted
 
 import scala.collection.{immutable, mutable}
+import scala.collection.parallel.CollectionConverters._
 
 object ScalaSortedSetIterationTest
 {

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -67,6 +67,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parallel-collections_2.13</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang.version}</version>
@@ -170,7 +176,7 @@
                                     com.google.code.findbugs:jsr305:jar
                                 </ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>
-                                    net.openhft:koloboke-impl-jdk8:jar
+                                    com.koloboke:koloboke-impl-jdk8:jar
                                 </ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>


### PR DESCRIPTION
This PR resolves compilation failures in the `jmh-scala-tests` module caused by the migration to Scala 2.13.

### Changes:
- Added `scala-parallel-collections` dependency to `jmh-scala-tests` and `jmh-tests`.
- Updated Scala benchmarks to use `scala.collection.parallel.CollectionConverters` for parallel operations.
- Replaced the depricated `IterableView` with `View` in `GroupBySetScalaTest`.
- Refactored `PresizableHashMap` to use the public `sizeHint` API insted of internal fields that were removed in Scala 2.13.
- Updated `jmh-tests/pom.xml` to ignore dependency analysis warnings for transitive Scala and Koloboke dependencies.

Verified the build with 

`mvn clean install -Pjava-8 -pl jmh-tests,jmh-scala-tests -am -DskipTests`