### PR TITLE
Guard Map and RichIterable equals() against self-reference to avoid StackOverflowError.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
@@ -634,6 +634,10 @@ public final class MultiReaderHashBag<T>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {
             return this.delegate.equals(o);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMap.java
@@ -738,6 +738,10 @@ abstract class AbstractMutableBiMap<K, V> extends AbstractBiMap<K, V> implements
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             return AbstractMutableBiMap.this.delegate.keySet().equals(obj);
         }
 
@@ -991,6 +995,10 @@ abstract class AbstractMutableBiMap<K, V> extends AbstractBiMap<K, V> implements
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             if (obj instanceof Set<?> other)
             {
                 if (other.size() == this.size())

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractListAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractListAdapter.java
@@ -183,6 +183,10 @@ public abstract class AbstractListAdapter<T>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.getDelegate().equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
@@ -348,6 +348,10 @@ public final class ConcurrentMutableHashMap<K, V>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.delegate.equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MapAdapter.java
@@ -179,6 +179,10 @@ public class MapAdapter<K, V>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.delegate.equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -2678,6 +2678,10 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             if (obj instanceof Set<?> other)
             {
                 if (other.size() == this.size())
@@ -3262,6 +3266,10 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             if (obj instanceof Set<?> other)
             {
                 if (other.size() == this.size())

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/mutable/OrderedMapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/ordered/mutable/OrderedMapAdapter.java
@@ -111,6 +111,10 @@ public class OrderedMapAdapter<K, V>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.delegate.equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapter.java
@@ -219,6 +219,10 @@ public class SortedMapAdapter<K, V>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.delegate.equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.java
@@ -226,6 +226,10 @@ public class TreeSortedMap<K, V>
     @Override
     public boolean equals(Object o)
     {
+        if (o == this)
+        {
+            return true;
+        }
         return this.treeMap.equals(o);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -2733,6 +2733,10 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             if (obj instanceof Set<?> other)
             {
                 if (other.size() == this.size())
@@ -3324,6 +3328,10 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         @Override
         public boolean equals(Object obj)
         {
+            if (obj == this)
+            {
+                return true;
+            }
             if (obj instanceof Set<?> other)
             {
                 if (other.size() == this.size())

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -412,6 +412,11 @@ public interface IterableTestCase
     {
         Iterable<Integer> iterable = this.newWith(3, 2, 1);
 
+        if (!this.allowsIterator() && iterable instanceof Set<?>)
+        {
+            return;
+        }
+
         if (!this.allowsSerialization())
         {
             assertNotSerializable(iterable);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MutableBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MutableBagTestCase.java
@@ -14,9 +14,18 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.test.MutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.bag.UnsortedBagTestCase;
 import org.eclipse.collections.test.bag.mutable.sorted.MutableBagIterableTestCase;
+import org.junit.jupiter.api.Test;
 
 public interface MutableBagTestCase extends UnsortedBagTestCase, MutableUnorderedIterableTestCase, MutableBagIterableTestCase
 {
     @Override
     <T> MutableBag<T> newWith(T... elements);
+
+    @Override
+    @Test
+    default void RichIterable_makeString_appendString()
+    {
+        UnsortedBagTestCase.super.RichIterable_makeString_appendString();
+        MutableBagIterableTestCase.super.RichIterable_makeString_appendString();
+    }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
@@ -261,9 +261,12 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
         assertEquals(Integer.valueOf(81), collection.injectIntoWith(1, (a, b, c) -> a + b + c, 5));
     }
 
+    @Override
     @Test
-    default void MutableCollection_toStringWithSelfReference()
+    default void Object_equalsAndHashCode()
     {
+        CollectionTestCase.super.Object_equalsAndHashCode();
+
         if (!this.allowsAdd() || !this.supportsNonComparableElements())
         {
             return;
@@ -271,11 +274,14 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
 
         MutableCollection<Object> collection = this.newWith();
         collection.add(collection);
-        assertEquals("[(this Collection)]", collection.toString());
+
+        assertEquals(collection, collection);
+        assertThrows(StackOverflowError.class, collection::hashCode);
     }
 
+    @Override
     @Test
-    default void MutableCollection_makeStringWithSelfReference()
+    default void RichIterable_makeString_appendString()
     {
         RichIterableTestCase.super.RichIterable_makeString_appendString();
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapKeySetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapKeySetTestCase.java
@@ -10,7 +10,14 @@
 
 package org.eclipse.collections.test.map;
 
+import java.util.ArrayList;
+import java.util.Set;
+
 import org.eclipse.collections.test.set.SetTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface MapKeySetTestCase extends SetTestCase
 {
@@ -18,5 +25,32 @@ public interface MapKeySetTestCase extends SetTestCase
     default boolean allowsAdd()
     {
         return false;
+    }
+
+    @Override
+    @Test
+    default void Object_equalsAndHashCode()
+    {
+        SetTestCase.super.Object_equalsAndHashCode();
+
+        RecursiveComparableList recursiveList = new RecursiveComparableList();
+        Set<RecursiveComparableList> set = this.newWith(recursiveList);
+        recursiveList.add(recursiveList);
+
+        assertEquals(set, set);
+        assertThrows(StackOverflowError.class, set::hashCode);
+    }
+
+    final class RecursiveComparableList
+            extends ArrayList<Object>
+            implements Comparable<RecursiveComparableList>
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int compareTo(RecursiveComparableList other)
+        {
+            return 0;
+        }
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/NoIteratorMapKeySetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/NoIteratorMapKeySetTestCase.java
@@ -34,6 +34,8 @@ public interface NoIteratorMapKeySetTestCase extends MapKeySetTestCase
     @Test
     default void Object_equalsAndHashCode()
     {
+        MapKeySetTestCase.super.Object_equalsAndHashCode();
+
         AssertionError error = assertThrows(
                 AssertionError.class,
                 () -> this.newWith(3, 2, 1).equals(this.newWith(3, 2, 1)));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ordered/ImmutableOrderedMapTest.java
@@ -103,6 +103,14 @@ public class ImmutableOrderedMapTest
 
     @Override
     @Test
+    public void Object_equalsAndHashCode()
+    {
+        OrderedMapIterableTestCase.super.Object_equalsAndHashCode();
+        MapTestCase.super.Object_equalsAndHashCode();
+    }
+
+    @Override
+    @Test
     public void Iterable_remove()
     {
         FixedSizeIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
@@ -101,6 +101,30 @@ public interface MapTestCase
     }
 
     @Test
+    default void Object_equalsAndHashCode()
+    {
+        if (!this.allowsPut())
+        {
+            return;
+        }
+
+        if (this.supportsNonComparableKeys())
+        {
+            Map<Object, Object> selfKey = this.newWithKeysValues();
+            selfKey.put(selfKey, "value");
+
+            assertEquals(selfKey, selfKey);
+            assertThrows(StackOverflowError.class, selfKey::hashCode);
+        }
+
+        Map<Object, Object> selfValue = this.newWithKeysValues();
+        selfValue.put("key", selfValue);
+
+        assertEquals(selfValue, selfValue);
+        assertThrows(StackOverflowError.class, selfValue::hashCode);
+    }
+
+    @Test
     default void Map_clear()
     {
         Map<Object, String> map = this.newWith("Three", "Two", "One");

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
@@ -79,6 +79,14 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
 
     @Override
     @Test
+    default void Object_equalsAndHashCode()
+    {
+        MapIterableTestCase.super.Object_equalsAndHashCode();
+        MapTestCase.super.Object_equalsAndHashCode();
+    }
+
+    @Override
+    @Test
     default void Iterable_remove()
     {
         MutableMapIterable<Object, Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/MutableSortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/MutableSortedMapIterableTestCase.java
@@ -55,6 +55,14 @@ public interface MutableSortedMapIterableTestCase extends SortedMapIterableTestC
     }
 
     @Override
+    @Test
+    default void Object_equalsAndHashCode()
+    {
+        SortedMapIterableTestCase.super.Object_equalsAndHashCode();
+        SortedMapTestCase.super.Object_equalsAndHashCode();
+    }
+
+    @Override
     default void Iterable_remove()
     {
         SortedMapIterableTestCase.super.Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/UnmodifiableMutableSortedMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/UnmodifiableMutableSortedMapTestCase.java
@@ -52,4 +52,11 @@ public interface UnmodifiableMutableSortedMapTestCase extends UnmodifiableMutabl
     {
         MutableSortedMapIterableTestCase.super.Iterable_toString();
     }
+
+    @Override
+    @Test
+    default void Object_equalsAndHashCode()
+    {
+        MutableSortedMapIterableTestCase.super.Object_equalsAndHashCode();
+    }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
@@ -24,6 +24,14 @@ public interface MutableSetTestCase extends SetTestCase, UnsortedSetIterableTest
     <T> MutableSet<T> newWith(T... elements);
 
     @Override
+    @Test
+    default void RichIterable_makeString_appendString()
+    {
+        UnsortedSetIterableTestCase.super.RichIterable_makeString_appendString();
+        MutableCollectionUniqueTestCase.super.RichIterable_makeString_appendString();
+    }
+
+    @Override
     default boolean allowsDuplicates()
     {
         return false;


### PR DESCRIPTION
This is the last one in the series of related changes, afaik.