### PR TITLE
ImmutableMapFactory: Add withMap, ofMapIterable, withMapIterable methods

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.factory.map;
 import java.util.Map;
 
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MapIterable;
 
 public interface ImmutableMapFactory
 {
@@ -61,10 +62,21 @@ public interface ImmutableMapFactory
 
     <K, V> ImmutableMap<K, V> ofMap(Map<? extends K, ? extends V> map);
 
+    <K, V> ImmutableMap<K, V> withMap(Map<? extends K, ? extends V> map);
+
+    <K, V> ImmutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
+
+    <K, V> ImmutableMap<K, V> withMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
+
     /**
-     * Same as {@link #withAll(Map)}.
+     * @deprecated use {@link #withMap(Map)} instead
      */
+    @Deprecated
     <K, V> ImmutableMap<K, V> ofAll(Map<? extends K, ? extends V> map);
 
+    /**
+     * @deprecated use {@link #withMap(Map)} instead
+     */
+    @Deprecated
     <K, V> ImmutableMap<K, V> withAll(Map<? extends K, ? extends V> map);
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import org.eclipse.collections.api.factory.map.ImmutableMapFactory;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MapIterable;
 
 @aQute.bnd.annotation.spi.ServiceProvider(ImmutableMapFactory.class)
 public class ImmutableMapFactoryImpl implements ImmutableMapFactory
@@ -133,23 +134,17 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
     }
 
     /**
-     * @deprecated use {@link #ofAll(Map)} instead (inlineable)
+     * @deprecated use {@link #withMap(Map)} instead (inlineable)
      */
     @Override
     @Deprecated
     public <K, V> ImmutableMap<K, V> ofMap(Map<? extends K, ? extends V> map)
     {
-        return this.ofAll(map);
+        return this.withMap(map);
     }
 
     @Override
-    public <K, V> ImmutableMap<K, V> ofAll(Map<? extends K, ? extends V> map)
-    {
-        return this.withAll(map);
-    }
-
-    @Override
-    public <K, V> ImmutableMap<K, V> withAll(Map<? extends K, ? extends V> map)
+    public <K, V> ImmutableMap<K, V> withMap(Map<? extends K, ? extends V> map)
     {
         if (map.isEmpty())
         {
@@ -184,5 +179,37 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
             default:
                 throw new AssertionError();
         }
+    }
+
+    @Override
+    public <K, V> ImmutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable)
+    {
+        return this.withMapIterable(mapIterable);
+    }
+
+    @Override
+    public <K, V> ImmutableMap<K, V> withMapIterable(MapIterable<? extends K, ? extends V> mapIterable)
+    {
+        return this.withMap(mapIterable);
+    }
+
+    /**
+     * @deprecated use {@link #withMap(Map)} instead
+     */
+    @Override
+    @Deprecated
+    public <K, V> ImmutableMap<K, V> ofAll(Map<? extends K, ? extends V> map)
+    {
+        return this.withAll(map);
+    }
+
+    /**
+     * @deprecated use {@link #withMap(Map)} instead
+     */
+    @Override
+    @Deprecated
+    public <K, V> ImmutableMap<K, V> withAll(Map<? extends K, ? extends V> map)
+    {
+        return this.withMap(map);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
@@ -543,7 +543,7 @@ public class SynchronizedMutableMap<K, V>
     {
         synchronized (this.lock)
         {
-            return Maps.immutable.withAll(this);
+            return Maps.immutable.withMap(this);
         }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
@@ -431,7 +431,7 @@ public class UnmodifiableMutableMap<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.withAll(this);
+        return Maps.immutable.withMap(this);
     }
 
     @Override


### PR DESCRIPTION
Fixes #738

Adds three missing methods to `ImmutableMapFactory` to match `MutableMapFactory`:
- `withMap(Map<? extends K, ? extends V> map)`
- `ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable)`
- `withMapIterable(MapIterable<? extends K, ? extends V> mapIterable)`

Deprecates `ofAll` and `withAll` in favor of `withMap`.

Updates internal callers in `SynchronizedMutableMap` and `UnmodifiableMutableMap` to use `withMap` instead of the deprecated `withAll`.